### PR TITLE
build: set local sharedkey per project basename

### DIFF
--- a/commands/bake.go
+++ b/commands/bake.go
@@ -9,6 +9,7 @@ import (
 	"github.com/containerd/containerd/platforms"
 	"github.com/docker/buildx/bake"
 	"github.com/docker/buildx/build"
+	"github.com/docker/buildx/util/confutil"
 	"github.com/docker/buildx/util/progress"
 	"github.com/docker/buildx/util/tracing"
 	"github.com/docker/cli/cli/command"
@@ -155,7 +156,7 @@ func runBake(dockerCli command.Cli, targets []string, in bakeOptions) (err error
 		return nil
 	}
 
-	resp, err := build.Build(ctx, dis, bo, dockerAPI(dockerCli), dockerCli.ConfigFile(), printer)
+	resp, err := build.Build(ctx, dis, bo, dockerAPI(dockerCli), dockerCli.ConfigFile(), confutil.ConfigDir(dockerCli), printer)
 	if err != nil {
 		return err
 	}

--- a/commands/build.go
+++ b/commands/build.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/docker/buildx/build"
 	"github.com/docker/buildx/util/buildflags"
+	"github.com/docker/buildx/util/confutil"
 	"github.com/docker/buildx/util/platformutil"
 	"github.com/docker/buildx/util/progress"
 	"github.com/docker/buildx/util/tracing"
@@ -224,7 +225,7 @@ func buildTargets(ctx context.Context, dockerCli command.Cli, opts map[string]bu
 
 	printer := progress.NewPrinter(ctx2, os.Stderr, progressMode)
 
-	resp, err := build.Build(ctx, dis, opts, dockerAPI(dockerCli), dockerCli.ConfigFile(), printer)
+	resp, err := build.Build(ctx, dis, opts, dockerAPI(dockerCli), dockerCli.ConfigFile(), confutil.ConfigDir(dockerCli), printer)
 	err1 := printer.Wait()
 	if err == nil {
 		err = err1

--- a/commands/util.go
+++ b/commands/util.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"net/url"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/docker/buildx/build"
 	"github.com/docker/buildx/driver"
 	"github.com/docker/buildx/store"
+	"github.com/docker/buildx/util/confutil"
 	"github.com/docker/buildx/util/platformutil"
 	"github.com/docker/buildx/util/progress"
 	"github.com/docker/cli/cli/command"
@@ -27,25 +27,11 @@ import (
 
 // getStore returns current builder instance store
 func getStore(dockerCli command.Cli) (*store.Txn, func(), error) {
-	s, err := store.New(getConfigStorePath(dockerCli))
+	s, err := store.New(confutil.ConfigDir(dockerCli))
 	if err != nil {
 		return nil, nil, err
 	}
 	return s.Txn()
-}
-
-// getConfigStorePath will look for correct configuration store path;
-// if `$BUILDX_CONFIG` is set - use it, otherwise use parent directory
-// of Docker config file (i.e. `${DOCKER_CONFIG}/buildx`)
-func getConfigStorePath(dockerCli command.Cli) string {
-	if buildxConfig := os.Getenv("BUILDX_CONFIG"); buildxConfig != "" {
-		logrus.Debugf("using config store %q based in \"$BUILDX_CONFIG\" environment variable", buildxConfig)
-		return buildxConfig
-	}
-
-	buildxConfig := filepath.Join(filepath.Dir(dockerCli.ConfigFile().Filename), "buildx")
-	logrus.Debugf("using default config store %q", buildxConfig)
-	return buildxConfig
 }
 
 // getCurrentEndpoint returns the current default endpoint value

--- a/util/confutil/config.go
+++ b/util/confutil/config.go
@@ -2,10 +2,27 @@ package confutil
 
 import (
 	"os"
+	"path/filepath"
 
+	"github.com/docker/cli/cli/command"
 	"github.com/pelletier/go-toml"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
+
+// ConfigDir will look for correct configuration store path;
+// if `$BUILDX_CONFIG` is set - use it, otherwise use parent directory
+// of Docker config file (i.e. `${DOCKER_CONFIG}/buildx`)
+func ConfigDir(dockerCli command.Cli) string {
+	if buildxConfig := os.Getenv("BUILDX_CONFIG"); buildxConfig != "" {
+		logrus.Debugf("using config store %q based in \"$BUILDX_CONFIG\" environment variable", buildxConfig)
+		return buildxConfig
+	}
+
+	buildxConfig := filepath.Join(filepath.Dir(dockerCli.ConfigFile().Filename), "buildx")
+	logrus.Debugf("using default config store %q", buildxConfig)
+	return buildxConfig
+}
 
 // loadConfigTree loads BuildKit config toml tree
 func loadConfigTree(fp string) (*toml.Tree, error) {


### PR DESCRIPTION
This allows separating building different projects so they don't rewrite each other's local source destination for better performance.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>