### PR TITLE
[Carry #79] Change compose file handling to require valid service specifications

### DIFF
--- a/bake/compose_test.go
+++ b/bake/compose_test.go
@@ -53,7 +53,6 @@ services:
 	c, err := ParseCompose(dt)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(c.Group))
-
 }
 
 func TestParseComposeTarget(t *testing.T) {
@@ -78,7 +77,7 @@ services:
 	require.Equal(t, "webapp", *c.Target["webapp"].Target)
 }
 
-func TestBogusCompose(t *testing.T) {
+func TestComposeBuildWithoutContext(t *testing.T) {
 	var dt = []byte(`
 version: "3.7"
 
@@ -92,6 +91,27 @@ services:
       target: webapp
 `)
 
+	c, err := ParseCompose(dt)
+	require.NoError(t, err)
+	require.Equal(t, "db", *c.Target["db"].Target)
+	require.Equal(t, "webapp", *c.Target["webapp"].Target)
+}
+
+func TestBogusCompose(t *testing.T) {
+	var dt = []byte(`
+version: "3.7"
+
+services:
+  db:
+    labels:
+      - "foo"
+  webapp:
+    build:
+      context: .
+      target: webapp
+`)
+
 	_, err := ParseCompose(dt)
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "has neither an image nor a build context specified. At least one must be provided")
 }

--- a/bake/compose_test.go
+++ b/bake/compose_test.go
@@ -40,7 +40,45 @@ services:
 	require.Equal(t, "123", c.Target["webapp"].Args["buildno"])
 }
 
+func TestNoBuildOutOfTreeService(t *testing.T) {
+	var dt = []byte(`
+version: "3.7"
+
+services:
+    external:
+        image: "verycooldb:1337"
+    webapp:
+        build: ./db
+`)
+	c, err := ParseCompose(dt)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(c.Group))
+
+}
+
 func TestParseComposeTarget(t *testing.T) {
+	var dt = []byte(`
+version: "3.7"
+
+services:
+  db:
+    build:
+      context: ./db
+      target: db
+  webapp:
+    build:
+      context: .
+      target: webapp
+`)
+
+	c, err := ParseCompose(dt)
+	require.NoError(t, err)
+
+	require.Equal(t, "db", *c.Target["db"].Target)
+	require.Equal(t, "webapp", *c.Target["webapp"].Target)
+}
+
+func TestBogusCompose(t *testing.T) {
 	var dt = []byte(`
 version: "3.7"
 
@@ -50,12 +88,10 @@ services:
       target: db
   webapp:
     build:
+      context: .
       target: webapp
 `)
 
-	c, err := ParseCompose(dt)
-	require.NoError(t, err)
-
-	require.Equal(t, "db", *c.Target["db"].Target)
-	require.Equal(t, "webapp", *c.Target["webapp"].Target)
+	_, err := ParseCompose(dt)
+	require.Error(t, err)
 }

--- a/hack/demo-env/examples/compose/docker-compose.yml
+++ b/hack/demo-env/examples/compose/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     image: docker.io/tonistiigi/db
   webapp:
     build:
+      context: .
       dockerfile: Dockerfile.webapp
       args:
         buildno: 1


### PR DESCRIPTION
Closes #79 which is carried in this PR.

This PR basically handles properly compose services without a `build` field, by skipping them, but errors out when neither a `build` nor an `image` field is present.

Tests updated accordingly.