### PR TITLE
Change compose file handling to require valid service specifications

### DIFF
--- a/bake/compose_test.go
+++ b/bake/compose_test.go
@@ -40,7 +40,45 @@ services:
 	require.Equal(t, "123", c.Target["webapp"].Args["buildno"])
 }
 
+func TestNoBuildOutOfTreeService(t *testing.T) {
+	var dt = []byte(`
+version: "3.7"
+
+services:
+    external:
+        image: "verycooldb:1337"
+    webapp:
+        build: ./db
+`)
+	c, err := ParseCompose(dt)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(c.Group))
+
+}
+
 func TestParseComposeTarget(t *testing.T) {
+	var dt = []byte(`
+version: "3.7"
+
+services:
+  db:
+    build:
+      context: ./db
+      target: db
+  webapp:
+    build:
+      context: .
+      target: webapp
+`)
+
+	c, err := ParseCompose(dt)
+	require.NoError(t, err)
+
+	require.Equal(t, "db", *c.Target["db"].Target)
+	require.Equal(t, "webapp", *c.Target["webapp"].Target)
+}
+
+func TestBogusCompose(t *testing.T) {
 	var dt = []byte(`
 version: "3.7"
 
@@ -50,12 +88,10 @@ services:
       target: db
   webapp:
     build:
+      context: .
       target: webapp
 `)
 
-	c, err := ParseCompose(dt)
-	require.NoError(t, err)
-
-	require.Equal(t, "db", *c.Target["db"].Target)
-	require.Equal(t, "webapp", *c.Target["webapp"].Target)
+	_, err := ParseCompose(dt)
+	require.Error(t, err)
 }

--- a/hack/demo-env/examples/compose/docker-compose.yml
+++ b/hack/demo-env/examples/compose/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     image: docker.io/tonistiigi/db
   webapp:
     build:
+      context: .
       dockerfile: Dockerfile.webapp
       args:
         buildno: 1


### PR DESCRIPTION
Added the checks and some tests
One of the tests wasn't valid docker-compose.yml, that's been changed.
Bad config throws an error and has a test

Signed-off-by: Jack Laxson <jackjrabbit@gmail.com>

I'm drafting some better tests still and will probably add them when they seem useful.

Also this is pending #78