### PR TITLE
Built-in variable `BAKE_LOCAL_PLATFORM`

### DIFF
--- a/commands/bake.go
+++ b/commands/bake.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/containerd/containerd/platforms"
 	"github.com/docker/buildx/bake"
 	"github.com/docker/buildx/build"
 	"github.com/docker/buildx/util/progress"
@@ -106,7 +107,10 @@ func runBake(dockerCli command.Cli, targets []string, in bakeOptions) (err error
 	}
 
 	t, g, err := bake.ReadTargets(ctx, files, targets, overrides, map[string]string{
-		"BAKE_CMD_CONTEXT": cmdContext,
+		// Don't forget to update documentation if you add a new
+		// built-in variable: docs/reference/buildx_bake.md#built-in-variables
+		"BAKE_CMD_CONTEXT":    cmdContext,
+		"BAKE_LOCAL_PLATFORM": platforms.DefaultString(),
 	})
 	if err != nil {
 		return err

--- a/docs/reference/buildx_bake.md
+++ b/docs/reference/buildx_bake.md
@@ -861,3 +861,10 @@ Complete list of valid fields for `x-bake`:
 
 `tags`, `cache-from`, `cache-to`, `secret`, `ssh`, `platforms`, `output`,
 `pull`, `no-cache`
+
+### Built-in variables
+
+* `BAKE_CMD_CONTEXT` can be used to access the main `context` for bake command
+from a bake file that has been [imported remotely](#file).
+* `BAKE_LOCAL_PLATFORM` returns the current platform's default platform
+specification (e.g. `linux/amd64`).

--- a/docs/reference/docker_buildx_bake.yaml
+++ b/docs/reference/docker_buildx_bake.yaml
@@ -931,6 +931,13 @@ examples: |-
 
   `tags`, `cache-from`, `cache-to`, `secret`, `ssh`, `platforms`, `output`,
   `pull`, `no-cache`
+
+  ### Built-in variables
+
+  * `BAKE_CMD_CONTEXT` can be used to access the main `context` for bake command
+  from a bake file that has been [imported remotely](#file).
+  * `BAKE_LOCAL_PLATFORM` returns the current platform's default platform
+  specification (e.g. `linux/amd64`).
 deprecated: false
 experimental: false
 experimentalcli: false


### PR DESCRIPTION
Add built-in variable `BAKE_LOCAL_PLATFORM` that returns the current platform's default platform specification (e.g. `linux/amd64`).

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>