### PR TITLE
README: add mkdir for .docker/cli-plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ $ make install
 ```
 $ export DOCKER_BUILDKIT=1
 $ docker build --platform=local -o . git://github.com/docker/buildx
+$ mkdir -p ~/.docker/cli-plugins
 $ mv buildx ~/.docker/cli-plugins/docker-buildx
 ```
 


### PR DESCRIPTION
this dir doesn't exist by default so add a mkdir