### PR TITLE
bake: fix using push override with output definition

### DIFF
--- a/bake/bake_test.go
+++ b/bake/bake_test.go
@@ -179,6 +179,51 @@ target "webapp" {
 	})
 }
 
+func TestPushOverride(t *testing.T) {
+	t.Parallel()
+
+	fp := File{
+		Name: "docker-bake.hc",
+		Data: []byte(
+			`target "app" {
+				output = ["type=image,compression=zstd"]
+			}`),
+	}
+	ctx := context.TODO()
+	m, _, err := ReadTargets(ctx, []File{fp}, []string{"app"}, []string{"*.push=true"}, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(m["app"].Outputs))
+	require.Equal(t, "type=image,compression=zstd,push=true", m["app"].Outputs[0])
+
+	fp = File{
+		Name: "docker-bake.hc",
+		Data: []byte(
+			`target "app" {
+				output = ["type=image,compression=zstd"]
+			}`),
+	}
+	ctx = context.TODO()
+	m, _, err = ReadTargets(ctx, []File{fp}, []string{"app"}, []string{"*.push=false"}, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(m["app"].Outputs))
+	require.Equal(t, "type=image,compression=zstd,push=false", m["app"].Outputs[0])
+
+	fp = File{
+		Name: "docker-bake.hc",
+		Data: []byte(
+			`target "app" {
+			}`),
+	}
+	ctx = context.TODO()
+	m, _, err = ReadTargets(ctx, []File{fp}, []string{"app"}, []string{"*.push=true"}, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(m["app"].Outputs))
+	require.Equal(t, "type=image,push=true", m["app"].Outputs[0])
+}
+
 func TestReadTargetsCompose(t *testing.T) {
 	t.Parallel()
 
@@ -228,7 +273,6 @@ services:
 }
 
 func TestHCLCwdPrefix(t *testing.T) {
-
 	fp := File{
 		Name: "docker-bake.hc",
 		Data: []byte(

--- a/commands/bake.go
+++ b/commands/bake.go
@@ -64,7 +64,7 @@ func runBake(dockerCli command.Cli, targets []string, in bakeOptions) (err error
 		if in.exportLoad {
 			return errors.Errorf("push and load may not be set together at the moment")
 		}
-		overrides = append(overrides, "*.output=type=registry")
+		overrides = append(overrides, "*.push=true")
 	} else if in.exportLoad {
 		overrides = append(overrides, "*.output=type=docker")
 	}

--- a/util/buildflags/output.go
+++ b/util/buildflags/output.go
@@ -100,7 +100,9 @@ func ParseOutputs(inp []string) ([]client.ExportEntry, error) {
 			delete(out.Attrs, "dest")
 		case "registry":
 			out.Type = client.ExporterImage
-			out.Attrs["push"] = "true"
+			if _, ok := out.Attrs["push"]; !ok {
+				out.Attrs["push"] = "true"
+			}
 		}
 
 		outs = append(outs, out)


### PR DESCRIPTION
Currently, using `bake --push` will replace the target definition with `type=registry`. This means that if the definition defined an output then it gets cleared and completely overwritten.

I think the basis of this refactor can also be used to implement additional operators like `--set key+=value` in the future.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>