### PR TITLE
feat: store kube config file to make buildx builder switchable

### DIFF
--- a/commands/create.go
+++ b/commands/create.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"encoding/csv"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 
@@ -145,7 +146,14 @@ func runCreate(dockerCli command.Cli, in createOptions, args []string) error {
 
 		if in.driver == "kubernetes" {
 			// naming endpoint to make --append works
-			ep = fmt.Sprintf("%s://%s?deployment=%s", in.driver, in.name, in.nodeName)
+			ep = (&url.URL{
+				Scheme: in.driver,
+				Path:   "/" + in.name,
+				RawQuery: (&url.Values{
+					"deployment": {in.nodeName},
+					"kubeconfig": {os.Getenv("KUBECONFIG")},
+				}).Encode(),
+			}).String()
 		}
 
 		m, err := csvToMap(in.driverOpts)


### PR DESCRIPTION
issue from slack by David Giffin

> Is there a way to pass a kubeconfig to "docker buildx"? I need to be able to switch between clusters / builders easily. It looks like buildx is using the default context / cluster when creating buildkit deployments, running builds, etc

failed use docker context, the auth way not support only `username` & `password` (https://github.com/docker/cli/blob/master/cli/context/kubernetes/load.go#L73-L74), 
which will break other auth ways like `client-key` & `client-cert`.

just added query parameter config-file  (from `KUBECONFIG` when builder created). and dynamic load kube config when use the kubernetes builder.