### PR TITLE
hack/util: take other arches into account on Darwin

### DIFF
--- a/hack/test
+++ b/hack/test
@@ -35,7 +35,7 @@ case $buildmode in
 esac
 
 cacheVolume="buildx-cache"
-if ! docker inspect "$cacheVolume" 2>&1 >/dev/null ; then
+if ! docker inspect "$cacheVolume" > /dev/null 2>&1 ; then
 cacheVolume=$(docker create --name=buildx-cache -v /root/.cache -v /go/pkg/mod alpine)
 fi
 

--- a/hack/util
+++ b/hack/util
@@ -22,9 +22,12 @@ else
 fi
 
 if [ -z "$CLI_PLATFORM" ]; then
-  rawos=$(uname -s)
-  if [ "$rawos" = "Darwin" ]; then
-    CLI_PLATFORM="darwin/amd64"
+  if [ "$(uname -s)" = "Darwin" ]; then
+      arch="$(uname -m)"
+      if [ "$arch" = "x86_64" ]; then
+          arch="amd64"
+      fi
+      CLI_PLATFORM="darwin/$arch"
   elif uname -s | grep MINGW > /dev/null 2>&1 ; then
     CLI_PLATFORM="windows/amd64"
   fi

--- a/hack/util
+++ b/hack/util
@@ -22,11 +22,11 @@ else
 fi
 
 if [ -z "$CLI_PLATFORM" ]; then
-	rawos=$(uname -s)
-	if [ "$rawos" = "Darwin" ]; then
-		CLI_PLATFORM="darwin/amd64"
-	elif uname -s | grep MINGW > /dev/null 2>&1 ; then
-		CLI_PLATFORM="windows/amd64"
-	fi
+  rawos=$(uname -s)
+  if [ "$rawos" = "Darwin" ]; then
+    CLI_PLATFORM="darwin/amd64"
+  elif uname -s | grep MINGW > /dev/null 2>&1 ; then
+    CLI_PLATFORM="windows/amd64"
+  fi
 fi
 

--- a/hack/util
+++ b/hack/util
@@ -25,7 +25,7 @@ if [ -z "$CLI_PLATFORM" ]; then
 	rawos=$(uname -s)
 	if [ "$rawos" = "Darwin" ]; then
 		CLI_PLATFORM="darwin/amd64"
-	elif uname -s | grep MINGW 2>&1 >/dev/null ; then
+	elif uname -s | grep MINGW > /dev/null 2>&1 ; then
 		CLI_PLATFORM="windows/amd64"
 	fi
 fi


### PR DESCRIPTION
Noticed that this script hard-coded amd64 on Darwin.

Haven't been able to test the output of `uname -m` on Apple silicon, so if someone's able to verify 🤗 


Also makes some small other changes caught by my linter (see individual commits for details)