### PR TITLE
Add HCL `env` func

### DIFF
--- a/bake/hclparser/stdlib.go
+++ b/bake/hclparser/stdlib.go
@@ -1,12 +1,15 @@
 package hclparser
 
 import (
+	"os"
+
 	"github.com/hashicorp/go-cty-funcs/cidr"
 	"github.com/hashicorp/go-cty-funcs/crypto"
 	"github.com/hashicorp/go-cty-funcs/encoding"
 	"github.com/hashicorp/go-cty-funcs/uuid"
 	"github.com/hashicorp/hcl/v2/ext/tryfunc"
 	"github.com/hashicorp/hcl/v2/ext/typeexpr"
+	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
 	"github.com/zclconf/go-cty/cty/function/stdlib"
 )
@@ -38,6 +41,7 @@ var stdlibFunctions = map[string]function.Function{
 	"distinct":               stdlib.DistinctFunc,
 	"divide":                 stdlib.DivideFunc,
 	"element":                stdlib.ElementFunc,
+	"env":                    EnvFunc,
 	"equal":                  stdlib.EqualFunc,
 	"flatten":                stdlib.FlattenFunc,
 	"floor":                  stdlib.FloorFunc,
@@ -109,3 +113,18 @@ var stdlibFunctions = map[string]function.Function{
 	"values":                 stdlib.ValuesFunc,
 	"zipmap":                 stdlib.ZipmapFunc,
 }
+
+// EnvFunc is a function that retrieves the value of the environment
+// variable named by the key.
+var EnvFunc = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{
+			Name: "key",
+			Type: cty.String,
+		},
+	},
+	Type: function.StaticReturnType(cty.String),
+	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+		return cty.StringVal(os.Getenv(args[0].AsString())), nil
+	},
+})


### PR DESCRIPTION
Atm we have to define a variable block to be able to retrieve an environment variable in a subsequent function or target. This PR implements an HCL `env` func to be able to retrieve an environment variable without defining a variable block.

Before:

```hcl
variable "GITHUB_REPOSITORY" {
}

variable "GITHUB_REF" {
}

target "build" {
  args = {
    GITHUB_REPOSITORY = GITHUB_REPOSITORY
    GITHUB_REF = GITHUB_REF
  }
  dockerfile = "./Dockerfile"
  target = "build"
}
```

```console
$ GITHUB_REPOSITORY=crazy-max/test docker buildx bake --print build
```

```json
{
  "target": {
    "build": {
      "context": ".",
      "dockerfile": "./Dockerfile",
      "args": {
        "GITHUB_REF": "",
        "GITHUB_REPOSITORY": "crazy-max/test",
      },
      "target": "build"
    }
  }
}
```

After:

```hcl
target "build" {
  args = {
    GITHUB_REPOSITORY = env("GITHUB_REPOSITORY")
    GITHUB_REF = env("GITHUB_REF")
  }
  dockerfile = "./Dockerfile"
  target = "build"
}
```

```console
$ GITHUB_REPOSITORY=crazy-max/test docker buildx bake --print build
```

```json
{
  "target": {
    "build": {
      "context": ".",
      "dockerfile": "./Dockerfile",
      "args": {
        "GITHUB_REF": "",
        "GITHUB_REPOSITORY": "crazy-max/test",
      },
      "target": "build"
    }
  }
}
```

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>