### PR TITLE
fixes #427: Handle empty strings in elements enabling conditional logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -741,6 +741,43 @@ $ docker buildx bake --print webapp
 }
 ```
 
+Example of only adding tags if a variable is not empty using an `notequal` function:
+
+```
+$ cat <<'EOF' > docker-bake.hcl
+variable "TAG" {default="" }
+
+group "default" {
+	targets = [
+    "webapp",
+  ]
+}
+
+target "webapp" {
+  context="."
+  dockerfile="Dockerfile"
+  tags = [
+      "my-image:latest",
+      notequal("",TAG) ? "my-image:${TAG}": "",
+  ]
+}
+EOF
+
+$ docker buildx bake --print webapp
+{
+   "target": {
+      "webapp": {
+         "context": ".",
+         "dockerfile": "Dockerfile",
+         "tags": [
+            "my-image:latest"
+         ]
+      }
+   }
+}
+```
+
+
 ### `buildx imagetools create [OPTIONS] [SOURCE] [SOURCE...]`
 
 Imagetools contains commands for working with manifest lists in the registry. These commands are useful for inspecting multi-platform build results.

--- a/README.md
+++ b/README.md
@@ -749,17 +749,17 @@ variable "TAG" {default="" }
 
 group "default" {
 	targets = [
-    "webapp",
-  ]
+		"webapp",
+	]
 }
 
 target "webapp" {
-  context="."
-  dockerfile="Dockerfile"
-  tags = [
-      "my-image:latest",
-      notequal("",TAG) ? "my-image:${TAG}": "",
-  ]
+	context="."
+	dockerfile="Dockerfile"
+	tags = [
+		"my-image:latest",
+		notequal("",TAG) ? "my-image:${TAG}": "",
+	]
 }
 EOF
 

--- a/bake/bake.go
+++ b/bake/bake.go
@@ -526,6 +526,9 @@ func removeDupes(s []string) []string {
 		if _, ok := seen[v]; ok {
 			continue
 		}
+		if v == "" {
+			continue
+		}
 		seen[v] = struct{}{}
 		s[i] = v
 		i++

--- a/bake/hcl.go
+++ b/bake/hcl.go
@@ -31,6 +31,7 @@ var (
 		"csvdecode":              stdlib.CSVDecodeFunc,
 		"coalesce":               stdlib.CoalesceFunc,
 		"coalescelist":           stdlib.CoalesceListFunc,
+		"compact":                stdlib.CompactFunc,
 		"concat":                 stdlib.ConcatFunc,
 		"contains":               stdlib.ContainsFunc,
 		"distinct":               stdlib.DistinctFunc,


### PR DESCRIPTION
this change aims to resolve #427 by allowing either the compact function to be used and also allowing empty strings to be present in the resulting bake file and stripping them out of the final file before actioning.

example file 1 with compact.
```
variable "TAG" {default="" }

group "default" {
	targets = [
    "app",
  ]
}

target "app" {
  context="."
  dockerfile="Dockerfile"
  tags = "${compact([
      "my-image:latest",
      notequal("",TAG) ? "my-image:${TAG}-1": "",
      notequal("",TAG) ? "my-image:${TAG}-2": null,
      null,
    ])}"
}

```

Example 2 with allowing empty strings in arrays will no longer cause any issues with docker push as they are stripped.
```variable "TAG" {default="" }

group "default" {
	targets = [
    "app",
  ]
}

target "app" {
  context="."
  dockerfile="Dockerfile"
  tags = [
      "my-image:latest",
      notequal("",TAG) ? "my-image:${TAG}-1": "",
      notequal("",TAG) ? "my-image:${TAG}-2": "",
  ]
}
```

the above two config files results in the below print
```
❯ docker buildx bake --print
{
   "target": {
      "app": {
         "context": ".",
         "dockerfile": "Dockerfile",
         "tags": [
            "my-image:latest"
         ]
      }
   }
}

❯ TAG="ok" docker buildx bake --print
{
   "target": {
      "app": {
         "context": ".",
         "dockerfile": "Dockerfile",
         "tags": [
            "my-image:latest",
            "my-image:ok-1",
            "my-image:ok-2"
         ]
      }
   }
}```