### PR TITLE
avoid cp in install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ cross:
 
 install: binaries
 	mkdir -p ~/.docker/cli-plugins
-	cp bin/buildx ~/.docker/cli-plugins/docker-buildx
+	install bin/buildx ~/.docker/cli-plugins/docker-buildx
 
 lint:
 	./hack/lint


### PR DESCRIPTION
New MacOS forbids executable files to be modified after they have run once. There is an inode-based cache that instantly kills the process when this happens. Solution is to use a method that removes the old file and then replaces it.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>