### PR TITLE
imagetools: avoid printing newline on raw mode

### DIFF
--- a/commands/imagetools/inspect.go
+++ b/commands/imagetools/inspect.go
@@ -30,7 +30,7 @@ func runInspect(dockerCli command.Cli, in inspectOptions, name string) error {
 	}
 
 	if in.raw {
-		fmt.Printf("%s\n", dt)
+		fmt.Printf("%s", dt) // avoid newline to keep digest
 		return nil
 	}
 


### PR DESCRIPTION
noticed in https://github.com/docker/buildx/issues/181

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>