### PR TITLE
RFC: releases add shasum create for releases bin files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
 
 script:
   - make binaries validate-all && TARGETPLATFORM="${CROSS_PLATFORMS}" ./hack/cross
-
+  - for i in ./out/*; do shasum --binary -a 256 "$i" >> "$i.sha256"; done
 
 deploy:
   - provider: script


### PR DESCRIPTION
the Binary release files are used in many CIs
so shasums and / or gpg sigs are Best Practices.

possible fix for #285 
feedback about the PR is welcome