### PR TITLE
refactor driver auth for easier passing

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -127,7 +127,7 @@ func allIndexes(l int) []int {
 	return out
 }
 
-func ensureBooted(ctx context.Context, drivers []DriverInfo, idxs []int, auth Auth, pw progress.Writer) ([]*client.Client, error) {
+func ensureBooted(ctx context.Context, drivers []DriverInfo, idxs []int, pw progress.Writer) ([]*client.Client, error) {
 	clients := make([]*client.Client, len(drivers))
 
 	eg, ctx := errgroup.WithContext(ctx)
@@ -135,7 +135,7 @@ func ensureBooted(ctx context.Context, drivers []DriverInfo, idxs []int, auth Au
 	for _, i := range idxs {
 		func(i int) {
 			eg.Go(func() error {
-				c, err := driver.Boot(ctx, drivers[i].Driver, auth, pw)
+				c, err := driver.Boot(ctx, drivers[i].Driver, pw)
 				if err != nil {
 					return err
 				}
@@ -199,7 +199,7 @@ func resolveDrivers(ctx context.Context, drivers []DriverInfo, auth Auth, opt ma
 		for k, opt := range opt {
 			m[k] = []driverPair{{driverIndex: 0, platforms: opt.Platforms}}
 		}
-		clients, err := ensureBooted(ctx, drivers, driverIndexes(m), auth, pw)
+		clients, err := ensureBooted(ctx, drivers, driverIndexes(m), pw)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -209,7 +209,7 @@ func resolveDrivers(ctx context.Context, drivers []DriverInfo, auth Auth, opt ma
 	// map based on existing platforms
 	if !undetectedPlatform {
 		m := splitToDriverPairs(availablePlatforms, opt)
-		clients, err := ensureBooted(ctx, drivers, driverIndexes(m), auth, pw)
+		clients, err := ensureBooted(ctx, drivers, driverIndexes(m), pw)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -217,7 +217,7 @@ func resolveDrivers(ctx context.Context, drivers []DriverInfo, auth Auth, opt ma
 	}
 
 	// boot all drivers in k
-	clients, err := ensureBooted(ctx, drivers, allIndexes(len(drivers)), auth, pw)
+	clients, err := ensureBooted(ctx, drivers, allIndexes(len(drivers)), pw)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -180,7 +180,7 @@ func boot(ctx context.Context, ngi *nginfo, dockerCli command.Cli) (bool, error)
 		func(idx int) {
 			eg.Go(func() error {
 				pw := mw.WithPrefix(ngi.ng.Nodes[idx].Name, len(toBoot) > 1)
-				_, err := driver.Boot(ctx, ngi.drivers[idx].di.Driver, dockerCli.ConfigFile(), pw)
+				_, err := driver.Boot(ctx, ngi.drivers[idx].di.Driver, pw)
 				if err != nil {
 					ngi.drivers[idx].err = err
 				}

--- a/commands/util.go
+++ b/commands/util.go
@@ -206,7 +206,7 @@ func driversForNodeGroup(ctx context.Context, dockerCli command.Cli, ng *store.N
 				if kcc == nil {
 					kcc = driver.KubeClientConfigInCluster{}
 				}
-				d, err := driver.GetDriver(ctx, "buildx_buildkit_"+n.Name, f, dockerapi, kcc, n.Flags, n.ConfigFile, assignDriverOptsByDriverInfo(n.DriverOpts, di), contextPathHash)
+				d, err := driver.GetDriver(ctx, "buildx_buildkit_"+n.Name, f, dockerapi, dockerCli.ConfigFile(), kcc, n.Flags, n.ConfigFile, assignDriverOptsByDriverInfo(n.DriverOpts, di), contextPathHash)
 				if err != nil {
 					di.Err = err
 					return nil
@@ -339,7 +339,7 @@ func getDefaultDrivers(ctx context.Context, dockerCli command.Cli, defaultOnly b
 		}
 	}
 
-	d, err := driver.GetDriver(ctx, "buildx_buildkit_default", nil, dockerCli.Client(), nil, nil, "", nil, contextPathHash)
+	d, err := driver.GetDriver(ctx, "buildx_buildkit_default", nil, dockerCli.Client(), dockerCli.ConfigFile(), nil, nil, "", nil, contextPathHash)
 	if err != nil {
 		return nil, err
 	}

--- a/driver/docker-container/driver.go
+++ b/driver/docker-container/driver.go
@@ -32,12 +32,12 @@ type Driver struct {
 	env     []string
 }
 
-func (d *Driver) Bootstrap(ctx context.Context, auth driver.Auth, l progress.Logger) error {
+func (d *Driver) Bootstrap(ctx context.Context, l progress.Logger) error {
 	return progress.Wrap("[internal] booting buildkit", l, func(sub progress.SubLogger) error {
 		_, err := d.DockerAPI.ContainerInspect(ctx, d.Name)
 		if err != nil {
 			if dockerclient.IsErrNotFound(err) {
-				return d.create(ctx, auth, sub)
+				return d.create(ctx, sub)
 			}
 			return err
 		}
@@ -53,14 +53,14 @@ func (d *Driver) Bootstrap(ctx context.Context, auth driver.Auth, l progress.Log
 	})
 }
 
-func (d *Driver) create(ctx context.Context, auth driver.Auth, l progress.SubLogger) error {
+func (d *Driver) create(ctx context.Context, l progress.SubLogger) error {
 	imageName := bkimage.DefaultImage
 	if d.image != "" {
 		imageName = d.image
 	}
 
 	if err := l.Wrap("pulling image "+imageName, func() error {
-		ra, err := imagetools.RegistryAuthForRef(imageName, auth)
+		ra, err := imagetools.RegistryAuthForRef(imageName, d.Auth)
 		if err != nil {
 			return err
 		}

--- a/driver/docker/driver.go
+++ b/driver/docker/driver.go
@@ -15,7 +15,7 @@ type Driver struct {
 	driver.InitConfig
 }
 
-func (d *Driver) Bootstrap(ctx context.Context, _ driver.Auth, l progress.Logger) error {
+func (d *Driver) Bootstrap(ctx context.Context, l progress.Logger) error {
 	return nil
 }
 

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -51,7 +51,7 @@ type Auth interface {
 
 type Driver interface {
 	Factory() Factory
-	Bootstrap(context.Context, Auth, progress.Logger) error
+	Bootstrap(context.Context, progress.Logger) error
 	Info(context.Context) (*Info, error)
 	Stop(ctx context.Context, force bool) error
 	Rm(ctx context.Context, force bool) error
@@ -59,7 +59,7 @@ type Driver interface {
 	Features() map[Feature]bool
 }
 
-func Boot(ctx context.Context, d Driver, auth Auth, pw progress.Writer) (*client.Client, error) {
+func Boot(ctx context.Context, d Driver, pw progress.Writer) (*client.Client, error) {
 	try := 0
 	for {
 		info, err := d.Info(ctx)
@@ -71,7 +71,7 @@ func Boot(ctx context.Context, d Driver, auth Auth, pw progress.Writer) (*client
 			if try > 2 {
 				return nil, errors.Errorf("failed to bootstrap %T driver in attempts", d)
 			}
-			if err := d.Bootstrap(ctx, auth, func(s *client.SolveStatus) {
+			if err := d.Bootstrap(ctx, func(s *client.SolveStatus) {
 				if pw != nil {
 					pw.Status() <- s
 				}

--- a/driver/kubernetes/driver.go
+++ b/driver/kubernetes/driver.go
@@ -44,7 +44,7 @@ type Driver struct {
 	podChooser       podchooser.PodChooser
 }
 
-func (d *Driver) Bootstrap(ctx context.Context, auth driver.Auth, l progress.Logger) error {
+func (d *Driver) Bootstrap(ctx context.Context, l progress.Logger) error {
 	return progress.Wrap("[internal] booting buildkit", l, func(sub progress.SubLogger) error {
 		_, err := d.deploymentClient.Get(ctx, d.deployment.Name, metav1.GetOptions{})
 		if err != nil {

--- a/driver/manager.go
+++ b/driver/manager.go
@@ -52,6 +52,7 @@ type InitConfig struct {
 	BuildkitFlags    []string
 	ConfigFile       string
 	DriverOpts       map[string]string
+	Auth             Auth
 	// ContextPathHash can be used for determining pods in the driver instance
 	ContextPathHash string
 }
@@ -98,7 +99,7 @@ func GetFactory(name string, instanceRequired bool) Factory {
 	return nil
 }
 
-func GetDriver(ctx context.Context, name string, f Factory, api dockerclient.APIClient, kcc KubeClientConfig, flags []string, config string, do map[string]string, contextPathHash string) (Driver, error) {
+func GetDriver(ctx context.Context, name string, f Factory, api dockerclient.APIClient, auth Auth, kcc KubeClientConfig, flags []string, config string, do map[string]string, contextPathHash string) (Driver, error) {
 	ic := InitConfig{
 		DockerAPI:        api,
 		KubeClientConfig: kcc,
@@ -106,6 +107,7 @@ func GetDriver(ctx context.Context, name string, f Factory, api dockerclient.API
 		BuildkitFlags:    flags,
 		ConfigFile:       config,
 		DriverOpts:       do,
+		Auth:             auth,
 		ContextPathHash:  contextPathHash,
 	}
 	if f == nil {

--- a/util/imagetools/inspect.go
+++ b/util/imagetools/inspect.go
@@ -111,6 +111,9 @@ func toCredentialsFunc(a Auth) func(string) (string, string, error) {
 }
 
 func RegistryAuthForRef(ref string, a Auth) (string, error) {
+	if a == nil {
+		return "", nil
+	}
 	r, err := parseRef(ref)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Refactor driver auth passing from #433 so it is initialized with the driver instead. Carrying auth config with function calls will become very cumbersome when more places that invoke `Boot` are added.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>