### PR TITLE
Allow booting builder after creation

### DIFF
--- a/docs/reference/buildx_create.md
+++ b/docs/reference/buildx_create.md
@@ -12,6 +12,7 @@ Create a new builder instance
 | Name | Description |
 | --- | --- |
 | [`--append`](#append) | Append a node to builder instead of changing it |
+| `--bootstrap` | Boot builder after creation |
 | `--builder string` | Override the configured builder instance |
 | [`--buildkitd-flags string`](#buildkitd-flags) | Flags for buildkitd daemon |
 | [`--config string`](#config) | BuildKit config file |


### PR DESCRIPTION
Fixes #189

Allow booting builder after creation with `docker buildx create --bootstrap ...`.

~Also adds `buildx start` command.~

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>