### PR TITLE
feat: enhance kubernetes driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,7 @@ Passes additional driver-specific options. Details for each driver:
   - `image=IMAGE` - Sets the container image to be used for running buildkit.
   - `namespace=NS` - Sets the Kubernetes namespace. Defaults to the current namespace.
   - `replicas=N` - Sets the number of `Pod` replicas. Defaults to 1.
+  - `nodeselector="label1=value1,label2=value2"` - Sets the kv of `Pod` nodeSelector. No Defaults. Example `nodeselector=kubernetes.io/arch=arm64`
   - `rootless=(true|false)` - Run the container as a non-root user without `securityContext.privileged`. [Using Ubuntu host kernel is recommended](https://github.com/moby/buildkit/blob/master/docs/rootless.md). Defaults to false.
   - `loadbalance=(sticky|random)` - Load-balancing strategy. If set to "sticky", the pod is chosen using the hash of the context path. Defaults to "sticky"
 

--- a/commands/create.go
+++ b/commands/create.go
@@ -142,6 +142,12 @@ func runCreate(dockerCli command.Cli, in createOptions, args []string) error {
 				return err
 			}
 		}
+
+		if in.driver == "kubernetes" {
+			// naming endpoint to make --append works
+			ep = fmt.Sprintf("%s://%s?deployment=%s", in.driver, in.name, in.nodeName)
+		}
+
 		m, err := csvToMap(in.driverOpts)
 		if err != nil {
 			return err

--- a/driver/kubernetes/driver.go
+++ b/driver/kubernetes/driver.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/docker/buildx/driver"
 	"github.com/docker/buildx/driver/kubernetes/execconn"
+	"github.com/docker/buildx/driver/kubernetes/manifest"
 	"github.com/docker/buildx/driver/kubernetes/podchooser"
 	"github.com/docker/buildx/store"
+	"github.com/docker/buildx/util/platformutil"
 	"github.com/docker/buildx/util/progress"
 	"github.com/moby/buildkit/client"
 	"github.com/pkg/errors"
@@ -109,6 +112,16 @@ func (d *Driver) Info(ctx context.Context) (*driver.Info, error) {
 			Name: p.Name,
 			// Other fields are unset (TODO: detect real platforms)
 		}
+
+		if p.Annotations != nil {
+			if p, ok := p.Annotations[manifest.AnnotationPlatform]; ok {
+				ps, err := platformutil.Parse(strings.Split(p, ","))
+				if err == nil {
+					node.Platforms = ps
+				}
+			}
+		}
+
 		dynNodes = append(dynNodes, node)
 	}
 	return &driver.Info{

--- a/driver/kubernetes/factory.go
+++ b/driver/kubernetes/factory.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/buildx/driver/bkimage"
 	"github.com/docker/buildx/driver/kubernetes/manifest"
 	"github.com/docker/buildx/driver/kubernetes/podchooser"
+	"github.com/docker/buildx/util/platformutil"
 	dockerclient "github.com/docker/docker/client"
 	"github.com/pkg/errors"
 	"k8s.io/client-go/kubernetes"
@@ -90,6 +91,24 @@ func (f *factory) New(ctx context.Context, cfg driver.InitConfig) (driver.Driver
 				return nil, err
 			}
 			deploymentOpt.Image = bkimage.DefaultRootlessImage
+		case "platform":
+			if v != "" {
+				platforms, err := platformutil.Parse(strings.Split(v, ","))
+				if err != nil {
+					return nil, err
+				}
+				deploymentOpt.Platforms = platforms
+			}
+		case "nodeselector":
+			kvs := strings.Split(strings.Trim(v, `"`), ",")
+			s := map[string]string{}
+			for i := range kvs {
+				kv := strings.Split(kvs[i], "=")
+				if len(kv) == 2 {
+					s[kv[0]] = kv[1]
+				}
+			}
+			deploymentOpt.NodeSelector = s
 		case "loadbalance":
 			switch v {
 			case LoadbalanceSticky:


### PR DESCRIPTION
fix #342 

now we could use kubernetes driver with `--append`

```bash
docker buildx create --use --name=buildkit --platform=linux/amd64 --node=buildkit-amd64 --driver=kubernetes --driver-opt="nodeselector=kubernetes.io/arch=amd64"
docker buildx create --append --name=buildkit --platform=linux/arm64 --node=buildkit-arm64 --driver=kubernetes --driver-opt="nodeselector=kubernetes.io/arch=arm64"
```

```bash
docker buildx inspect buildkit --bootstrap

Name:   buildkit
Driver: kubernetes

Nodes:
Name:      buildkit-amd64
Endpoint:  kubernetes://buildkit/buildkit-amd64
Status:    running
Platforms: linux/amd64*, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/arm/v7, linux/arm/v6

Name:      buildkit-arm64
Endpoint:  kubernetes://buildkit/buildkit-arm64
Status:    running
Platforms: linux/arm64*, linux/amd64, linux/riscv64, linux/ppc64le, linux/s390x, linux/arm/v7, linux/arm/v6
```

without `binfmt`
```bash
docker buildx inspect buildkit

Name:   buildkit
Driver: kubernetes

Nodes:
Name:      buildkit-amd64
Endpoint:  kubernetes://buildkit/buildkit-amd64
Status:    running
Platforms: linux/amd64*, linux/386

Name:      buildkit-arm64
Endpoint:  kubernetes://buildkit/buildkit-arm64
Status:    running
Platforms: linux/arm64*
```

without `--append`, kubernetes driver works as previous behavior