### PR TITLE
Support parsing json config with hcl v2

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -72,8 +72,8 @@ func ParseFile(fn string) (*Config, error) {
 
 type Config struct {
 	Variables []*Variable `json:"-" hcl:"variable,block"`
-	Groups    []*Group    `json:"groups" hcl:"group,block"`
-	Targets   []*Target   `json:"targets" hcl:"target,block"`
+	Groups    []*Group    `json:"group" hcl:"group,block"`
+	Targets   []*Target   `json:"target" hcl:"target,block"`
 	Remain    hcl.Body    `json:"-" hcl:",remain"`
 }
 

--- a/bake/hcl.go
+++ b/bake/hcl.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/hcl/v2/ext/userfunc"
 	"github.com/hashicorp/hcl/v2/hclsimple"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/json"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
 	"github.com/zclconf/go-cty/cty/function/stdlib"
@@ -73,8 +74,16 @@ type staticConfig struct {
 }
 
 func ParseHCL(dt []byte, fn string) (*Config, error) {
+	var file *hcl.File
+	var diags hcl.Diagnostics
+
 	// Decode user defined functions.
-	file, diags := hclsyntax.ParseConfig(dt, fn, hcl.Pos{Line: 1, Column: 1})
+	fnl := strings.ToLower(fn)
+	if strings.HasSuffix(fnl, ".json") {
+		file, diags = json.Parse(dt, fn)
+	} else {
+		file, diags = hclsyntax.ParseConfig(dt, fn, hcl.Pos{Line: 1, Column: 1})
+	}
 	if diags.HasErrors() {
 		return nil, diags
 	}


### PR DESCRIPTION
Providing a `docker-bake.json` to `docker buildx bake` fails to parse because we were always assuming `hcl` formatted config after the hcl v2 upgrade.

```
$ cat <<'EOF' > docker-bake.json
{
  "variable": {
    "TAG": {
      "default": "latest"
    }
  },
  "group": {
    "default": {
      "targets": ["webapp"]
    }
  },
  "target": {
    "webapp": {
      "args": {
        "buildno": "${add(123, 1)}"
      }
    }
  }
}
EOF
$ docker buildx bake -f docker-bake.json --print webapp                                                                   
bake.json:1,1-2: Argument or block definition required; An argument or block definition is required here.  
```

Fixed this by using the json parser based on the file suffix.

```
$ docker buildx bake -f docker-bake.json --print webapp                                                                   
{                                                                                                                  
   "target": {                                                                                                     
      "webapp": {                                                                                                  
         "context": ".",                                                                                           
         "dockerfile": "Dockerfile",                                                                               
         "args": {                                                                                                 
            "buildno": "124"                                                                                       
         }                                                                                                         
      }                                                                                                            
   }                                                                                                               
}
```

Also fixes json keys for groups and targets.

Fixes https://github.com/docker/buildx/issues/278