### PR TITLE
driver: do not insert "platform" as driver-opt

### DIFF
--- a/commands/util.go
+++ b/commands/util.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/docker/buildx/build"
 	"github.com/docker/buildx/driver"
@@ -220,7 +219,7 @@ func driversForNodeGroup(ctx context.Context, dockerCli command.Cli, ng *store.N
 					}
 				}
 
-				d, err := driver.GetDriver(ctx, "buildx_buildkit_"+n.Name, f, dockerapi, dockerCli.ConfigFile(), kcc, n.Flags, n.ConfigFile, assignDriverOptsByDriverInfo(n.DriverOpts, di), contextPathHash)
+				d, err := driver.GetDriver(ctx, "buildx_buildkit_"+n.Name, f, dockerapi, dockerCli.ConfigFile(), kcc, n.Flags, n.ConfigFile, n.DriverOpts, n.Platforms, contextPathHash)
 				if err != nil {
 					di.Err = err
 					return nil
@@ -236,20 +235,6 @@ func driversForNodeGroup(ctx context.Context, dockerCli command.Cli, ng *store.N
 	}
 
 	return dis, nil
-}
-
-// pass platform as driver opts to provide for some drive, like kubernetes
-func assignDriverOptsByDriverInfo(opts map[string]string, driveInfo build.DriverInfo) map[string]string {
-	m := map[string]string{}
-
-	if len(driveInfo.Platform) > 0 {
-		m["platform"] = strings.Join(platformutil.Format(driveInfo.Platform), ",")
-	}
-
-	for key := range opts {
-		m[key] = opts[key]
-	}
-	return m
 }
 
 // clientForEndpoint returns a docker client for an endpoint
@@ -353,7 +338,7 @@ func getDefaultDrivers(ctx context.Context, dockerCli command.Cli, defaultOnly b
 		}
 	}
 
-	d, err := driver.GetDriver(ctx, "buildx_buildkit_default", nil, dockerCli.Client(), dockerCli.ConfigFile(), nil, nil, "", nil, contextPathHash)
+	d, err := driver.GetDriver(ctx, "buildx_buildkit_default", nil, dockerCli.Client(), dockerCli.ConfigFile(), nil, nil, "", nil, nil, contextPathHash)
 	if err != nil {
 		return nil, err
 	}

--- a/driver/kubernetes/factory.go
+++ b/driver/kubernetes/factory.go
@@ -9,7 +9,6 @@ import (
 	"github.com/docker/buildx/driver/bkimage"
 	"github.com/docker/buildx/driver/kubernetes/manifest"
 	"github.com/docker/buildx/driver/kubernetes/podchooser"
-	"github.com/docker/buildx/util/platformutil"
 	dockerclient "github.com/docker/docker/client"
 	"github.com/pkg/errors"
 	"k8s.io/client-go/kubernetes"
@@ -71,6 +70,7 @@ func (f *factory) New(ctx context.Context, cfg driver.InitConfig) (driver.Driver
 		Replicas:      1,
 		BuildkitFlags: cfg.BuildkitFlags,
 		Rootless:      false,
+		Platforms:     cfg.Platforms,
 	}
 	loadbalance := LoadbalanceSticky
 	imageOverride := ""
@@ -91,14 +91,6 @@ func (f *factory) New(ctx context.Context, cfg driver.InitConfig) (driver.Driver
 				return nil, err
 			}
 			deploymentOpt.Image = bkimage.DefaultRootlessImage
-		case "platform":
-			if v != "" {
-				platforms, err := platformutil.Parse(strings.Split(v, ","))
-				if err != nil {
-					return nil, err
-				}
-				deploymentOpt.Platforms = platforms
-			}
 		case "nodeselector":
 			kvs := strings.Split(strings.Trim(v, `"`), ",")
 			s := map[string]string{}

--- a/driver/manager.go
+++ b/driver/manager.go
@@ -11,6 +11,7 @@ import (
 
 	dockerclient "github.com/docker/docker/client"
 	"github.com/moby/buildkit/client"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
@@ -55,6 +56,7 @@ type InitConfig struct {
 	ConfigFile       string
 	DriverOpts       map[string]string
 	Auth             Auth
+	Platforms        []specs.Platform
 	// ContextPathHash can be used for determining pods in the driver instance
 	ContextPathHash string
 }
@@ -101,7 +103,7 @@ func GetFactory(name string, instanceRequired bool) Factory {
 	return nil
 }
 
-func GetDriver(ctx context.Context, name string, f Factory, api dockerclient.APIClient, auth Auth, kcc KubeClientConfig, flags []string, config string, do map[string]string, contextPathHash string) (Driver, error) {
+func GetDriver(ctx context.Context, name string, f Factory, api dockerclient.APIClient, auth Auth, kcc KubeClientConfig, flags []string, config string, do map[string]string, platforms []specs.Platform, contextPathHash string) (Driver, error) {
 	ic := InitConfig{
 		DockerAPI:        api,
 		KubeClientConfig: kcc,
@@ -110,6 +112,7 @@ func GetDriver(ctx context.Context, name string, f Factory, api dockerclient.API
 		ConfigFile:       config,
 		DriverOpts:       do,
 		Auth:             auth,
+		Platforms:        platforms,
 		ContextPathHash:  contextPathHash,
 	}
 	if f == nil {


### PR DESCRIPTION
Addresses https://github.com/docker/setup-buildx-action/issues/45

Simple repro:
```
$ buildx create --platform linux/amd64 --use
$ buildx build - <<EOF
from scratch
EOF
```

Since https://github.com/docker/buildx/pull/370 a `platform` driver-opt was automatically inserted with the value specified by `--platform` flag on regardless of the type of driver, even though it was only used in the kubernetes driver. However, because the docker-container driver is pedantic about the options being passed, it errored out.

Another side-effect I suspect is that with the kubernetes driver it was now possible to specify the platforms in two different ways: `--driver-opt platform=...` and `--platform`.

This patch reverts completely the `platform` driver-opt and instead ensures the platforms information is passed onto the kubernetes driver via variables.

Signed-off-by: Tibor Vass <tibor@docker.com>

cc @morlay 