### PR TITLE
Fail fast on multi platform build with load

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -456,6 +456,9 @@ func toSolveOpt(ctx context.Context, d driver.Driver, multiDriver bool, opt Opti
 			return nil, nil, notSupported(d, driver.OCIExporter)
 		}
 		if e.Type == "docker" {
+			if len(opt.Platforms) > 1 {
+				return nil, nil, errors.Errorf("docker exporter does not currently support exporting manifest lists")
+			}
 			if e.Output == nil {
 				if d.IsMobyDriver() {
 					e.Type = "image"


### PR DESCRIPTION
Avoid doing a build if we cannot load the images at the end.

This doesn't really fix anything but at least users will see the error right away and not after a potentially long build.