### PR TITLE
Mod outdated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,4 +53,7 @@ docs:
 authors:
 	$(BUILDX_CMD) bake update-authors
 
+mod-outdated:
+	$(BUILDX_CMD) bake mod-outdated
+
 .PHONY: shell binaries binaries-cross install release validate-all lint validate-vendor validate-docs validate-authors vendor docs authors

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -76,6 +76,13 @@ target "update-authors" {
   output = ["."]
 }
 
+target "mod-outdated" {
+  inherits = ["_common"]
+  dockerfile = "./hack/dockerfiles/vendor.Dockerfile"
+  target = "outdated"
+  output = ["type=cacheonly"]
+}
+
 target "test" {
   inherits = ["_common"]
   target = "test-coverage"


### PR DESCRIPTION
Just a fancy tool to be able to check updates for direct dependencies:

```shell
$ make mod-outdated
...
#12 21.34 +------------------------------------+-----------------------------------------------------+------------------------------------+--------+------------------+
#12 21.34 |               MODULE               |                       VERSION                       |            NEW VERSION             | DIRECT | VALID TIMESTAMPS |
#12 21.34 +------------------------------------+-----------------------------------------------------+------------------------------------+--------+------------------+
#12 21.34 | github.com/compose-spec/compose-go | v0.0.0-20210729195839-de56f4f0cb3c                  | v0.0.0-20210901090333-feb401cda7f7 | true   | true             |
#12 21.34 | github.com/containerd/console      | v1.0.2                                              | v1.0.3                             | true   | true             |
#12 21.34 | github.com/docker/cli              | v20.10.3-0.20210702143511-f782d1355eff+incompatible | v20.10.8+incompatible              | true   | true             |
#12 21.34 | github.com/docker/docker           | v20.10.3-0.20210609100121-ef4d47340142+incompatible | v20.10.8+incompatible              | true   | true             |
#12 21.34 | github.com/gofrs/flock             | v0.7.3                                              | v0.8.1                             | true   | true             |
#12 21.34 | github.com/hashicorp/hcl/v2        | v2.8.2                                              | v2.10.1                            | true   | true             |
#12 21.34 | github.com/moby/buildkit           | v0.8.2-0.20210702160134-1a7543a10527                | v0.9.0                             | true   | true             |
#12 21.34 | github.com/serialx/hashring        | v0.0.0-20190422032157-8b2912629002                  | v0.0.0-20200727003509-22c0c7ab6b1b | true   | true             |
#12 21.34 | github.com/zclconf/go-cty          | v1.7.1                                              | v1.9.1                             | true   | true             |
#12 21.34 | go.opentelemetry.io/otel           | v1.0.0-RC1                                          | v1.0.0-RC3                         | true   | true             |
#12 21.34 | go.opentelemetry.io/otel/trace     | v1.0.0-RC1                                          | v1.0.0-RC3                         | true   | true             |
#12 21.34 | k8s.io/api                         | v0.20.6                                             | v0.22.1                            | true   | true             |
#12 21.34 | k8s.io/apimachinery                | v0.20.6                                             | v0.22.1                            | true   | true             |
#12 21.34 | k8s.io/client-go                   | v0.20.6                                             | v0.22.1                            | true   | true             |
#12 21.34 +------------------------------------+-----------------------------------------------------+------------------------------------+--------+------------------+
#12 DONE 21.4s
```

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>