### PR TITLE
Allow Docker to ship buildx guarded by the experimental flag

### DIFF
--- a/cmd/buildx/main.go
+++ b/cmd/buildx/main.go
@@ -16,6 +16,8 @@ import (
 	_ "github.com/docker/buildx/driver/docker-container"
 )
 
+var experimental string
+
 func main() {
 	if os.Getenv("DOCKER_CLI_PLUGIN_ORIGINAL_CLI_COMMAND") == "" {
 		if len(os.Args) < 2 || os.Args[1] != manager.MetadataSubcommandName {
@@ -41,5 +43,6 @@ func main() {
 			SchemaVersion: "0.1.0",
 			Vendor:        "Docker Inc.",
 			Version:       version.Version,
+			Experimental:  experimental != "",
 		})
 }


### PR DESCRIPTION
Discussion in docker/cli#1898 and docker/cli#1897

To guard this Docker CLI plugin with docker's experimental CLI config, buildx needs to be built with `go build -ldflags "-X main.experimental=1"`