### PR TITLE
docker-container: ensure credentials are passed when pulling buildkit

### DIFF
--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -81,7 +81,7 @@ func runInspect(dockerCli command.Cli, in inspectOptions) error {
 
 	if in.bootstrap {
 		var ok bool
-		ok, err = boot(ctx, ngi)
+		ok, err = boot(ctx, ngi, dockerCli)
 		if err != nil {
 			return err
 		}
@@ -153,7 +153,7 @@ func inspectCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 	return cmd
 }
 
-func boot(ctx context.Context, ngi *nginfo) (bool, error) {
+func boot(ctx context.Context, ngi *nginfo, dockerCli command.Cli) (bool, error) {
 	toBoot := make([]int, 0, len(ngi.drivers))
 	for i, d := range ngi.drivers {
 		if d.err != nil || d.di.Err != nil || d.di.Driver == nil || d.info == nil {
@@ -176,7 +176,7 @@ func boot(ctx context.Context, ngi *nginfo) (bool, error) {
 		func(idx int) {
 			eg.Go(func() error {
 				pw := mw.WithPrefix(ngi.ng.Nodes[idx].Name, len(toBoot) > 1)
-				_, err := driver.Boot(ctx, ngi.drivers[idx].di.Driver, pw)
+				_, err := driver.Boot(ctx, ngi.drivers[idx].di.Driver, dockerCli.ConfigFile(), pw)
 				if err != nil {
 					ngi.drivers[idx].err = err
 				}

--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -79,12 +79,14 @@ func runInspect(dockerCli command.Cli, in inspectOptions) error {
 
 	err = loadNodeGroupData(timeoutCtx, dockerCli, ngi)
 
+	var bootNgi *nginfo
 	if in.bootstrap {
 		var ok bool
 		ok, err = boot(ctx, ngi, dockerCli)
 		if err != nil {
 			return err
 		}
+		bootNgi = ngi
 		if ok {
 			ngi = &nginfo{ng: ng}
 			err = loadNodeGroupData(ctx, dockerCli, ngi)
@@ -113,6 +115,8 @@ func runInspect(dockerCli command.Cli, in inspectOptions) error {
 				fmt.Fprintf(w, "Error:\t%s\n", err.Error())
 			} else if err := ngi.drivers[i].err; err != nil {
 				fmt.Fprintf(w, "Error:\t%s\n", err.Error())
+			} else if bootNgi != nil && len(bootNgi.drivers) > i && bootNgi.drivers[i].err != nil {
+				fmt.Fprintf(w, "Error:\t%s\n", bootNgi.drivers[i].err.Error())
 			} else {
 				fmt.Fprintf(w, "Status:\t%s\n", ngi.drivers[i].info.Status)
 				if len(n.Flags) > 0 {

--- a/driver/docker/driver.go
+++ b/driver/docker/driver.go
@@ -15,7 +15,7 @@ type Driver struct {
 	driver.InitConfig
 }
 
-func (d *Driver) Bootstrap(ctx context.Context, l progress.Logger) error {
+func (d *Driver) Bootstrap(ctx context.Context, _ driver.Auth, l progress.Logger) error {
 	return nil
 }
 

--- a/driver/kubernetes/driver.go
+++ b/driver/kubernetes/driver.go
@@ -44,7 +44,7 @@ type Driver struct {
 	podChooser       podchooser.PodChooser
 }
 
-func (d *Driver) Bootstrap(ctx context.Context, l progress.Logger) error {
+func (d *Driver) Bootstrap(ctx context.Context, auth driver.Auth, l progress.Logger) error {
 	return progress.Wrap("[internal] booting buildkit", l, func(sub progress.SubLogger) error {
 		_, err := d.deploymentClient.Get(ctx, d.deployment.Name, metav1.GetOptions{})
 		if err != nil {

--- a/util/imagetools/inspect.go
+++ b/util/imagetools/inspect.go
@@ -3,6 +3,8 @@ package imagetools
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"io"
 	"net/http"
 
@@ -106,4 +108,24 @@ func toCredentialsFunc(a Auth) func(string) (string, string, error) {
 		}
 		return ac.Username, ac.Password, nil
 	}
+}
+
+func RegistryAuthForRef(ref string, a Auth) (string, error) {
+	r, err := parseRef(ref)
+	if err != nil {
+		return "", err
+	}
+	host := reference.Domain(r)
+	if host == "docker.io" {
+		host = "https://index.docker.io/v1/"
+	}
+	ac, err := a.GetAuthConfig(host)
+	if err != nil {
+		return "", err
+	}
+	buf, err := json.Marshal(ac)
+	if err != nil {
+		return "", err
+	}
+	return base64.URLEncoding.EncodeToString(buf), nil
 }


### PR DESCRIPTION
Anonymous pulls may get rate limited differently so make sure to send user credentials when pulling buildkit image for creating builder container.

If anyone hits this live workaround is to run `docker pull moby/buildkit:buildx-stable-1` manually before `docker buildx create`.

@AkihiroSuda you probably want to make a similar change for kube driver.

