### PR TITLE
bake: allow pattern matching for target names in --set

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,10 +507,12 @@ Options:
 | Flag | Description |
 | --- | --- |
 |  -f, --file stringArray  | Build definition file
+|      --load              | Shorthand for --set=*.output=type=docker
 |      --no-cache          | Do not use cache when building the image
 |      --print             | Print the options without building
 |      --progress string   | Set type of progress output (auto, plain, tty). Use plain to show container output (default "auto")
 |      --pull              | Always attempt to pull a newer version of the image
+|      --push              | Shorthand for --set=*.output=type=registry
 |      --set stringArray   | Override target value (eg: targetpattern.key=value)
 
 #### `-f, --file FILE`

--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ Options:
 |      --print             | Print the options without building
 |      --progress string   | Set type of progress output (auto, plain, tty). Use plain to show container output (default "auto")
 |      --pull              | Always attempt to pull a newer version of the image
-|      --set stringArray   | Override target value (eg: target.key=value)
+|      --set stringArray   | Override target value (eg: targetpattern.key=value)
 
 #### `-f, --file FILE`
 
@@ -554,14 +554,16 @@ Same as `build --progress`. Set type of progress output (auto, plain, tty). Use 
 
 Same as `build --pull`.
 
-#### `--set target.key[.subkey]=value`
+#### `--set targetpattern.key[.subkey]=value`
 
-Override target configurations from command line.
+Override target configurations from command line. The pattern matching syntax is defined in https://golang.org/pkg/path/#Match.
 
 Example:
 ```
 docker buildx bake --set target.args.mybuildarg=value
 docker buildx bake --set target.platform=linux/arm64
+docker buildx bake --set foo*.args.mybuildarg=value	# overrides build arg for all targets starting with 'foo'
+docker buildx bake --set *.platform=linux/arm64		# overrides platform for all targets
 ```
 
 #### File definition

--- a/bake/bake_test.go
+++ b/bake/bake_test.go
@@ -49,7 +49,7 @@ target "webapp" {
 	t.Run("InvalidTargetOverrides", func(t *testing.T) {
 		_, err := ReadTargets(ctx, []string{fp}, []string{"webapp"}, []string{"nosuchtarget.context=foo"})
 		require.NotNil(t, err)
-		require.Equal(t, err.Error(), "unknown target nosuchtarget")
+		require.Equal(t, err.Error(), "could not find any target matching 'nosuchtarget'")
 	})
 
 	t.Run("ArgsOverrides", func(t *testing.T) {

--- a/commands/bake.go
+++ b/commands/bake.go
@@ -99,7 +99,7 @@ func bakeCmd(dockerCli command.Cli) *cobra.Command {
 
 	flags.StringArrayVarP(&options.files, "file", "f", []string{}, "Build definition file")
 	flags.BoolVar(&options.printOnly, "print", false, "Print the options without building")
-	flags.StringArrayVar(&options.overrides, "set", nil, "Override target value (eg: target.key=value)")
+	flags.StringArrayVar(&options.overrides, "set", nil, "Override target value (eg: targetpattern.key=value)")
 
 	commonFlags(&options.commonOptions, flags)
 

--- a/commands/build.go
+++ b/commands/build.go
@@ -38,9 +38,6 @@ type buildOptions struct {
 	extraHosts  []string
 	networkMode string
 
-	exportPush bool
-	exportLoad bool
-
 	// unimplemented
 	squash bool
 	quiet  bool
@@ -65,9 +62,11 @@ type buildOptions struct {
 }
 
 type commonOptions struct {
-	noCache  bool
-	progress string
-	pull     bool
+	noCache    bool
+	progress   string
+	pull       bool
+	exportPush bool
+	exportLoad bool
 }
 
 func runBuild(dockerCli command.Cli, in buildOptions) error {


### PR DESCRIPTION
Although bake is for running multiple targets, --set required a single
target name for overriding a property. This change allows matching
multiple targets for overrides.

bake: add --load and --push shorthands for --set