### PR TITLE
Put driver names to create --help

### DIFF
--- a/commands/create.go
+++ b/commands/create.go
@@ -154,6 +154,11 @@ func runCreate(dockerCli command.Cli, in createOptions, args []string) error {
 func createCmd(dockerCli command.Cli) *cobra.Command {
 	var options createOptions
 
+	var drivers []string
+	for s := range driver.GetFactories() {
+		drivers = append(drivers, s)
+	}
+
 	cmd := &cobra.Command{
 		Use:   "create [OPTIONS] [CONTEXT|ENDPOINT]",
 		Short: "Create a new builder instance",
@@ -166,7 +171,7 @@ func createCmd(dockerCli command.Cli) *cobra.Command {
 	flags := cmd.Flags()
 
 	flags.StringVar(&options.name, "name", "", "Builder instance name")
-	flags.StringVar(&options.driver, "driver", "", "Driver to use (eg. docker-container)")
+	flags.StringVar(&options.driver, "driver", "", fmt.Sprintf("Driver to use (available: %v)", drivers))
 	flags.StringVar(&options.nodeName, "node", "", "Create/modify node with given name")
 	flags.StringArrayVar(&options.platform, "platform", []string{}, "Fixed platforms for current node")
 

--- a/driver/manager.go
+++ b/driver/manager.go
@@ -85,3 +85,7 @@ func GetDriver(ctx context.Context, name string, f Factory, api dockerclient.API
 	}
 	return f.New(ctx, ic)
 }
+
+func GetFactories() map[string]Factory {
+	return drivers
+}


### PR DESCRIPTION
  $ docker buildx driver ls
  NAME             USAGE
  docker           docker
  docker-container docker-container

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>