### PR TITLE
use long-running context for client initialization

### DIFF
--- a/bake/remote.go
+++ b/bake/remote.go
@@ -43,7 +43,7 @@ func ReadRemoteFiles(ctx context.Context, dis []build.DriverInfo, url string, na
 		return nil, nil, nil
 	}
 
-	c, err := driver.Boot(ctx, di.Driver, pw)
+	c, err := driver.Boot(ctx, ctx, di.Driver, pw)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/build/build.go
+++ b/build/build.go
@@ -143,12 +143,13 @@ func allIndexes(l int) []int {
 func ensureBooted(ctx context.Context, drivers []DriverInfo, idxs []int, pw progress.Writer) ([]*client.Client, error) {
 	clients := make([]*client.Client, len(drivers))
 
+	baseCtx := ctx
 	eg, ctx := errgroup.WithContext(ctx)
 
 	for _, i := range idxs {
 		func(i int) {
 			eg.Go(func() error {
-				c, err := driver.Boot(ctx, drivers[i].Driver, pw)
+				c, err := driver.Boot(ctx, baseCtx, drivers[i].Driver, pw)
 				if err != nil {
 					return err
 				}

--- a/build/url.go
+++ b/build/url.go
@@ -14,7 +14,7 @@ import (
 )
 
 func createTempDockerfileFromURL(ctx context.Context, d driver.Driver, url string, pw progress.Writer) (string, error) {
-	c, err := driver.Boot(ctx, d, pw)
+	c, err := driver.Boot(ctx, ctx, d, pw)
 	if err != nil {
 		return "", err
 	}

--- a/commands/util.go
+++ b/commands/util.go
@@ -507,12 +507,13 @@ func boot(ctx context.Context, ngi *nginfo) (bool, error) {
 
 	printer := progress.NewPrinter(context.TODO(), os.Stderr, "auto")
 
+	baseCtx := ctx
 	eg, _ := errgroup.WithContext(ctx)
 	for _, idx := range toBoot {
 		func(idx int) {
 			eg.Go(func() error {
 				pw := progress.WithPrefix(printer, ngi.ng.Nodes[idx].Name, len(toBoot) > 1)
-				_, err := driver.Boot(ctx, ngi.drivers[idx].di.Driver, pw)
+				_, err := driver.Boot(ctx, baseCtx, ngi.drivers[idx].di.Driver, pw)
 				if err != nil {
 					ngi.drivers[idx].err = err
 				}

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -61,7 +61,7 @@ type Driver interface {
 	Config() InitConfig
 }
 
-func Boot(ctx context.Context, d Driver, pw progress.Writer) (*client.Client, error) {
+func Boot(ctx, clientContext context.Context, d Driver, pw progress.Writer) (*client.Client, error) {
 	try := 0
 	for {
 		info, err := d.Info(ctx)
@@ -78,7 +78,7 @@ func Boot(ctx context.Context, d Driver, pw progress.Writer) (*client.Client, er
 			}
 		}
 
-		c, err := d.Client(ctx)
+		c, err := d.Client(clientContext)
 		if err != nil {
 			if errors.Cause(err) == ErrNotRunning && try <= 2 {
 				continue


### PR DESCRIPTION
fixes #737

Context passed to `NewClient` should not be canceled after `NewClient` returns but client is still used. Another way would be to create a new context internally and block the `Done` channel but I think passing separate context is clearer.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>