### PR TITLE
Make k8s driver priority lower

### DIFF
--- a/driver/kubernetes/factory.go
+++ b/driver/kubernetes/factory.go
@@ -14,8 +14,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-const prioritySupported = 30
-const priorityUnsupported = 70
+const prioritySupported = 40
+const priorityUnsupported = 80
 
 func init() {
 	driver.Register(&factory{})

--- a/go.mod
+++ b/go.mod
@@ -89,3 +89,5 @@ require (
 )
 
 replace github.com/jaguilar/vt100 => github.com/tonistiigi/vt100 v0.0.0-20190402012908-ad4c4a574305
+
+go 1.13


### PR DESCRIPTION
Otherwise it ends up being default and it's probably not the normal
case.