### PR TITLE
Update Dockerfile docs to the correct image tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Here is how to use buildx inside a Dockerfile through the [`docker/buildx-bin`](
 
 ```Dockerfile
 FROM docker
-COPY --from=docker/buildx-bin:latest /buildx /usr/libexec/docker/cli-plugins/docker-buildx
+COPY --from=docker/buildx-bin:master /buildx /usr/libexec/docker/cli-plugins/docker-buildx
 RUN docker buildx version
 ```
 


### PR DESCRIPTION
Actual tag ``latest`` doesnt exists on dockerhub, causing the error :
```
manifest for docker/buildx-bin:latest not found: manifest unknown: manifest unknown
```
I change the Readme to use the tag ``master``, because its the only tag thats exists on [Dockerhub](https://hub.docker.com/r/docker/buildx-bin/tags?page=1&ordering=last_updated) 
