### PR TITLE
bake: allow variables in user functions

### DIFF
--- a/bake/hcl.go
+++ b/bake/hcl.go
@@ -167,15 +167,6 @@ func parseHCL(dt []byte, fn string) (_ *Config, err error) {
 		}
 	}
 
-	userFunctions, _, diags := userfunc.DecodeUserFunctions(file.Body, "function", func() *hcl.EvalContext {
-		return &hcl.EvalContext{
-			Functions: stdlibFunctions,
-		}
-	})
-	if diags.HasErrors() {
-		return nil, diags
-	}
-
 	var sc staticConfig
 
 	// Decode only variable blocks without interpolation.
@@ -187,6 +178,16 @@ func parseHCL(dt []byte, fn string) (_ *Config, err error) {
 	variables := make(map[string]cty.Value)
 	for _, variable := range sc.Variables {
 		variables[variable.Name] = cty.StringVal(variable.Default)
+	}
+
+	userFunctions, _, diags := userfunc.DecodeUserFunctions(file.Body, "function", func() *hcl.EvalContext {
+		return &hcl.EvalContext{
+			Functions: stdlibFunctions,
+			Variables: variables,
+		}
+	})
+	if diags.HasErrors() {
+		return nil, diags
 	}
 
 	// Override default with values from environment.


### PR DESCRIPTION
Currently, all variables used in functions need to be passed in as parameters. This is quite cumbersome and ofter means variables need to be redefined as parameters. Eg. https://github.com/tonistiigi/binfmt/blob/master/docker-bake.hcl#L47 . This change allows user functions to see global variables by just changing their parsing order.

@vanstee @crazy-max 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>