### PR TITLE
build: only use env for args if set

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -305,7 +305,10 @@ func listToMap(values []string, defaultEnv bool) map[string]string {
 		kv := strings.SplitN(value, "=", 2)
 		if len(kv) == 1 {
 			if defaultEnv {
-				result[kv[0]] = os.Getenv(kv[0])
+				v, ok := os.LookupEnv(kv[0])
+				if ok {
+					result[kv[0]] = v
+				}
 			} else {
 				result[kv[0]] = ""
 			}


### PR DESCRIPTION
When following this pattern:

```
buildx build --arg FOO
```

Where we want to pull `FOO` from env, currently we always set `FOO`
regardless if the `FOO` env var is even set.

This change makes it so that `FOO` would only be set if it has been set
in the env (even if it is set to empty).

Signed-off-by: Brian Goff <cpuguy83@gmail.com>