### PR TITLE
Implement `--quiet` support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,10 @@ test:
 
 validate-vendor:
 	./hack/validate-vendor
-	
+
 validate-docs:
 	./hack/validate-docs
-	
+
 validate-all: lint test validate-vendor validate-docs
 
 vendor:

--- a/build/build.go
+++ b/build/build.go
@@ -54,7 +54,6 @@ type Options struct {
 	BuildArgs   map[string]string
 	Pull        bool
 	ImageIDFile string
-	Quiet       bool
 	ExtraHosts  []string
 	NetworkMode string
 
@@ -685,9 +684,6 @@ func Build(ctx context.Context, drivers []DriverInfo, opt map[string]Options, do
 				respMu.Unlock()
 				if len(res) == 1 {
 					digest := res[0].ExporterResponse["containerimage.digest"]
-					if opt.Quiet {
-						fmt.Println(digest)
-					}
 					if opt.ImageIDFile != "" {
 						return ioutil.WriteFile(opt.ImageIDFile, []byte(digest), 0644)
 					}
@@ -717,9 +713,6 @@ func Build(ctx context.Context, drivers []DriverInfo, opt map[string]Options, do
 							dt, desc, err := itpull.Combine(ctx, names[0], descs)
 							if err != nil {
 								return err
-							}
-							if opt.Quiet {
-								fmt.Println(desc.Digest)
 							}
 							if opt.ImageIDFile != "" {
 								return ioutil.WriteFile(opt.ImageIDFile, []byte(desc.Digest), 0644)

--- a/build/build.go
+++ b/build/build.go
@@ -54,6 +54,7 @@ type Options struct {
 	BuildArgs   map[string]string
 	Pull        bool
 	ImageIDFile string
+	Quiet       bool
 	ExtraHosts  []string
 	NetworkMode string
 
@@ -683,8 +684,12 @@ func Build(ctx context.Context, drivers []DriverInfo, opt map[string]Options, do
 				resp[k] = res[0]
 				respMu.Unlock()
 				if len(res) == 1 {
+					digest := res[0].ExporterResponse["containerimage.digest"]
+					if opt.Quiet {
+						fmt.Println(digest)
+					}
 					if opt.ImageIDFile != "" {
-						return ioutil.WriteFile(opt.ImageIDFile, []byte(res[0].ExporterResponse["containerimage.digest"]), 0644)
+						return ioutil.WriteFile(opt.ImageIDFile, []byte(digest), 0644)
 					}
 					return nil
 				}
@@ -712,6 +717,9 @@ func Build(ctx context.Context, drivers []DriverInfo, opt map[string]Options, do
 							dt, desc, err := itpull.Combine(ctx, names[0], descs)
 							if err != nil {
 								return err
+							}
+							if opt.Quiet {
+								fmt.Println(desc.Digest)
 							}
 							if opt.ImageIDFile != "" {
 								return ioutil.WriteFile(opt.ImageIDFile, []byte(desc.Digest), 0644)

--- a/docs/reference/buildx_build.md
+++ b/docs/reference/buildx_build.md
@@ -33,6 +33,7 @@ Start a build
 | [`--progress string`](#progress) | Set type of progress output (auto, plain, tty). Use plain to show container output |
 | `--pull` | Always attempt to pull a newer version of the image |
 | [`--push`](#push) | Shorthand for --output=type=registry |
+| `-q`, `--quiet` | Suppress the build output and print image ID on success |
 | `--secret stringArray` | Secret file to expose to the build: id=mysecret,src=/local/secret |
 | `--ssh stringArray` | SSH agent socket or keys to expose to the build (format: default|<id>[=<socket>|<key>[,<key>]]) |
 | [`-t`](https://docs.docker.com/engine/reference/commandline/build/#tag-an-image--t), [`--tag stringArray`](https://docs.docker.com/engine/reference/commandline/build/#tag-an-image--t) | Name and optionally a tag in the 'name:tag' format |


### PR DESCRIPTION
See #621.  I needed this in order to script logic of the following structure (where I didn't want to use a temporary file on disk for `--iidfile`):

```
$ image=$(docker build --quiet .)
$ docker run $image
```

This worked _unless_ someone had installed `buildx` in place of `docker build` (as I had 😛 ) in which case the `image` was an empty string and the `docker run` failed catastrophically.