### PR TITLE
separate manual and automatically detected platforms

### DIFF
--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -117,7 +117,7 @@ func runInspect(dockerCli command.Cli, in inspectOptions, args []string) error {
 				if len(n.Flags) > 0 {
 					fmt.Fprintf(w, "Flags:\t%s\n", strings.Join(n.Flags, " "))
 				}
-				fmt.Fprintf(w, "Platforms:\t%s\n", strings.Join(platformutil.Format(platformutil.Dedupe(append(n.Platforms, ngi.drivers[i].platforms...))), ", "))
+				fmt.Fprintf(w, "Platforms:\t%s\n", strings.Join(platformutil.FormatInGroups(n.Platforms, ngi.drivers[i].platforms), ", "))
 			}
 		}
 	}

--- a/commands/ls.go
+++ b/commands/ls.go
@@ -126,11 +126,10 @@ func printngi(w io.Writer, ngi *nginfo) {
 			if d.info != nil {
 				status = d.info.Status.String()
 			}
-			p := append(n.Platforms, d.platforms...)
 			if err != "" {
 				fmt.Fprintf(w, "  %s\t%s\t%s\n", n.Name, n.Endpoint, err)
 			} else {
-				fmt.Fprintf(w, "  %s\t%s\t%s\t%s\n", n.Name, n.Endpoint, status, strings.Join(platformutil.Format(p), ", "))
+				fmt.Fprintf(w, "  %s\t%s\t%s\t%s\n", n.Name, n.Endpoint, status, strings.Join(platformutil.FormatInGroups(n.Platforms, d.platforms), ", "))
 			}
 		}
 	}

--- a/util/platformutil/parse.go
+++ b/util/platformutil/parse.go
@@ -53,6 +53,27 @@ func Dedupe(in []specs.Platform) []specs.Platform {
 	return out
 }
 
+func FormatInGroups(gg ...[]specs.Platform) []string {
+	m := map[string]struct{}{}
+	out := make([]string, 0, len(gg))
+	for i, g := range gg {
+		for _, p := range g {
+			p := platforms.Normalize(p)
+			key := platforms.Format(p)
+			if _, ok := m[key]; ok {
+				continue
+			}
+			m[key] = struct{}{}
+			v := platforms.Format(p)
+			if i == 0 {
+				v += "*"
+			}
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
 func Format(in []specs.Platform) []string {
 	if len(in) == 0 {
 		return nil


### PR DESCRIPTION
Allow preferred platforms to be distinguished from automatic ones and fix missing dedupe in ls.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>