### PR TITLE
docker-container: place build containers in a separate cgroup

### DIFF
--- a/docs/reference/buildx_create.md
+++ b/docs/reference/buildx_create.md
@@ -130,7 +130,7 @@ Passes additional driver-specific options. Details for each driver:
 - `docker-container`
     - `image=IMAGE` - Sets the container image to be used for running buildkit.
     - `network=NETMODE` - Sets the network mode for running the buildkit container.
-    - `cgroup-parent=CGROUP` - Sets the cgroup parent of the buildkit container if docker is using the "cgroupfs" driver.
+    - `cgroup-parent=CGROUP` - Sets the cgroup parent of the buildkit container if docker is using the "cgroupfs" driver. Defaults to `/docker/buildx`.
     - Example:
 
       ```console

--- a/docs/reference/buildx_create.md
+++ b/docs/reference/buildx_create.md
@@ -130,6 +130,7 @@ Passes additional driver-specific options. Details for each driver:
 - `docker-container`
     - `image=IMAGE` - Sets the container image to be used for running buildkit.
     - `network=NETMODE` - Sets the network mode for running the buildkit container.
+    - `cgroup-parent=CGROUP` - Sets the cgroup parent of the buildkit container if docker is using the "cgroupfs" driver.
     - Example:
 
       ```console

--- a/driver/docker-container/driver.go
+++ b/driver/docker-container/driver.go
@@ -38,10 +38,11 @@ const (
 
 type Driver struct {
 	driver.InitConfig
-	factory driver.Factory
-	netMode string
-	image   string
-	env     []string
+	factory      driver.Factory
+	netMode      string
+	image        string
+	cgroupParent string
+	env          []string
 }
 
 func (d *Driver) IsMobyDriver() bool {
@@ -124,6 +125,11 @@ func (d *Driver) create(ctx context.Context, l progress.SubLogger) error {
 		}
 		if d.netMode != "" {
 			hc.NetworkMode = container.NetworkMode(d.netMode)
+		}
+		if info, err := d.DockerAPI.Info(ctx); err == nil && info.CgroupDriver == "cgroupfs" {
+			if d.cgroupParent != "" {
+				hc.CgroupParent = d.cgroupParent
+			}
 		}
 		_, err := d.DockerAPI.ContainerCreate(ctx, cfg, hc, &network.NetworkingConfig{}, nil, d.Name)
 		if err != nil {

--- a/driver/docker-container/driver.go
+++ b/driver/docker-container/driver.go
@@ -127,6 +127,9 @@ func (d *Driver) create(ctx context.Context, l progress.SubLogger) error {
 			hc.NetworkMode = container.NetworkMode(d.netMode)
 		}
 		if info, err := d.DockerAPI.Info(ctx); err == nil && info.CgroupDriver == "cgroupfs" {
+			// Place all buildkit containers inside this cgroup by default so limits can be attached
+			// to all build activity on the host.
+			hc.CgroupParent = "/docker/buildx"
 			if d.cgroupParent != "" {
 				hc.CgroupParent = d.cgroupParent
 			}

--- a/driver/docker-container/factory.go
+++ b/driver/docker-container/factory.go
@@ -49,6 +49,8 @@ func (f *factory) New(ctx context.Context, cfg driver.InitConfig) (driver.Driver
 			}
 		case k == "image":
 			d.image = v
+		case k == "cgroup-parent":
+			d.cgroupParent = v
 		case strings.HasPrefix(k, "env."):
 			envName := strings.TrimPrefix(k, "env.")
 			if envName == "" {


### PR DESCRIPTION
Previously build containers created by the `docker-container` driver were in the default parent cgroup, along with non-build containers. This made it hard to apply resource limits to all the builds on a machine.

This PR adds a `--driver-opt cgroup-parent=CGROUP` to allow the cgroup to be customised. A default value of `/docker/buildx` is  set.
