### PR TITLE
Add setproduct function to the bake HCL

### DIFF
--- a/bake/hcl.go
+++ b/bake/hcl.go
@@ -95,6 +95,7 @@ var (
 		"rsadecrypt":             crypto.RsaDecryptFunc,
 		"sethaselement":          stdlib.SetHasElementFunc,
 		"setintersection":        stdlib.SetIntersectionFunc,
+		"setproduct":             stdlib.SetProductFunc,
 		"setsubtract":            stdlib.SetSubtractFunc,
 		"setsymmetricdifference": stdlib.SetSymmetricDifferenceFunc,
 		"setunion":               stdlib.SetUnionFunc,


### PR DESCRIPTION
As explained in the following link, it's a very useful function.

https://www.terraform.io/docs/configuration/functions/setproduct.html#finding-combinations-for-for_each

This is my use case:

```hcl
function "create_tags" {
  params = [image_name]
  variadic_param = tags
  
  result = [
    for rt in setproduct(["docker.io", "ghcr.io"], tags):
        "${rt[0]}/${image_name}:${rt[1]}"
  ]
}
```