### PR TITLE
BUILDKIT_SANDBOX_HOSTNAME build-arg

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -411,6 +411,10 @@ func toSolveOpt(ctx context.Context, d driver.Driver, multiDriver bool, opt Opti
 		so.FrontendAttrs["multi-platform"] = "true"
 	}
 
+	if v, ok := opt.BuildArgs["BUILDKIT_SANDBOX_HOSTNAME"]; ok {
+		so.FrontendAttrs["hostname"] = v
+	}
+
 	switch len(opt.Exports) {
 	case 1:
 		// valid

--- a/docs/reference/buildx_build.md
+++ b/docs/reference/buildx_build.md
@@ -317,3 +317,11 @@ with `--allow-insecure-entitlement` (see [`create --buildkitd-flags`](buildx_cre
 $ docker buildx create --use --name insecure-builder --buildkitd-flags '--allow-insecure-entitlement security.insecure'
 $ docker buildx build --allow security.insecure .
 ```
+
+### Built-in build args
+
+Special build-time variables (`--build-arg`) for BuildKit are available:
+
+* `BUILDKIT_INLINE_CACHE=<bool>` [exports inline cache metadata](#cache-to) to image configuration or not
+* `BUILDKIT_MULTI_PLATFORM=<bool>` opts into determnistic output regardless of multi-platform output or not
+* `BUILDKIT_SANDBOX_HOSTNAME=<string>` sets the hostname at build-time (default `buildkitsandbox`) 


### PR DESCRIPTION
Fixes #474 

```dockerfile
FROM alpine
RUN echo "HOSTNAME envvar: $HOSTNAME" && \
  echo "hostname: $(hostname)" && \
  echo "kernel: $(cat /proc/sys/kernel/hostname)"  && \
  echo "/etc/hosts: $(cat /etc/hosts)"
```

```shell
$ docker buildx build --build-arg "BUILDKIT_SANDBOX_HOSTNAME=myhostname" .
...
#6 [2/2] RUN echo "HOSTNAME envvar: $HOSTNAME" &&   echo "hostname: $(hostname)" &&   echo "kernel: $(cat /proc/sys/kernel/hostname)"  &&   echo "/etc/hosts: $(cat /etc/hosts)"
#6 0.166 HOSTNAME envvar: myhostname
#6 0.166 hostname: myhostname
#6 0.167 kernel: myhostname
#6 0.168 /etc/hosts: 127.0.0.1  localhost myhostname
#6 0.168 ::1    localhost ip6-localhost ip6-loopback
#6 DONE 0.2s
```

@tonistiigi Do we need to add this into the Dockerfile frontend as well? (`"build-arg:BUILDKIT_SANDBOX_HOSTNAME"`)

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>