### PR TITLE
docker: dial session directly with http hijack

### DIFF
--- a/driver/docker/driver.go
+++ b/driver/docker/driver.go
@@ -40,6 +40,8 @@ func (d *Driver) Rm(ctx context.Context, force bool, rmVolume bool) error {
 func (d *Driver) Client(ctx context.Context) (*client.Client, error) {
 	return client.New(ctx, "", client.WithContextDialer(func(context.Context, string) (net.Conn, error) {
 		return d.DockerAPI.DialHijack(ctx, "/grpc", "h2c", nil)
+	}), client.WithSessionDialer(func(ctx context.Context, proto string, meta map[string][]string) (net.Conn, error) {
+		return d.DockerAPI.DialHijack(ctx, "/session", proto, meta)
 	}))
 }
 


### PR DESCRIPTION
This enables better performance for session transfers for docker driver by avoiding double grpc. Ensures that https://github.com/docker/cli/pull/3314 does not have lower performance on the default path.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>