### PR TITLE
Ignore release-out folder

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 bin/
 cross-out/
+release-out/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,6 +125,8 @@ jobs:
   binaries:
     runs-on: ubuntu-latest
     needs: [test, cross]
+    env:
+      RELEASE_OUT: ./release-out
     steps:
       -
         name: Checkout
@@ -159,24 +161,17 @@ jobs:
       -
         name: Build ${{ steps.prep.outputs.tag }}
         run: |
-          ./hack/release "${{ steps.prep.outputs.tag }}" release-out
+          ./hack/release ${{ env.RELEASE_OUT }}
         env:
           PLATFORMS: ${{ env.PLATFORMS }},darwin/amd64,darwin/arm64,windows/amd64,windows/arm64
           CACHEDIR_FROM: /tmp/.buildx-cache/${{ env.CACHEKEY_BINARIES }}
-      -
-        name: Move artifacts
-        run: |
-          mv ./release-out/**/* ./release-out/
       -
         name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
           name: buildx
-          path: ./release-out/*
+          path: ${{ env.RELEASE_OUT }}/*
           if-no-files-found: error
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
       -
         name: Docker meta
         id: meta
@@ -214,5 +209,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           draft: true
-          files: ./release-out/*
+          files: ${{ env.RELEASE_OUT }}/*
           name: ${{ steps.prep.outputs.tag }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin
 coverage
 cross-out
+release-out

--- a/hack/release
+++ b/hack/release
@@ -1,21 +1,11 @@
 #!/usr/bin/env bash
 
-TAG=$1
-OUT=$2
+OUT=${1:-release-out}
 
 . $(dirname $0)/util
 set -eu -o pipefail
 
 : ${PLATFORMS=linux/amd64}
-
-usage() {
-  echo "usage: ./hack/release <tag> <out>"
-  exit 1
-}
-
-if [ -z "$TAG" ] || [ -z "$OUT" ]; then
-  usage
-fi
 
 importCacheFlags=""
 if [[ -n "$cacheRefFrom" ]] && [[ "$cacheType" = "local" ]]; then
@@ -29,3 +19,10 @@ buildxCmd build $importCacheFlags \
   --platform "$PLATFORMS" \
   --output "type=local,dest=$OUT" \
   $currentcontext
+
+# wrap binaries
+{ set +x; } 2>/dev/null
+if [[ $PLATFORMS =~ "," ]]; then
+  mv -f ./$OUT/**/* ./$OUT/
+  find ./$OUT -type d -empty -delete
+fi


### PR DESCRIPTION
Also remove unused `TAG` env var and wrap binaries in shell script.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>