### PR TITLE
driver: allow configuring buildkitd flags

### DIFF
--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -114,6 +114,9 @@ func runInspect(dockerCli command.Cli, in inspectOptions, args []string) error {
 				fmt.Fprintf(w, "Error:\t%s\n", err.Error())
 			} else {
 				fmt.Fprintf(w, "Status:\t%s\n", ngi.drivers[i].info.Status)
+				if len(n.Flags) > 0 {
+					fmt.Fprintf(w, "Flags:\t%s\n", strings.Join(n.Flags, " "))
+				}
 				fmt.Fprintf(w, "Platforms:\t%s\n", strings.Join(platformutil.Format(platformutil.Dedupe(append(n.Platforms, ngi.drivers[i].platforms...))), ", "))
 			}
 		}

--- a/commands/util.go
+++ b/commands/util.go
@@ -174,7 +174,7 @@ func driversForNodeGroup(ctx context.Context, dockerCli command.Cli, ng *store.N
 				// TODO: replace the following line with dockerclient.WithAPIVersionNegotiation option in clientForEndpoint
 				dockerapi.NegotiateAPIVersion(ctx)
 
-				d, err := driver.GetDriver(ctx, "buildx_buildkit_"+n.Name, f, dockerapi)
+				d, err := driver.GetDriver(ctx, "buildx_buildkit_"+n.Name, f, dockerapi, n.Flags)
 				if err != nil {
 					di.Err = err
 					return nil
@@ -251,7 +251,7 @@ func getDefaultDrivers(ctx context.Context, dockerCli command.Cli) ([]build.Driv
 		return driversForNodeGroup(ctx, dockerCli, ng)
 	}
 
-	d, err := driver.GetDriver(ctx, "buildx_buildkit_default", nil, dockerCli.Client())
+	d, err := driver.GetDriver(ctx, "buildx_buildkit_default", nil, dockerCli.Client(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/driver/docker-container/driver.go
+++ b/driver/docker-container/driver.go
@@ -59,10 +59,16 @@ func (d *Driver) create(ctx context.Context, l progress.SubLogger) error {
 	}); err != nil {
 		return err
 	}
+
+	cfg := &container.Config{
+		Image: buildkitImage,
+	}
+	if d.InitConfig.BuildkitFlags != nil {
+		cfg.Cmd = d.InitConfig.BuildkitFlags
+	}
+
 	if err := l.Wrap("creating container "+d.Name, func() error {
-		_, err := d.DockerAPI.ContainerCreate(ctx, &container.Config{
-			Image: buildkitImage,
-		}, &container.HostConfig{
+		_, err := d.DockerAPI.ContainerCreate(ctx, cfg, &container.HostConfig{
 			Privileged: true,
 		}, &network.NetworkingConfig{}, d.Name)
 		if err != nil {

--- a/driver/manager.go
+++ b/driver/manager.go
@@ -23,10 +23,10 @@ type BuildkitConfig struct {
 
 type InitConfig struct {
 	// This object needs updates to be generic for different drivers
-	Name           string
-	DockerAPI      dockerclient.APIClient
-	BuildkitConfig BuildkitConfig
-	Meta           map[string]interface{}
+	Name          string
+	DockerAPI     dockerclient.APIClient
+	BuildkitFlags []string
+	Meta          map[string]interface{}
 }
 
 var drivers map[string]Factory
@@ -71,10 +71,11 @@ func GetFactory(name string, instanceRequired bool) Factory {
 	return nil
 }
 
-func GetDriver(ctx context.Context, name string, f Factory, api dockerclient.APIClient) (Driver, error) {
+func GetDriver(ctx context.Context, name string, f Factory, api dockerclient.APIClient, flags []string) (Driver, error) {
 	ic := InitConfig{
-		DockerAPI: api,
-		Name:      name,
+		DockerAPI:     api,
+		Name:          name,
+		BuildkitFlags: flags,
 	}
 	if f == nil {
 		var err error

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/google/certificate-transparency-go v1.0.21 // indirect
 	github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf // indirect
+	github.com/google/shlex v0.0.0-20150127133951-6f45313302b9
 	github.com/gorilla/mux v1.7.0 // indirect
 	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed // indirect
 	github.com/hashicorp/go-version v1.1.0 // indirect

--- a/store/nodegroup.go
+++ b/store/nodegroup.go
@@ -19,6 +19,7 @@ type Node struct {
 	Name      string
 	Endpoint  string
 	Platforms []specs.Platform
+	Flags     []string
 }
 
 func (ng *NodeGroup) Leave(name string) error {
@@ -33,7 +34,7 @@ func (ng *NodeGroup) Leave(name string) error {
 	return nil
 }
 
-func (ng *NodeGroup) Update(name, endpoint string, platforms []string, endpointsSet bool, actionAppend bool) error {
+func (ng *NodeGroup) Update(name, endpoint string, platforms []string, endpointsSet bool, actionAppend bool, flags []string) error {
 	i := ng.findNode(name)
 	if i == -1 && !actionAppend {
 		if len(ng.Nodes) > 0 {
@@ -55,6 +56,9 @@ func (ng *NodeGroup) Update(name, endpoint string, platforms []string, endpoints
 		if len(platforms) > 0 {
 			n.Platforms = pp
 		}
+		if flags != nil {
+			n.Flags = flags
+		}
 		ng.Nodes[i] = n
 		if err := ng.validateDuplicates(endpoint, i); err != nil {
 			return err
@@ -75,6 +79,7 @@ func (ng *NodeGroup) Update(name, endpoint string, platforms []string, endpoints
 		Name:      name,
 		Endpoint:  endpoint,
 		Platforms: pp,
+		Flags:     flags,
 	}
 	ng.Nodes = append(ng.Nodes, n)
 

--- a/store/nodegroup_test.go
+++ b/store/nodegroup_test.go
@@ -11,16 +11,16 @@ func TestNodeGroupUpdate(t *testing.T) {
 	t.Parallel()
 
 	ng := &NodeGroup{}
-	err := ng.Update("foo", "foo0", []string{"linux/amd64"}, true, false)
+	err := ng.Update("foo", "foo0", []string{"linux/amd64"}, true, false, []string{"--debug"})
 	require.NoError(t, err)
 
-	err = ng.Update("foo1", "foo1", []string{"linux/arm64", "linux/arm/v7"}, true, true)
+	err = ng.Update("foo1", "foo1", []string{"linux/arm64", "linux/arm/v7"}, true, true, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, len(ng.Nodes), 2)
 
 	// update
-	err = ng.Update("foo", "foo2", []string{"linux/amd64", "linux/arm"}, true, false)
+	err = ng.Update("foo", "foo2", []string{"linux/amd64", "linux/arm"}, true, false, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, len(ng.Nodes), 2)
@@ -28,9 +28,11 @@ func TestNodeGroupUpdate(t *testing.T) {
 	require.Equal(t, []string{"linux/arm64"}, platformutil.Format(ng.Nodes[1].Platforms))
 
 	require.Equal(t, "foo2", ng.Nodes[0].Endpoint)
+	require.Equal(t, []string{"--debug"}, ng.Nodes[0].Flags)
+	require.Equal(t, []string(nil), ng.Nodes[1].Flags)
 
 	// duplicate endpoint
-	err = ng.Update("foo1", "foo2", nil, true, false)
+	err = ng.Update("foo1", "foo2", nil, true, false, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "duplicate endpoint")
 


### PR DESCRIPTION
Add `docker buildx create --buildkitd-flags ''` for setting custom flags for buildkitd daemon.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>