### PR TITLE
Keep BuildKit state in a volume

### DIFF
--- a/docs/reference/buildx_rm.md
+++ b/docs/reference/buildx_rm.md
@@ -7,6 +7,13 @@ docker buildx rm [NAME]
 <!---MARKER_GEN_START-->
 Remove a builder instance
 
+### Options
+
+| Name | Description |
+| --- | --- |
+| `--builder string` | Override the configured builder instance |
+| [`--keep-state`](#keep-state) | Keep BuildKit state |
+
 
 <!---MARKER_GEN_END-->
 
@@ -14,3 +21,10 @@ Remove a builder instance
 
 Removes the specified or current builder. It is a no-op attempting to remove the
 default builder.
+
+## Examples
+
+### <a name="keep-state"></a> Keep BuildKit state (--keep-state)
+
+Keep BuildKit state, so it can be reused by a new builder with the same name.
+Currently, only supported by the [`docker-container` driver](buildx_create.md#driver).

--- a/driver/docker-container/driver.go
+++ b/driver/docker-container/driver.go
@@ -17,13 +17,17 @@ import (
 	"github.com/docker/docker/api/types"
 	dockertypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
 	dockerclient "github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/util/appdefaults"
 	"github.com/moby/buildkit/util/tracing/detect"
 	"github.com/pkg/errors"
 )
+
+const volumeStateSuffix = "_state"
 
 type Driver struct {
 	driver.InitConfig
@@ -103,6 +107,13 @@ func (d *Driver) create(ctx context.Context, l progress.SubLogger) error {
 		hc := &container.HostConfig{
 			Privileged: true,
 			UsernsMode: "host",
+			Mounts: []mount.Mount{
+				{
+					Type:   mount.TypeVolume,
+					Source: d.Name + volumeStateSuffix,
+					Target: appdefaults.Root,
+				},
+			},
 		}
 		if d.netMode != "" {
 			hc.NetworkMode = container.NetworkMode(d.netMode)
@@ -226,7 +237,7 @@ func (d *Driver) start(ctx context.Context, l progress.SubLogger) error {
 }
 
 func (d *Driver) Info(ctx context.Context) (*driver.Info, error) {
-	container, err := d.DockerAPI.ContainerInspect(ctx, d.Name)
+	ctn, err := d.DockerAPI.ContainerInspect(ctx, d.Name)
 	if err != nil {
 		if dockerclient.IsErrNotFound(err) {
 			return &driver.Info{
@@ -236,7 +247,7 @@ func (d *Driver) Info(ctx context.Context) (*driver.Info, error) {
 		return nil, err
 	}
 
-	if container.State.Running {
+	if ctn.State.Running {
 		return &driver.Info{
 			Status: driver.Running,
 		}, nil
@@ -258,16 +269,21 @@ func (d *Driver) Stop(ctx context.Context, force bool) error {
 	return nil
 }
 
-func (d *Driver) Rm(ctx context.Context, force bool) error {
+func (d *Driver) Rm(ctx context.Context, force bool, rmVolume bool) error {
 	info, err := d.Info(ctx)
 	if err != nil {
 		return err
 	}
 	if info.Status != driver.Inactive {
-		return d.DockerAPI.ContainerRemove(ctx, d.Name, dockertypes.ContainerRemoveOptions{
+		if err := d.DockerAPI.ContainerRemove(ctx, d.Name, dockertypes.ContainerRemoveOptions{
 			RemoveVolumes: true,
-			Force:         true,
-		})
+			Force:         force,
+		}); err != nil {
+			return err
+		}
+		if rmVolume {
+			return d.DockerAPI.VolumeRemove(ctx, d.Name+volumeStateSuffix, false)
+		}
 	}
 	return nil
 }

--- a/driver/docker/driver.go
+++ b/driver/docker/driver.go
@@ -33,7 +33,7 @@ func (d *Driver) Stop(ctx context.Context, force bool) error {
 	return nil
 }
 
-func (d *Driver) Rm(ctx context.Context, force bool) error {
+func (d *Driver) Rm(ctx context.Context, force bool, rmVolume bool) error {
 	return nil
 }
 

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -54,7 +54,7 @@ type Driver interface {
 	Bootstrap(context.Context, progress.Logger) error
 	Info(context.Context) (*Info, error)
 	Stop(ctx context.Context, force bool) error
-	Rm(ctx context.Context, force bool) error
+	Rm(ctx context.Context, force bool, rmVolume bool) error
 	Client(ctx context.Context) (*client.Client, error)
 	Features() map[Feature]bool
 	IsMobyDriver() bool

--- a/driver/kubernetes/driver.go
+++ b/driver/kubernetes/driver.go
@@ -143,7 +143,7 @@ func (d *Driver) Stop(ctx context.Context, force bool) error {
 	return nil
 }
 
-func (d *Driver) Rm(ctx context.Context, force bool) error {
+func (d *Driver) Rm(ctx context.Context, force bool, rmVolume bool) error {
 	if err := d.deploymentClient.Delete(ctx, d.deployment.Name, metav1.DeleteOptions{}); err != nil {
 		return errors.Wrapf(err, "error while calling deploymentClient.Delete for %q", d.deployment.Name)
 	}


### PR DESCRIPTION
Retain BuildKit state inside a named volume if the container is removed for the `docker-container` driver. `--volume` flag has also been added to the `rm` command to be able to force volume removal.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>