### PR TITLE
build: support cacheonly exporter

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -382,6 +382,15 @@ func toSolveOpt(d driver.Driver, multiDriver bool, opt Options, dl dockerLoadCal
 		}
 	}
 
+	// cacheonly is a fake exporter to opt out of default behaviors
+	exports := make([]client.ExportEntry, 0, len(opt.Exports))
+	for _, e := range opt.Exports {
+		if e.Type != "cacheonly" {
+			exports = append(exports, e)
+		}
+	}
+	opt.Exports = exports
+
 	// set up exporters
 	for i, e := range opt.Exports {
 		if (e.Type == "local" || e.Type == "tar") && opt.ImageIDFile != "" {

--- a/build/build.go
+++ b/build/build.go
@@ -343,11 +343,13 @@ func toSolveOpt(d driver.Driver, multiDriver bool, opt Options, dl dockerLoadCal
 		IsDefaultMobyDriver()
 	})
 
+	noDefaultLoad, _ := strconv.ParseBool(os.Getenv("BUILDX_NO_DEFAULT_LOAD"))
+
 	switch len(opt.Exports) {
 	case 1:
 		// valid
 	case 0:
-		if isDefaultMobyDriver {
+		if isDefaultMobyDriver && !noDefaultLoad {
 			// backwards compat for docker driver only:
 			// this ensures the build results in a docker image.
 			opt.Exports = []client.ExportEntry{{Type: "image", Attrs: map[string]string{}}}


### PR DESCRIPTION
cacheonly is a fake exporter name supported by moby to avoid default behavior of creating an image. Add support for buildx as well so same flags can be used.

Second commit also adds an env to opt-out of default behavior that is probably a cleaner solution if you don't know if docker or container driver is used by buildx.