### PR TITLE
demo-env: correct dockerd logging

### DIFF
--- a/hack/demo-env/entrypoint.sh
+++ b/hack/demo-env/entrypoint.sh
@@ -10,7 +10,7 @@ if [ -n "$TMUX_ENTRYPOINT" ]; then
   tmux new-window
   tmux a -t demo
 else
-  ( $dockerdCmd 2>/var/log/dockerd.log & )
+  ( $dockerdCmd &>/var/log/dockerd.log & )
   exec ash
 fi
 


### PR DESCRIPTION
Some containerd logs print to stdout 🤷‍♂️ , so make sure both fds are sent to file to make sure this doesn't mess up build output.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>