### PR TITLE
Allow users to have separate store paths

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -15,7 +15,6 @@ import (
 )
 
 func New(root string) (*Store, error) {
-	root = filepath.Join(root, "buildx")
 	if err := os.MkdirAll(filepath.Join(root, "instances"), 0700); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- decouple store path from `$DOCKER_CONFIG`
- improve containerised build setup
- introduce new `$BUILDX_CONFIG` environment variable

Related to #308