### PR TITLE
bake: fix override bug with inheritance

### DIFF
--- a/bake/bake_test.go
+++ b/bake/bake_test.go
@@ -19,10 +19,17 @@ func TestReadTargets(t *testing.T) {
 	fp := filepath.Join(tmpdir, "config.hcl")
 	err = ioutil.WriteFile(fp, []byte(`
 target "dep" {
+	args {
+		VAR_INHERITED = "dep"
+		VAR_BOTH = "dep"
+	}
 }
 
 target "webapp" {
 	dockerfile = "Dockerfile.webapp"
+	args {
+		VAR_BOTH = "webapp"
+	}
 	inherits = ["dep"]
 }`), 0600)
 	require.NoError(t, err)
@@ -32,35 +39,61 @@ target "webapp" {
 	t.Run("NoOverrides", func(t *testing.T) {
 		m, err := ReadTargets(ctx, []string{fp}, []string{"webapp"}, nil)
 		require.NoError(t, err)
+		require.Equal(t, 1, len(m))
 
 		require.Equal(t, "Dockerfile.webapp", *m["webapp"].Dockerfile)
 		require.Equal(t, ".", *m["webapp"].Context)
+		require.Equal(t, "dep", m["webapp"].Args["VAR_INHERITED"])
+	})
+
+	t.Run("InvalidTargetOverrides", func(t *testing.T) {
+		_, err := ReadTargets(ctx, []string{fp}, []string{"webapp"}, []string{"nosuchtarget.context=foo"})
+		require.NotNil(t, err)
+		require.Equal(t, err.Error(), "unknown target nosuchtarget")
 	})
 
 	t.Run("ArgsOverrides", func(t *testing.T) {
-		os.Setenv("VAR_FROMENV"+t.Name(), "fromEnv")
-		defer os.Unsetenv("VAR_FROM_ENV" + t.Name())
+		t.Run("leaf", func(t *testing.T) {
+			os.Setenv("VAR_FROMENV"+t.Name(), "fromEnv")
+			defer os.Unsetenv("VAR_FROM_ENV" + t.Name())
 
-		m, err := ReadTargets(ctx, []string{fp}, []string{"webapp"}, []string{
-			"webapp.args.VAR_UNSET",
-			"webapp.args.VAR_EMPTY=",
-			"webapp.args.VAR_SET=bananas",
-			"webapp.args.VAR_FROMENV" + t.Name(),
+			m, err := ReadTargets(ctx, []string{fp}, []string{"webapp"}, []string{
+				"webapp.args.VAR_UNSET",
+				"webapp.args.VAR_EMPTY=",
+				"webapp.args.VAR_SET=bananas",
+				"webapp.args.VAR_FROMENV" + t.Name(),
+				"webapp.args.VAR_INHERITED=override",
+				// not overriding VAR_BOTH on purpose
+			})
+			require.NoError(t, err)
+
+			require.Equal(t, "Dockerfile.webapp", *m["webapp"].Dockerfile)
+			require.Equal(t, ".", *m["webapp"].Context)
+
+			_, isSet := m["webapp"].Args["VAR_UNSET"]
+			require.False(t, isSet, m["webapp"].Args["VAR_UNSET"])
+
+			_, isSet = m["webapp"].Args["VAR_EMPTY"]
+			require.True(t, isSet, m["webapp"].Args["VAR_EMPTY"])
+
+			require.Equal(t, m["webapp"].Args["VAR_SET"], "bananas")
+
+			require.Equal(t, m["webapp"].Args["VAR_FROMENV"+t.Name()], "fromEnv")
+
+			require.Equal(t, m["webapp"].Args["VAR_BOTH"], "webapp")
+			require.Equal(t, m["webapp"].Args["VAR_INHERITED"], "override")
 		})
-		require.NoError(t, err)
 
-		require.Equal(t, "Dockerfile.webapp", *m["webapp"].Dockerfile)
-		require.Equal(t, ".", *m["webapp"].Context)
-
-		_, isSet := m["webapp"].Args["VAR_UNSET"]
-		require.False(t, isSet, m["webapp"].Args["VAR_UNSET"])
-
-		_, isSet = m["webapp"].Args["VAR_EMPTY"]
-		require.True(t, isSet, m["webapp"].Args["VAR_EMPTY"])
-
-		require.Equal(t, m["webapp"].Args["VAR_SET"], "bananas")
-
-		require.Equal(t, m["webapp"].Args["VAR_FROMENV"+t.Name()], "fromEnv")
+		// building leaf but overriding parent fields
+		t.Run("parent", func(t *testing.T) {
+			m, err := ReadTargets(ctx, []string{fp}, []string{"webapp"}, []string{
+				"dep.args.VAR_INHERITED=override",
+				"dep.args.VAR_BOTH=override",
+			})
+			require.NoError(t, err)
+			require.Equal(t, m["webapp"].Args["VAR_INHERITED"], "override")
+			require.Equal(t, m["webapp"].Args["VAR_BOTH"], "webapp")
+		})
 	})
 
 	t.Run("ContextOverride", func(t *testing.T) {


### PR DESCRIPTION
Added the bug case in tests:

```hcl
target "dep" {
	args {
		VAR_INHERITED = "dep"
	}
}
target "webapp" {
	dockerfile = "Dockerfile.webapp"
	inherits = ["dep"]
}
```

`bake --set webapp.args.VAR_INHERITED=override` was still inheriting `dep` value.