### PR TITLE
[v0.6] container-driver: fix volume destination for cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,11 +5,13 @@ on:
   push:
     branches:
       - 'master'
+      - 'v[0-9]*'
     tags:
       - 'v*'
   pull_request:
     branches:
       - 'master'
+      - 'v[0-9]*'
 
 env:
   REPO_SLUG: "docker/buildx-bin"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,11 +5,13 @@ on:
   push:
     branches:
       - 'master'
+      - 'v[0-9]*'
     tags:
       - 'v*'
   pull_request:
     branches:
       - 'master'
+      - 'v[0-9]*'
 
 env:
   REPO_SLUG_ORIGIN: "moby/buildkit:master"

--- a/driver/docker-container/driver.go
+++ b/driver/docker-container/driver.go
@@ -22,12 +22,19 @@ import (
 	dockerclient "github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/moby/buildkit/client"
-	"github.com/moby/buildkit/util/appdefaults"
 	"github.com/moby/buildkit/util/tracing/detect"
 	"github.com/pkg/errors"
 )
 
-const volumeStateSuffix = "_state"
+const (
+	volumeStateSuffix = "_state"
+
+	// containerStateDir is the location where buildkitd inside the container
+	// stores its state. The container driver creates a Linux container, so
+	// this should match the location for Linux, as defined in:
+	// https://github.com/moby/buildkit/blob/v0.9.0/util/appdefaults/appdefaults_unix.go#L11-L15
+	containerBuildKitRootDir = "/var/lib/buildkit"
+)
 
 type Driver struct {
 	driver.InitConfig
@@ -111,7 +118,7 @@ func (d *Driver) create(ctx context.Context, l progress.SubLogger) error {
 				{
 					Type:   mount.TypeVolume,
 					Source: d.Name + volumeStateSuffix,
-					Target: appdefaults.Root,
+					Target: containerBuildKitRootDir,
 				},
 			},
 		}


### PR DESCRIPTION
pick #751

The container-driver creates a Linux container (as there currently isn't a
Windows version of buildkitd). However, the defaults are platform specific.

Buildx was using the defaults from the buildkit `util/appdefault' package,
which resulted in Buildx running on a Windows client to create a Linux
container that used the Windows location, which causes it to fail:

    invalid mount config for type "volume": invalid mount path: 'C:/ProgramData/buildkitd/.buildstate' mount path must be absolute

This patch hard-codes the destination to the default Linux path.

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
(cherry picked from commit 93867d02f0a989f084e54d7133371f583a4d3c5e)