### PR TITLE
clarified that buildx not always included in linux distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Using `buildx` as a docker CLI plugin requires using Docker 19.03 or newer. A li
 
 ### Docker
 
-`buildx` comes bundled with Docker Desktop and in latest Docker CE packages.
+`buildx` comes bundled with Docker Desktop and in latest Docker CE packages, but may not be installed in all repackaged Linux distros (in which case follow the binary release instructions).
 
 ### Binary release
 


### PR DESCRIPTION
subsumes #384