### PR TITLE
ls: platform column now includes user-specified one with driver fallback

### DIFF
--- a/commands/ls.go
+++ b/commands/ls.go
@@ -126,7 +126,10 @@ func printngi(w io.Writer, ngi *nginfo) {
 			if d.info != nil {
 				status = d.info.Status.String()
 			}
-			p := append(n.Platforms, d.platforms...)
+			p := n.Platforms
+			if len(p) == 0 {
+				p = d.platforms
+			}
 			if err != "" {
 				fmt.Fprintf(w, "  %s\t%s\t%s\n", n.Name, n.Endpoint, err)
 			} else {


### PR DESCRIPTION
When creating builders with `create --platform`, the user can set a subset
of the platforms supported by the builder, but `ls` should only show
the user-specified platforms, when set. Otherwise, the default platforms.

Signed-off-by: Tibor Vass <tibor@docker.com>