### PR TITLE
driver: allow setting driver opts

### DIFF
--- a/commands/util.go
+++ b/commands/util.go
@@ -174,7 +174,7 @@ func driversForNodeGroup(ctx context.Context, dockerCli command.Cli, ng *store.N
 				// TODO: replace the following line with dockerclient.WithAPIVersionNegotiation option in clientForEndpoint
 				dockerapi.NegotiateAPIVersion(ctx)
 
-				d, err := driver.GetDriver(ctx, "buildx_buildkit_"+n.Name, f, dockerapi, n.Flags, n.ConfigFile)
+				d, err := driver.GetDriver(ctx, "buildx_buildkit_"+n.Name, f, dockerapi, n.Flags, n.ConfigFile, n.DriverOpts)
 				if err != nil {
 					di.Err = err
 					return nil
@@ -251,7 +251,7 @@ func getDefaultDrivers(ctx context.Context, dockerCli command.Cli) ([]build.Driv
 		return driversForNodeGroup(ctx, dockerCli, ng)
 	}
 
-	d, err := driver.GetDriver(ctx, "buildx_buildkit_default", nil, dockerCli.Client(), nil, "")
+	d, err := driver.GetDriver(ctx, "buildx_buildkit_default", nil, dockerCli.Client(), nil, "", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/driver/docker-container/factory.go
+++ b/driver/docker-container/factory.go
@@ -45,8 +45,10 @@ func (f *factory) New(ctx context.Context, cfg driver.InitConfig) (driver.Driver
 			if v == "host" {
 				d.InitConfig.BuildkitFlags = append(d.InitConfig.BuildkitFlags, "--allow-insecure-entitlement=network.host")
 			}
+		case "image":
+			d.image = v
 		default:
-			return nil, errors.Errorf("invalid driver option %s for docker-container driver")
+			return nil, errors.Errorf("invalid driver option %s for docker-container driver", k)
 		}
 	}
 

--- a/driver/manager.go
+++ b/driver/manager.go
@@ -27,7 +27,7 @@ type InitConfig struct {
 	DockerAPI     dockerclient.APIClient
 	BuildkitFlags []string
 	ConfigFile    string
-	Meta          map[string]interface{}
+	DriverOpts    map[string]string
 }
 
 var drivers map[string]Factory
@@ -72,12 +72,13 @@ func GetFactory(name string, instanceRequired bool) Factory {
 	return nil
 }
 
-func GetDriver(ctx context.Context, name string, f Factory, api dockerclient.APIClient, flags []string, config string) (Driver, error) {
+func GetDriver(ctx context.Context, name string, f Factory, api dockerclient.APIClient, flags []string, config string, do map[string]string) (Driver, error) {
 	ic := InitConfig{
 		DockerAPI:     api,
 		Name:          name,
 		BuildkitFlags: flags,
 		ConfigFile:    config,
+		DriverOpts:    do,
 	}
 	if f == nil {
 		var err error

--- a/store/nodegroup.go
+++ b/store/nodegroup.go
@@ -21,6 +21,7 @@ type Node struct {
 	Platforms  []specs.Platform
 	Flags      []string
 	ConfigFile string
+	DriverOpts map[string]string
 }
 
 func (ng *NodeGroup) Leave(name string) error {
@@ -35,7 +36,7 @@ func (ng *NodeGroup) Leave(name string) error {
 	return nil
 }
 
-func (ng *NodeGroup) Update(name, endpoint string, platforms []string, endpointsSet bool, actionAppend bool, flags []string, configFile string) error {
+func (ng *NodeGroup) Update(name, endpoint string, platforms []string, endpointsSet bool, actionAppend bool, flags []string, configFile string, do map[string]string) error {
 	i := ng.findNode(name)
 	if i == -1 && !actionAppend {
 		if len(ng.Nodes) > 0 {
@@ -82,6 +83,7 @@ func (ng *NodeGroup) Update(name, endpoint string, platforms []string, endpoints
 		Platforms:  pp,
 		ConfigFile: configFile,
 		Flags:      flags,
+		DriverOpts: do,
 	}
 	ng.Nodes = append(ng.Nodes, n)
 

--- a/store/nodegroup_test.go
+++ b/store/nodegroup_test.go
@@ -11,16 +11,16 @@ func TestNodeGroupUpdate(t *testing.T) {
 	t.Parallel()
 
 	ng := &NodeGroup{}
-	err := ng.Update("foo", "foo0", []string{"linux/amd64"}, true, false, []string{"--debug"}, "")
+	err := ng.Update("foo", "foo0", []string{"linux/amd64"}, true, false, []string{"--debug"}, "", nil)
 	require.NoError(t, err)
 
-	err = ng.Update("foo1", "foo1", []string{"linux/arm64", "linux/arm/v7"}, true, true, nil, "")
+	err = ng.Update("foo1", "foo1", []string{"linux/arm64", "linux/arm/v7"}, true, true, nil, "", nil)
 	require.NoError(t, err)
 
 	require.Equal(t, len(ng.Nodes), 2)
 
 	// update
-	err = ng.Update("foo", "foo2", []string{"linux/amd64", "linux/arm"}, true, false, nil, "")
+	err = ng.Update("foo", "foo2", []string{"linux/amd64", "linux/arm"}, true, false, nil, "", nil)
 	require.NoError(t, err)
 
 	require.Equal(t, len(ng.Nodes), 2)
@@ -32,7 +32,7 @@ func TestNodeGroupUpdate(t *testing.T) {
 	require.Equal(t, []string(nil), ng.Nodes[1].Flags)
 
 	// duplicate endpoint
-	err = ng.Update("foo1", "foo2", nil, true, false, nil, "")
+	err = ng.Update("foo1", "foo2", nil, true, false, nil, "", nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "duplicate endpoint")
 


### PR DESCRIPTION
Allow setting driver options `create --driver-opt`:
- `network=host`
- `image=moby/buildkit:v0.5.0`