### PR TITLE
feat: add resources handling to kubernetes driver

### DIFF
--- a/docs/reference/buildx_create.md
+++ b/docs/reference/buildx_create.md
@@ -125,6 +125,10 @@ Passes additional driver-specific options. Details for each driver:
     - `image=IMAGE` - Sets the container image to be used for running buildkit.
     - `namespace=NS` - Sets the Kubernetes namespace. Defaults to the current namespace.
     - `replicas=N` - Sets the number of `Pod` replicas. Defaults to 1.
+    - `requests.cpu` - Sets the request CPU value specified in units of Kubernetes CPU. Example `requests.cpu=100m`, `requests.cpu=2`
+    - `requests.memory` - Sets the request memory value specified in bytes or with a valid suffix. Example `requests.memory=500Mi`, `requests.memory=4G`
+    - `limits.cpu` - Sets the limit CPU value specified in units of Kubernetes CPU. Example `limits.cpu=100m`, `limits.cpu=2`
+    - `limits.memory` - Sets the limit memory value specified in bytes or with a valid suffix. Example `limits.memory=500Mi`, `limits.memory=4G`
     - `nodeselector="label1=value1,label2=value2"` - Sets the kv of `Pod` nodeSelector. No Defaults. Example `nodeselector=kubernetes.io/arch=arm64`
     - `rootless=(true|false)` - Run the container as a non-root user without `securityContext.privileged`. [Using Ubuntu host kernel is recommended](https://github.com/moby/buildkit/blob/master/docs/rootless.md). Defaults to false.
     - `loadbalance=(sticky|random)` - Load-balancing strategy. If set to "sticky", the pod is chosen using the hash of the context path. Defaults to "sticky"

--- a/driver/kubernetes/factory.go
+++ b/driver/kubernetes/factory.go
@@ -85,6 +85,14 @@ func (f *factory) New(ctx context.Context, cfg driver.InitConfig) (driver.Driver
 			if err != nil {
 				return nil, err
 			}
+		case "requests.cpu":
+			deploymentOpt.RequestsCPU = v
+		case "requests.memory":
+			deploymentOpt.RequestsMemory = v
+		case "limits.cpu":
+			deploymentOpt.LimitsCPU = v
+		case "limits.memory":
+			deploymentOpt.LimitsMemory = v
 		case "rootless":
 			deploymentOpt.Rootless, err = strconv.ParseBool(v)
 			if err != nil {


### PR DESCRIPTION
This PR covers https://github.com/docker/buildx/issues/210. 

I have tried to add a single `resources` driver-opt at first which could be used as following:
```
buildx create --driver kubernetes --driver-opt replicas=1,resources="requests.cpu=100m,requests.memory=100Mi,limits.cpu=100m,limits.memory=100Mi"
```
But then found out its not possible to nest keyvalues inside driver-opts at the moment (raised an issue for that https://github.com/docker/buildx/issues/617)

The next step could be https://github.com/docker/buildx/issues/377 where it was proposed to add a possibility of extending the YAML manifest.

I might take care of that later, but decided to add resource handling in a simple way for now.