### PR TITLE
Get multi-platform buildkit frontend opt from args

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -331,6 +331,12 @@ func toSolveOpt(d driver.Driver, multiDriver bool, opt Options, dl dockerLoadCal
 		AllowedEntitlements: opt.Allow,
 	}
 
+	if v, ok := opt.BuildArgs["BUILDKIT_MULTI_PLATFORM"]; ok {
+		if v, _ := strconv.ParseBool(v); v {
+			so.FrontendAttrs["multi-platform"] = "true"
+		}
+	}
+
 	if multiDriver {
 		// force creation of manifest list
 		so.FrontendAttrs["multi-platform"] = "true"


### PR DESCRIPTION
This allows builders to opt into determnistic output regardless of
multi-platform output or not.

This resolves the real intention behind 158; deterministic output.

Closes #158