### PR TITLE
bake: allow attributes in global scope

### DIFF
--- a/bake/hcl_test.go
+++ b/bake/hcl_test.go
@@ -502,3 +502,14 @@ func TestHCLMultiFileAttrs(t *testing.T) {
 	require.Equal(t, c.Targets[0].Name, "app")
 	require.Equal(t, "pre-ghi", c.Targets[0].Args["v1"])
 }
+
+func TestJSONAttributes(t *testing.T) {
+	dt := []byte(`{"FOO": "abc", "variable": {"BAR": {"default": "def"}}, "target": { "app": { "args": {"v1": "pre-${FOO}-${BAR}"}} } }`)
+
+	c, err := ParseFile(dt, "docker-bake.json")
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(c.Targets))
+	require.Equal(t, c.Targets[0].Name, "app")
+	require.Equal(t, "pre-abc-def", c.Targets[0].Args["v1"])
+}


### PR DESCRIPTION
depends on #539 #538

I propose this as a base for https://github.com/docker/buildx/pull/489#pullrequestreview-561253366 

You can now define global scope attributes in HCL/JSON and use them for code reuse and setting values for variables. This means you can do a "data-only" HCL file with the values you want to set/override and use it in the list of regular output files.

Eg.

```
variable "REPO" {
  default = "tonistiigi/repo"
}

APP_TAG="foo"

target "app" {
  tags = ["${REPO}/${APP_TAG}"]
  args = {
     variant = APP_TAG
  }
}
```

You can use this file directly or create an override configuration file

```
WHOAMI="myuser"
REPO="${WHOAMI}/foo"
APP_TAG="bar-by-${WHOAMI}"
```

and invoke bake together with both of the files.

So instead of loading a `.env` automatically with another custom format, you can just pass any config file. The HCL attributes are not 100% compatible with env file format so I think for compose support we still should have a fallback, and maybe still automatically load it if you parse compose. Possibly we can just use the new compose library that does that automatically on parsing compose. For everything else, you can use HCL/JSON attributes.

In addition to strings HCL file attributes also support custom data types: arrays, booleans etc. You can refer to other attributes or call built-in functions(user functions not supported atm).

The difference between variables and attributes is that only variables are configurable by the user on invocation. I think this distinction is important, for example in the future I would expect that we add a "description" property to variables so we can show the user what variables are accepted and what do they mean.

I think we should also do https://github.com/docker/buildx/issues/445

@crazy-max @tiborvass @thaJeztah @vanstee 