### PR TITLE
cli: fix builder persistent flag

### DIFF
--- a/commands/create.go
+++ b/commands/create.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/buildx/driver"
 	"github.com/docker/buildx/store"
 	"github.com/docker/buildx/store/storeutil"
+	"github.com/docker/buildx/util/cobrautil"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/google/shlex"
@@ -238,7 +239,8 @@ func createCmd(dockerCli command.Cli) *cobra.Command {
 	flags.BoolVar(&options.actionLeave, "leave", false, "Remove a node from builder instead of changing it")
 	flags.BoolVar(&options.use, "use", false, "Set the current builder instance")
 
-	_ = flags
+	// hide builder persistent flag for this command
+	cobrautil.HideInheritedFlags(cmd, "builder")
 
 	return cmd
 }

--- a/commands/imagetools/create.go
+++ b/commands/imagetools/create.go
@@ -261,7 +261,6 @@ func createCmd(dockerCli command.Cli, opts RootOptions) *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-
 	flags.StringArrayVarP(&options.files, "file", "f", []string{}, "Read source descriptor from file")
 	flags.StringArrayVarP(&options.tags, "tag", "t", []string{}, "Set reference for new image")
 	flags.BoolVar(&options.dryrun, "dry-run", false, "Show final image instead of pushing")

--- a/commands/imagetools/inspect.go
+++ b/commands/imagetools/inspect.go
@@ -85,7 +85,6 @@ func inspectCmd(dockerCli command.Cli, rootOpts RootOptions) *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-
 	flags.BoolVar(&options.raw, "raw", false, "Show original JSON manifest")
 
 	return cmd

--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -132,10 +132,7 @@ func inspectCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-
 	flags.BoolVar(&options.bootstrap, "bootstrap", false, "Ensure builder has booted before inspecting")
-
-	_ = flags
 
 	return cmd
 }

--- a/commands/install.go
+++ b/commands/install.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"os"
 
+	"github.com/docker/buildx/util/cobrautil"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/config"
@@ -47,6 +48,9 @@ func installCmd(dockerCli command.Cli) *cobra.Command {
 		},
 		Hidden: true,
 	}
+
+	// hide builder persistent flag for this command
+	cobrautil.HideInheritedFlags(cmd, "builder")
 
 	return cmd
 }

--- a/commands/ls.go
+++ b/commands/ls.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/docker/buildx/store"
 	"github.com/docker/buildx/store/storeutil"
+	"github.com/docker/buildx/util/cobrautil"
 	"github.com/docker/buildx/util/platformutil"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
@@ -147,6 +148,9 @@ func lsCmd(dockerCli command.Cli) *cobra.Command {
 			return runLs(dockerCli, options)
 		},
 	}
+
+	// hide builder persistent flag for this command
+	cobrautil.HideInheritedFlags(cmd, "builder")
 
 	return cmd
 }

--- a/commands/stop.go
+++ b/commands/stop.go
@@ -62,12 +62,6 @@ func stopCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 		},
 	}
 
-	flags := cmd.Flags()
-
-	// flags.StringArrayVarP(&options.outputs, "output", "o", []string{}, "Output destination (format: type=local,dest=path)")
-
-	_ = flags
-
 	return cmd
 }
 

--- a/commands/uninstall.go
+++ b/commands/uninstall.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"os"
 
+	"github.com/docker/buildx/util/cobrautil"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/config"
@@ -53,6 +54,9 @@ func uninstallCmd(dockerCli command.Cli) *cobra.Command {
 		},
 		Hidden: true,
 	}
+
+	// hide builder persistent flag for this command
+	cobrautil.HideInheritedFlags(cmd, "builder")
 
 	return cmd
 }

--- a/commands/use.go
+++ b/commands/use.go
@@ -80,11 +80,8 @@ func useCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-
 	flags.BoolVar(&options.isGlobal, "global", false, "Builder persists context changes")
 	flags.BoolVar(&options.isDefault, "default", false, "Set builder as default for current context")
-
-	_ = flags
 
 	return cmd
 }

--- a/commands/version.go
+++ b/commands/version.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 
+	"github.com/docker/buildx/util/cobrautil"
 	"github.com/docker/buildx/version"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
@@ -23,5 +24,9 @@ func versionCmd(dockerCli command.Cli) *cobra.Command {
 			return runVersion(dockerCli)
 		},
 	}
+
+	// hide builder persistent flag for this command
+	cobrautil.HideInheritedFlags(cmd, "builder")
+
 	return cmd
 }

--- a/docs/generate.go
+++ b/docs/generate.go
@@ -3,7 +3,6 @@ package main
 import (
 	"log"
 	"os"
-	"path/filepath"
 
 	"github.com/docker/buildx/commands"
 	clidocstool "github.com/docker/cli-docs-tool"
@@ -40,27 +39,28 @@ func gen(opts *options) error {
 	}
 
 	cmd.AddCommand(commands.NewRootCmd("buildx", true, dockerCLI))
-	clidocstool.DisableFlagsInUseLine(cmd)
 
-	cwd, _ := os.Getwd()
-	source := filepath.Join(cwd, opts.source)
-
-	if err = os.MkdirAll(source, 0755); err != nil {
+	c, err := clidocstool.New(clidocstool.Options{
+		Root:      cmd,
+		SourceDir: opts.source,
+		Plugin:    true,
+	})
+	if err != nil {
 		return err
 	}
 
 	for _, format := range opts.formats {
 		switch format {
 		case "md":
-			if err = clidocstool.GenMarkdownTree(cmd, source); err != nil {
+			if err = c.GenMarkdownTree(cmd); err != nil {
 				return err
 			}
 		case "yaml":
-			if err = clidocstool.GenYamlTree(cmd, source); err != nil {
+			if err = c.GenYamlTree(cmd); err != nil {
 				return err
 			}
 		default:
-			return errors.Errorf("unknwown doc format %q", format)
+			return errors.Errorf("unknown format %q", format)
 		}
 	}
 

--- a/docs/reference/buildx.md
+++ b/docs/reference/buildx.md
@@ -27,5 +27,17 @@ Extended build capabilities with BuildKit
 | [`version`](buildx_version.md) | Show buildx version information |
 
 
+### Options
+
+| Name | Description |
+| --- | --- |
+| [`--builder string`](#builder) | Override the configured builder instance |
+
 
 <!---MARKER_GEN_END-->
+
+## Examples
+
+### <a name="builder"></a> Override the configured builder instance (--builder)
+
+You can also use the `BUILDX_BUILDER` environment variable.

--- a/docs/reference/buildx_bake.md
+++ b/docs/reference/buildx_bake.md
@@ -15,7 +15,7 @@ Build from a file
 
 | Name | Description |
 | --- | --- |
-| `--builder string` | Override the configured builder instance |
+| [`--builder string`](#builder) | Override the configured builder instance |
 | [`-f`](#file), [`--file stringArray`](#file) | Build definition file |
 | `--load` | Shorthand for `--set=*.output=type=docker` |
 | `--metadata-file string` | Write build result metadata to the file |
@@ -42,6 +42,10 @@ features in the future if needed. We are looking for feedback on improving the
 command and extending the functionality further.
 
 ## Examples
+
+### <a name="builder"></a> Override the configured builder instance (--builder)
+
+Same as [`buildx --builder`](buildx.md#builder).
 
 ### <a name="file"></a> Specify a build definition file (-f, --file)
 

--- a/docs/reference/buildx_build.md
+++ b/docs/reference/buildx_build.md
@@ -18,7 +18,7 @@ Start a build
 | [`--add-host stringSlice`](https://docs.docker.com/engine/reference/commandline/build/#add-entries-to-container-hosts-file---add-host) | Add a custom host-to-IP mapping (format: `host:ip`) |
 | [`--allow stringSlice`](#allow) | Allow extra privileged entitlement (e.g., `network.host`, `security.insecure`) |
 | [`--build-arg stringArray`](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg) | Set build-time variables |
-| `--builder string` | Override the configured builder instance |
+| [`--builder string`](#builder) | Override the configured builder instance |
 | [`--cache-from stringArray`](#cache-from) | External cache sources (e.g., `user/app:cache`, `type=local,src=path/to/dir`) |
 | [`--cache-to stringArray`](#cache-to) | Cache export destinations (e.g., `user/app:cache`, `type=local,dest=path/to/dir`) |
 | [`--cgroup-parent string`](https://docs.docker.com/engine/reference/commandline/build/#use-a-custom-parent-cgroup---cgroup-parent) | Optional parent cgroup for the container |
@@ -55,6 +55,10 @@ documentation](https://docs.docker.com/engine/reference/commandline/build/). In
 here we’ll document a subset of the new flags.
 
 ## Examples
+
+### <a name="builder"></a> Override the configured builder instance (--builder)
+
+Same as [`buildx --builder`](buildx.md#builder).
 
 ### <a name="platform"></a> Set the target platforms for the build (--platform)
 

--- a/docs/reference/buildx_create.md
+++ b/docs/reference/buildx_create.md
@@ -13,7 +13,6 @@ Create a new builder instance
 | --- | --- |
 | [`--append`](#append) | Append a node to builder instead of changing it |
 | `--bootstrap` | Boot builder after creation |
-| `--builder string` | Override the configured builder instance |
 | [`--buildkitd-flags string`](#buildkitd-flags) | Flags for buildkitd daemon |
 | [`--config string`](#config) | BuildKit config file |
 | [`--driver string`](#driver) | Driver to use (available: `docker`, `docker-container`, `kubernetes`) |

--- a/docs/reference/buildx_du.md
+++ b/docs/reference/buildx_du.md
@@ -11,9 +11,15 @@ Disk usage
 
 | Name | Description |
 | --- | --- |
-| `--builder string` | Override the configured builder instance |
+| [`--builder string`](#builder) | Override the configured builder instance |
 | `--filter filter` | Provide filter values |
 | `--verbose` | Provide a more verbose output |
 
 
 <!---MARKER_GEN_END-->
+
+## Examples
+
+### <a name="builder"></a> Override the configured builder instance (--builder)
+
+Same as [`buildx --builder`](buildx.md#builder).

--- a/docs/reference/buildx_imagetools.md
+++ b/docs/reference/buildx_imagetools.md
@@ -15,6 +15,12 @@ Commands to work on images in registry
 | [`inspect`](buildx_imagetools_inspect.md) | Show details of image in the registry |
 
 
+### Options
+
+| Name | Description |
+| --- | --- |
+| [`--builder string`](#builder) | Override the configured builder instance |
+
 
 <!---MARKER_GEN_END-->
 
@@ -22,3 +28,9 @@ Commands to work on images in registry
 
 Imagetools contains commands for working with manifest lists in the registry.
 These commands are useful for inspecting multi-platform build results.
+
+## Examples
+
+### <a name="builder"></a> Override the configured builder instance (--builder)
+
+Same as [`buildx --builder`](buildx.md#builder).

--- a/docs/reference/buildx_imagetools_create.md
+++ b/docs/reference/buildx_imagetools_create.md
@@ -12,7 +12,7 @@ Create a new image based on source images
 | Name | Description |
 | --- | --- |
 | [`--append`](#append) | Append to existing manifest |
-| `--builder string` | Override the configured builder instance |
+| [`--builder string`](#builder) | Override the configured builder instance |
 | [`--dry-run`](#dry-run) | Show final image instead of pushing |
 | [`-f`](#file), [`--file stringArray`](#file) | Read source descriptor from file |
 | [`-t`](#tag), [`--tag stringArray`](#tag) | Set reference for new image |
@@ -36,6 +36,10 @@ specified, create performs a carbon copy.
 
 Use the `--append` flag to append the new sources to an existing manifest list
 in the destination.
+
+### <a name="builder"></a> Override the configured builder instance (--builder)
+
+Same as [`buildx --builder`](buildx.md#builder).
 
 ### <a name="dry-run"></a> Show final image instead of pushing (--dry-run)
 

--- a/docs/reference/buildx_imagetools_inspect.md
+++ b/docs/reference/buildx_imagetools_inspect.md
@@ -11,7 +11,7 @@ Show details of image in the registry
 
 | Name | Description |
 | --- | --- |
-| `--builder string` | Override the configured builder instance |
+| [`--builder string`](#builder) | Override the configured builder instance |
 | [`--raw`](#raw) | Show original JSON manifest |
 
 
@@ -40,6 +40,12 @@ Manifests:
   Platform:  linux/arm/v6
  ...
 ```
+
+## Examples
+
+### <a name="builder"></a> Override the configured builder instance (--builder)
+
+Same as [`buildx --builder`](buildx.md#builder).
 
 ### <a name="raw"></a> Show original, unformatted JSON manifest (--raw)
 

--- a/docs/reference/buildx_inspect.md
+++ b/docs/reference/buildx_inspect.md
@@ -12,7 +12,7 @@ Inspect current builder instance
 | Name | Description |
 | --- | --- |
 | [`--bootstrap`](#bootstrap) | Ensure builder has booted before inspecting |
-| `--builder string` | Override the configured builder instance |
+| [`--builder string`](#builder) | Override the configured builder instance |
 
 
 <!---MARKER_GEN_END-->
@@ -22,6 +22,19 @@ Inspect current builder instance
 Shows information about the current or specified builder.
 
 ## Examples
+
+### <a name="bootstrap"></a> Ensure that the builder is running before inspecting (--bootstrap)
+
+Use the `--bootstrap` option to ensure that the builder is running before
+inspecting it. If the driver is `docker-container`, then `--bootstrap` starts
+the buildkit container and waits until it is operational. Bootstrapping is
+automatically done during build, and therefore not necessary. The same BuildKit
+container is used during the lifetime of the associated builder node (as
+displayed in `buildx ls`).
+
+### <a name="builder"></a> Override the configured builder instance (--builder)
+
+Same as [`buildx --builder`](buildx.md#builder).
 
 ### Get information about a builder instance
 
@@ -47,12 +60,3 @@ Endpoint:  ssh://ubuntu@1.2.3.4
 Status:    running
 Platforms: linux/arm64, linux/arm/v7, linux/arm/v6
 ```
-
-### <a name="bootstrap"></a> Ensure that the builder is running before inspecting (--bootstrap)
-
-Use the `--bootstrap` option to ensure that the builder is running before
-inspecting it. If the driver is `docker-container`, then `--bootstrap` starts
-the buildkit container and waits until it is operational. Bootstrapping is
-automatically done during build, and therefore not necessary. The same BuildKit
-container is used during the lifetime of the associated builder node (as
-displayed in `buildx ls`).

--- a/docs/reference/buildx_prune.md
+++ b/docs/reference/buildx_prune.md
@@ -12,7 +12,7 @@ Remove build cache
 | Name | Description |
 | --- | --- |
 | `-a`, `--all` | Remove all unused images, not just dangling ones |
-| `--builder string` | Override the configured builder instance |
+| [`--builder string`](#builder) | Override the configured builder instance |
 | `--filter filter` | Provide filter values (e.g., `until=24h`) |
 | `-f`, `--force` | Do not prompt for confirmation |
 | `--keep-storage bytes` | Amount of disk space to keep for cache |
@@ -21,3 +21,8 @@ Remove build cache
 
 <!---MARKER_GEN_END-->
 
+## Examples
+
+### <a name="builder"></a> Override the configured builder instance (--builder)
+
+Same as [`buildx --builder`](buildx.md#builder).

--- a/docs/reference/buildx_rm.md
+++ b/docs/reference/buildx_rm.md
@@ -11,7 +11,7 @@ Remove a builder instance
 
 | Name | Description |
 | --- | --- |
-| `--builder string` | Override the configured builder instance |
+| [`--builder string`](#builder) | Override the configured builder instance |
 | [`--keep-state`](#keep-state) | Keep BuildKit state |
 
 
@@ -23,6 +23,10 @@ Removes the specified or current builder. It is a no-op attempting to remove the
 default builder.
 
 ## Examples
+
+### <a name="builder"></a> Override the configured builder instance (--builder)
+
+Same as [`buildx --builder`](buildx.md#builder).
 
 ### <a name="keep-state"></a> Keep BuildKit state (--keep-state)
 

--- a/docs/reference/buildx_stop.md
+++ b/docs/reference/buildx_stop.md
@@ -7,6 +7,12 @@ docker buildx stop [NAME]
 <!---MARKER_GEN_START-->
 Stop builder instance
 
+### Options
+
+| Name | Description |
+| --- | --- |
+| [`--builder string`](#builder) | Override the configured builder instance |
+
 
 <!---MARKER_GEN_END-->
 
@@ -14,3 +20,9 @@ Stop builder instance
 
 Stops the specified or current builder. This will not prevent buildx build to
 restart the builder. The implementation of stop depends on the driver.
+
+## Examples
+
+### <a name="builder"></a> Override the configured builder instance (--builder)
+
+Same as [`buildx --builder`](buildx.md#builder).

--- a/docs/reference/buildx_use.md
+++ b/docs/reference/buildx_use.md
@@ -11,7 +11,7 @@ Set the current builder instance
 
 | Name | Description |
 | --- | --- |
-| `--builder string` | Override the configured builder instance |
+| [`--builder string`](#builder) | Override the configured builder instance |
 | `--default` | Set builder as default for current context |
 | `--global` | Builder persists context changes |
 
@@ -23,3 +23,9 @@ Set the current builder instance
 Switches the current builder instance. Build commands invoked after this command
 will run on a specified builder. Alternatively, a context name can be used to
 switch to the default builder of that context.
+
+## Examples
+
+### <a name="builder"></a> Override the configured builder instance (--builder)
+
+Same as [`buildx --builder`](buildx.md#builder).

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/containerd/console v1.0.3
 	github.com/containerd/containerd v1.5.5
 	github.com/docker/cli v20.10.8+incompatible
-	github.com/docker/cli-docs-tool v0.1.1
+	github.com/docker/cli-docs-tool v0.2.1
 	github.com/docker/compose-on-kubernetes v0.4.19-0.20190128150448-356b2919c496 // indirect
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/docker/docker v20.10.7+incompatible

--- a/go.sum
+++ b/go.sum
@@ -410,8 +410,8 @@ github.com/distribution/distribution/v3 v3.0.0-20210316161203-a01c71e2477e/go.mo
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/docker/cli v20.10.3-0.20210702143511-f782d1355eff+incompatible h1:CaaxCD/l9Dxogu6lxf7AQautlv3sHULrasPadayp0fM=
 github.com/docker/cli v20.10.3-0.20210702143511-f782d1355eff+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
-github.com/docker/cli-docs-tool v0.1.1 h1:c6vuTMvogCkSFQCXIr6Mb4gFgUpdZ+28YMbCBfaQLik=
-github.com/docker/cli-docs-tool v0.1.1/go.mod h1:oMzPNt1wC3TcxuY22GMnOODNOxkwGH51gV3AhqAjFQ4=
+github.com/docker/cli-docs-tool v0.2.1 h1:ffZhhdws6kE+dCKHLMlYROZz8z01RtWbz+g4xz0eBIU=
+github.com/docker/cli-docs-tool v0.2.1/go.mod h1:rgW5KKdNpLMBIuH4WQ/1RNh38nH+/Ay5jgL4P0ZMPpY=
 github.com/docker/compose-on-kubernetes v0.4.19-0.20190128150448-356b2919c496 h1:90ytrX1dbzL7Uf/hHiuWwvywC+gikHv4hkAy4CwRTbs=
 github.com/docker/compose-on-kubernetes v0.4.19-0.20190128150448-356b2919c496/go.mod h1:iT2pYfi580XlpaV4KmK0T6+4/9+XoKmk/fhoDod1emE=
 github.com/docker/distribution v0.0.0-20190905152932-14b96e55d84c/go.mod h1:0+TTO4EOBfRPhZXAeF1Vu+W3hHZ8eLp8PgKVZlcvtFY=

--- a/util/cobrautil/cobrautil.go
+++ b/util/cobrautil/cobrautil.go
@@ -1,0 +1,14 @@
+package cobrautil
+
+import "github.com/spf13/cobra"
+
+// HideInheritedFlags hides inherited flags
+func HideInheritedFlags(cmd *cobra.Command, hidden ...string) {
+	for _, h := range hidden {
+		// we could use cmd.SetHelpFunc to override the helper
+		// but, it's not enough because we also want the generated
+		// docs to be updated, so we override the flag instead
+		cmd.Flags().String(h, "", "")
+		_ = cmd.Flags().MarkHidden(h)
+	}
+}

--- a/vendor/github.com/docker/cli-docs-tool/README.md
+++ b/vendor/github.com/docker/cli-docs-tool/README.md
@@ -41,61 +41,10 @@ require (
 )
 ```
 
-Next, create a file named `docgen.go` inside that directory containing the
-following Go code:
+Next, create a file named `main.go` inside that directory containing the
+following Go code from [`example/main.go`](example/main.go).
 
-```go
-package main
-
-import (
-  "log"
-  "os"
-  "path/filepath"
-
-  "github.com/docker/buildx/commands"
-  "github.com/docker/cli/cli/command"
-  clidocstool "github.com/docker/cli-docs-tool"
-  "github.com/spf13/cobra"
-)
-
-const sourcePath = "docs/"
-
-func main() {
-  log.SetFlags(0)
-
-  dockerCLI, err := command.NewDockerCli()
-  if err != nil {
-    log.Printf("ERROR: %+v", err)
-  }
-
-  cmd := &cobra.Command{
-    Use:               "docker [OPTIONS] COMMAND [ARG...]",
-    Short:             "The base command for the Docker CLI.",
-    DisableAutoGenTag: true,
-  }
-
-  cmd.AddCommand(commands.NewRootCmd("buildx", true, dockerCLI))
-  clidocstool.DisableFlagsInUseLine(cmd)
-
-  cwd, _ := os.Getwd()
-  source := filepath.Join(cwd, sourcePath)
-
-  // Make sure "source" folder is created first
-  if err = os.MkdirAll(source, 0755); err != nil {
-    log.Printf("ERROR: %+v", err)
-  }
-  
-  // Generate Markdown and YAML documentation to "source" folder
-  if err = clidocstool.GenTree(cmd, source); err != nil {
-    log.Printf("ERROR: %+v", err)
-  }
-}
-```
-
-Here we create a new instance of Docker CLI with `command.NewDockerCli` and a
-subcommand `commands.NewRootCmd` for `buildx`.
-
-Finally, we generate Markdown and YAML documentation with `clidocstool.GenTree`.
+Running this example should produce the following output:
 
 ```console
 $ go run main.go

--- a/vendor/github.com/docker/cli-docs-tool/go.mod
+++ b/vendor/github.com/docker/cli-docs-tool/go.mod
@@ -3,7 +3,6 @@ module github.com/docker/cli-docs-tool
 go 1.16
 
 require (
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0

--- a/vendor/github.com/docker/cli-docs-tool/go.sum
+++ b/vendor/github.com/docker/cli-docs-tool/go.sum
@@ -191,8 +191,6 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -100,7 +100,7 @@ github.com/docker/cli/cli/streams
 github.com/docker/cli/cli/trust
 github.com/docker/cli/cli/version
 github.com/docker/cli/opts
-# github.com/docker/cli-docs-tool v0.1.1
+# github.com/docker/cli-docs-tool v0.2.1
 ## explicit
 github.com/docker/cli-docs-tool
 # github.com/docker/compose-on-kubernetes v0.4.19-0.20190128150448-356b2919c496


### PR DESCRIPTION
`--builder` flag should not be persistent for all subcommands.

Before

```console
$ docker buildx version --help

Usage:  docker buildx version

Show buildx version information

Options:
      --builder string   Override the configured builder instance
```

Now

```console
$ docker buildx version --help

Usage:  docker buildx version

Show buildx version information
```

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>