### PR TITLE
fix: should ignore nil client

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -197,6 +197,10 @@ func resolveDrivers(ctx context.Context, drivers []DriverInfo, auth Auth, opt ma
 
 	eg, ctx := errgroup.WithContext(ctx)
 	for i, c := range clients {
+		if c == nil {
+			continue
+		}
+
 		func(i int, c *client.Client) {
 			eg.Go(func() error {
 				clients[i].Build(ctx, client.SolveOpt{}, "buildx", func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {


### PR DESCRIPTION
maybe fix https://github.com/docker/buildx/issues/675

I have another issue

With multi-node builder, but single platform build `buildx build --platform=linux/amd64`, will cause the nil issue too