### PR TITLE
driver: set netmode to host for container driver

### DIFF
--- a/driver/docker-container/driver.go
+++ b/driver/docker-container/driver.go
@@ -63,7 +63,8 @@ func (d *Driver) create(ctx context.Context, l progress.SubLogger) error {
 		_, err := d.DockerAPI.ContainerCreate(ctx, &container.Config{
 			Image: buildkitImage,
 		}, &container.HostConfig{
-			Privileged: true,
+			Privileged:  true,
+			NetworkMode: "host",
 		}, &network.NetworkingConfig{}, d.Name)
 		if err != nil {
 			return err


### PR DESCRIPTION
with #102 these flags work better in the context of host network. as the container is already privileged atm there isn't an extra security concern.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>