### PR TITLE
bake: merge targets on same groups

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -77,7 +77,20 @@ func mergeConfig(c1, c2 Config) Config {
 		if c1.Group == nil {
 			c1.Group = map[string]Group{}
 		}
-		c1.Group[k] = g
+		if g1, exists := c1.Group[k]; exists {
+		nextTarget:
+			for _, t := range g.Targets {
+				for _, t2 := range g1.Targets {
+					if t == t2 {
+						continue nextTarget
+					}
+				}
+				g1.Targets = append(g1.Targets, t)
+			}
+			c1.Group[k] = g1
+		} else {
+			c1.Group[k] = g
+		}
 	}
 
 	for k, t := range c2.Target {

--- a/bake/bake_test.go
+++ b/bake/bake_test.go
@@ -59,11 +59,30 @@ services:
 `), 0600)
 	require.NoError(t, err)
 
-	ctx := context.TODO()
+	fp2 := filepath.Join(tmpdir, "docker-compose2.yml")
+	err = ioutil.WriteFile(fp2, []byte(`
+version: "3"
 
-	m, err := ReadTargets(ctx, []string{fp}, []string{"default"}, nil)
+services:
+  newservice:
+    build: .
+  webapp:
+    build:
+      args:
+        buildno2: 12
+`), 0600)
 	require.NoError(t, err)
 
+	ctx := context.TODO()
+
+	m, err := ReadTargets(ctx, []string{fp, fp2}, []string{"default"}, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, 3, len(m))
+	_, ok := m["newservice"]
+	require.True(t, ok)
 	require.Equal(t, "Dockerfile.webapp", *m["webapp"].Dockerfile)
 	require.Equal(t, ".", *m["webapp"].Context)
+	require.Equal(t, "1", m["webapp"].Args["buildno"])
+	require.Equal(t, "12", m["webapp"].Args["buildno2"])
 }


### PR DESCRIPTION
fixes #133 

Workaround is to name all the targets in the command line

@FernandoMiguel 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>