### PR TITLE
Bump to codecov/codecov-action v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
           CACHEDIR_FROM: /tmp/.buildx-cache/${{ env.CACHEKEY_BINARIES }}
       -
         name: Send to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           file: ./coverage/coverage.txt
 


### PR DESCRIPTION
https://github.com/codecov/codecov-action#%EF%B8%8F--deprecration-of-v1

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>