### PR TITLE
imagetools inspect: don't discard errors from PrintManifestList

### DIFF
--- a/commands/imagetools/inspect.go
+++ b/commands/imagetools/inspect.go
@@ -38,7 +38,7 @@ func runInspect(dockerCli command.Cli, in inspectOptions, name string) error {
 	// case images.MediaTypeDockerSchema2Manifest, specs.MediaTypeImageManifest:
 	// TODO: handle distribution manifest and schema1
 	case images.MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex:
-		imagetools.PrintManifestList(dt, desc, name, os.Stdout)
+		return imagetools.PrintManifestList(dt, desc, name, os.Stdout)
 	default:
 		fmt.Printf("%s\n", dt)
 	}


### PR DESCRIPTION
Saw I had this change uncommitted in my local repo, so let me push it as a PR 😂 

Looks like this function may return an error, which we currently discard.
