### PR TITLE
Remove "version" annotations from du and prune commands

### DIFF
--- a/commands/diskusage.go
+++ b/commands/diskusage.go
@@ -109,7 +109,6 @@ func duCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 			options.builder = rootOpts.builder
 			return runDiskUsage(dockerCli, options)
 		},
-		Annotations: map[string]string{"version": "1.00"},
 	}
 
 	flags := cmd.Flags()

--- a/commands/prune.go
+++ b/commands/prune.go
@@ -135,7 +135,6 @@ func pruneCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 			options.builder = rootOpts.builder
 			return runPrune(dockerCli, options)
 		},
-		Annotations: map[string]string{"version": "1.00"},
 	}
 
 	flags := cmd.Flags()


### PR DESCRIPTION
These annotations were picked up by the YAML docs generator, and showed up as "minimum API version" (https://github.com/docker/docker.github.io/pull/11447). I couldn't find a reference to these annotations in the PR that added them, so thought it would be ok to remove


