### PR TITLE
Allow to set default progress through env var

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -311,7 +311,13 @@ func buildCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 
 func commonBuildFlags(options *commonOptions, flags *pflag.FlagSet) {
 	options.noCache = flags.Bool("no-cache", false, "Do not use cache when building the image")
-	flags.StringVar(&options.progress, "progress", "auto", "Set type of progress output (auto, plain, tty). Use plain to show container output")
+
+	defaultProgress, ok := os.LookupEnv("BUILDX_PROGRESS_DEFAULT")
+	if !ok {
+		defaultProgress = "auto"
+	}
+	flags.StringVar(&options.progress, "progress", defaultProgress, "Set type of progress output (auto, plain, tty). Use plain to show container output")
+
 	options.pull = flags.Bool("pull", false, "Always attempt to pull a newer version of the image")
 }
 


### PR DESCRIPTION
In my case I want to always use plain to show container output without specifying `--progress` flag every time. This PR allows to set the default `progress` value through the `BUILDX_PROGRESS_DEFAULT` env var.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>