### PR TITLE
imagetools: fix pushing same image with multiple names

### DIFF
--- a/util/imagetools/create.go
+++ b/util/imagetools/create.go
@@ -150,7 +150,7 @@ func (r *Resolver) Combine(ctx context.Context, in string, descs []ocispec.Descr
 func (r *Resolver) Push(ctx context.Context, ref reference.Named, desc ocispec.Descriptor, dt []byte) error {
 	ref = reference.TagNameOnly(ref)
 
-	p, err := r.r.Pusher(ctx, ref.String())
+	p, err := r.resolver().Pusher(ctx, ref.String())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
fixes #799

containerd pusher can’t handle this case atm so we
need to make sure we always create a new resolver
for each name.

This only affects multi-node builds as pushes inside BuildKit use their own resolver pool that protects against this.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>