### PR TITLE
allow builder flag to switch to default instance

### DIFF
--- a/commands/rm.go
+++ b/commands/rm.go
@@ -93,7 +93,7 @@ func stop(ctx context.Context, dockerCli command.Cli, ng *store.NodeGroup, rm bo
 }
 
 func stopCurrent(ctx context.Context, dockerCli command.Cli, rm bool) error {
-	dis, err := getDefaultDrivers(ctx, dockerCli, "")
+	dis, err := getDefaultDrivers(ctx, dockerCli, false, "")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Currently `docker buildx --builder=default build .` produces error `error: open /root/.docker/buildx/instances/default: no such file or directory`. This makes it work properly and produces appropriate error if context name is used instead.

@cpuguy83 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>