### PR TITLE
set DefaultRootlessImage to "moby/buildkit:buildx-stable-1-rootless"

### DIFF
--- a/driver/bkimage/bkimage.go
+++ b/driver/bkimage/bkimage.go
@@ -2,5 +2,5 @@ package bkimage
 
 const (
 	DefaultImage         = "moby/buildkit:buildx-stable-1" // TODO: make this verified
-	DefaultRootlessImage = "moby/buildkit:v0.6.2-rootless"
+	DefaultRootlessImage = DefaultImage + "-rootless"
 )


### PR DESCRIPTION
Fix #479