### PR TITLE
Support environment variables in docker-container driver

### DIFF
--- a/driver/docker-container/driver.go
+++ b/driver/docker-container/driver.go
@@ -29,6 +29,7 @@ type Driver struct {
 	factory driver.Factory
 	netMode string
 	image   string
+	env     []string
 }
 
 func (d *Driver) Bootstrap(ctx context.Context, l progress.Logger) error {
@@ -57,6 +58,7 @@ func (d *Driver) create(ctx context.Context, l progress.SubLogger) error {
 	if d.image != "" {
 		imageName = d.image
 	}
+	env := d.env
 	if err := l.Wrap("pulling image "+imageName, func() error {
 		rc, err := d.DockerAPI.ImageCreate(ctx, imageName, types.ImageCreateOptions{})
 		if err != nil {
@@ -70,6 +72,7 @@ func (d *Driver) create(ctx context.Context, l progress.SubLogger) error {
 
 	cfg := &container.Config{
 		Image: imageName,
+		Env:   env,
 	}
 	if d.InitConfig.BuildkitFlags != nil {
 		cfg.Cmd = d.InitConfig.BuildkitFlags


### PR DESCRIPTION
Fixes #169

Example usage:

```bash
docker buildx create --driver-opt env.http_proxy=$http_proxy --driver-opt env.https_proxy=$https_proxy --driver-opt '"env.no_proxy='$no_proxy'"'
```

---

Original suggestion:

```bash
docker buildx create --driver-env http_proxy=$http_proxy --driver-env https_proxy=$https_proxy --driver-env '"no_proxy='$no_proxy'"'
```