### PR TITLE
Minor fix to links in the document

### DIFF
--- a/docs/reference/buildx_bake.md
+++ b/docs/reference/buildx_bake.md
@@ -264,8 +264,8 @@ $ TAG=$(git rev-parse --short HEAD) docker buildx bake --print webapp
 
 
 A [set of generally useful functions](https://github.com/docker/buildx/blob/master/bake/hcl.go#L19-L65)
-provided by [go-cty](https://github.com/zclconf/go-cty/tree/master/cty/function/stdlib)
-are available for use in HCL files. In addition, [user defined functions](https://github.com/hashicorp/hcl/tree/hcl2/ext/userfunc)
+provided by [go-cty](https://github.com/zclconf/go-cty/tree/main/cty/function/stdlib)
+are available for use in HCL files. In addition, [user defined functions](https://github.com/hashicorp/hcl/tree/main/ext/userfunc)
 are also supported.
 
 Example of using the `add` function:


### PR DESCRIPTION
Reflect the branch name change of the linked repository.
(It is automatically redirected, so the current link is also working.)

I just happened to open this link and checked the others, but they didn't seem to need similar modifications.