### PR TITLE
imagetools: fix merging JSON descriptor with old one

### DIFF
--- a/docs/reference/buildx_imagetools_create.md
+++ b/docs/reference/buildx_imagetools_create.md
@@ -50,6 +50,19 @@ Use the `--dry-run` flag to not push the image, just show it.
 Reads source from files. A source can be a manifest digest, manifest reference,
 or a JSON of OCI descriptor object.
 
+In order to define annotations or additional platform properties like `os.version` and
+`os.features` you need to add them in the OCI descriptor object encoded in JSON.
+
+```
+docker buildx imagetools inspect --raw alpine | jq '.manifests[0] | .platform."os.version"="10.1"' > descr.json
+docker buildx imagetools create -f descr.json myuser/image
+```
+
+The descriptor in the file is merged with existing descriptor in the registry if it exists.
+
+The supported fields for the descriptor are defined in [OCI spec](https://github.com/opencontainers/image-spec/blob/master/descriptor.md#properties) .
+
+
 ### <a name="tag"></a> Set reference for new image  (-t, --tag)
 
 ```


### PR DESCRIPTION
closes #562 #563

Fixes the case where remote descriptor would overwrite the local one parsed from the JSON and override custom annotations/platform info. Add docs for this case.

@thaJeztah @crazy-max @sjackman

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>