### PR TITLE
bake: allow BAKE_CMD_CONTEXT builtin var

### DIFF
--- a/bake/hcl_test.go
+++ b/bake/hcl_test.go
@@ -276,7 +276,7 @@ func TestHCLMultiFileSharedVariables(t *testing.T) {
 	c, err := ParseFiles([]File{
 		{Data: dt, Name: "c1.hcl"},
 		{Data: dt2, Name: "c2.hcl"},
-	})
+	}, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(c.Targets))
 	require.Equal(t, c.Targets[0].Name, "app")
@@ -288,7 +288,7 @@ func TestHCLMultiFileSharedVariables(t *testing.T) {
 	c, err = ParseFiles([]File{
 		{Data: dt, Name: "c1.hcl"},
 		{Data: dt2, Name: "c2.hcl"},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(c.Targets))
@@ -326,7 +326,7 @@ func TestHCLVarsWithVars(t *testing.T) {
 	c, err := ParseFiles([]File{
 		{Data: dt, Name: "c1.hcl"},
 		{Data: dt2, Name: "c2.hcl"},
-	})
+	}, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(c.Targets))
 	require.Equal(t, c.Targets[0].Name, "app")
@@ -338,7 +338,7 @@ func TestHCLVarsWithVars(t *testing.T) {
 	c, err = ParseFiles([]File{
 		{Data: dt, Name: "c1.hcl"},
 		{Data: dt2, Name: "c2.hcl"},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(c.Targets))
@@ -483,7 +483,7 @@ func TestHCLMultiFileAttrs(t *testing.T) {
 	c, err := ParseFiles([]File{
 		{Data: dt, Name: "c1.hcl"},
 		{Data: dt2, Name: "c2.hcl"},
-	})
+	}, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(c.Targets))
 	require.Equal(t, c.Targets[0].Name, "app")
@@ -494,7 +494,7 @@ func TestHCLMultiFileAttrs(t *testing.T) {
 	c, err = ParseFiles([]File{
 		{Data: dt, Name: "c1.hcl"},
 		{Data: dt2, Name: "c2.hcl"},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(c.Targets))
@@ -589,7 +589,7 @@ services:
 	c, err := ParseFiles([]File{
 		{Data: dt, Name: "c1.hcl"},
 		{Data: dt2, Name: "c2.yml"},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(c.Targets))
@@ -598,4 +598,25 @@ services:
 	require.Equal(t, "bar", c.Targets[0].Args["v2"])
 	require.Equal(t, "dir", *c.Targets[0].Context)
 	require.Equal(t, "Dockerfile-alternate", *c.Targets[0].Dockerfile)
+}
+
+func TestHCLBuiltinVars(t *testing.T) {
+	dt := []byte(`
+		target "app" {
+			context = BAKE_CMD_CONTEXT
+			dockerfile = "test"
+		}
+		`)
+
+	c, err := ParseFiles([]File{
+		{Data: dt, Name: "c1.hcl"},
+	}, map[string]string{
+		"BAKE_CMD_CONTEXT": "foo",
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(c.Targets))
+	require.Equal(t, c.Targets[0].Name, "app")
+	require.Equal(t, "foo", *c.Targets[0].Context)
+	require.Equal(t, "test", *c.Targets[0].Dockerfile)
 }


### PR DESCRIPTION
fix #641 

Allows accessing the main context for bake command from bake
file that has been imported remotely.

```bash
# docker buildx bake "git://github.com/docker/cli" --print
{
  "target": {
    "binary": {
      "context": "git:/github.com/docker/cli",
      "dockerfile": "Dockerfile",
      "args": {
        "BASE_VARIANT": "alpine",
        "GO_STRIP": "",
        "VERSION": ""
      },
      "target": "binary",
      "platforms": [
        "local"
      ],
      "output": [
        "build"
      ]
    }
  }
}

/tmp/a # touch foo bar
/tmp/a # docker buildx bake "git://github.com/tonistiigi/buildx#remote-test"
...
 > [4/4] RUN ls -l && stop:
#9 0.207 total 0
#9 0.207 -rw-r--r--    1 root     root             0 Jul 13 03:39 bar
#9 0.207 -rw-r--r--    1 root     root             0 Jul 13 03:39 foo
#9 0.207 /bin/sh: stop: not found


 # docker buildx bake "git://github.com/tonistiigi/buildx#remote-test" "git://github.com/docker/cli"
...
#8 0.232 -rw-r--r--    1 root     root          1893 Jul 13 03:58 poule.yml
#8 0.232 drwxr-xr-x    7 root     root          4096 Jul 13 03:58 scripts
#8 0.232 drwxr-xr-x    3 root     root          4096 Jul 13 03:58 service
#8 0.232 drwxr-xr-x    2 root     root          4096 Jul 13 03:58 templates
#8 0.232 drwxr-xr-x   11 root     root          4096 Jul 13 03:58 vendor
#8 0.232 -rwxr-xr-x    1 root     root         10123 Jul 13 03:58 vendor.conf
#8 0.232 /bin/sh: stop: not found

#   docker buildx bake "git://github.com/tonistiigi/buildx#remote-test" "https://ftp.gnu.org/gnu/binutils/binutils-2.36.tar.gz"
...
 > [4/4] RUN ls -l && stop:
#8 0.250 total 4
#8 0.251 drwxrwxrwx   19 root     root          4096 Jul 13 04:00 binutils-2.36
#8 0.251 /bin/sh: stop: not found
```

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>