### PR TITLE
bake: fix protocol detection

### DIFF
--- a/bake/remote.go
+++ b/bake/remote.go
@@ -21,9 +21,10 @@ type Input struct {
 }
 
 func ReadRemoteFiles(ctx context.Context, dis []build.DriverInfo, url string, names []string, pw progress.Writer) ([]File, *Input, error) {
-	st, filename, ok := detectHTTPContext(url)
+	var filename string
+	st, ok := detectGitContext(url)
 	if !ok {
-		st, ok = detectGitContext(url)
+		st, filename, ok = detectHTTPContext(url)
 		if !ok {
 			return nil, nil, errors.Errorf("not url context")
 		}


### PR DESCRIPTION
while investigating with the current state of `git://` protocol (https://github.blog/2021-09-01-improving-git-protocol-security-github/) I encounter an issue with bake and the ability to use a remote definition using https:

```
$ docker buildx bake "https://github.com/docker/cli.git#master" --print
#1 [internal] load remote build context
#1 DONE 0.0s
error: failed to parse https://github.com/docker/cli.git#master: parsing yaml: yaml: line 99: mapping values are not allowed in this context, parsing hcl: https://github.com/docker/cli.git#master.hcl:225,21-22: Unsupported operator; Bitwise operators are not supported. Did you mean boolean AND ("&&")?, and 75 other diagnostic(s)
```

With this PR we now detect if a git-like url is used:

```
$ docker buildx bake "https://github.com/docker/cli.git#master" --print
#1 [internal] load git source https://github.com/docker/cli.git
#1 0.036 hint: Using 'master' as the name for the initial branch. This default branch name
#1 0.036 hint: is subject to change. To configure the initial branch name to use in all
#1 0.036 hint: of your new repositories, which will suppress this warning, call:
#1 0.036 hint:
#1 0.036 hint:  git config --global init.defaultBranch <name>
#1 0.036 hint:
#1 0.036 hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
#1 0.036 hint: 'development'. The just-created branch can be renamed via this command:
#1 0.036 hint:
#1 0.036 hint:  git branch -m <name>
#1 0.037 Initialized empty Git repository in /var/lib/buildkit/runc-overlayfs/snapshots/snapshots/626/fs/
#1 0.491 ref: refs/heads/master HEAD
#1 0.494 3fb4fb83dfb5db0c0753a8316f21aea54dab32c5       HEAD
#1 0.944 3fb4fb83dfb5db0c0753a8316f21aea54dab32c5       refs/heads/master
#1 0.459 ref: refs/heads/master HEAD
#1 0.462 3fb4fb83dfb5db0c0753a8316f21aea54dab32c5       HEAD
#1 2.859 From https://github.com/docker/cli
#1 2.859  * [new branch]      master     -> master
#1 2.859  * [new branch]      master     -> origin/master
#1 DONE 3.7s
{
  "group": {
    "default": [
      "binary"
    ]
  },
  "target": {
    "binary": {
      "context": "https://github.com/docker/cli.git",
      "dockerfile": "Dockerfile",
      "args": {
        "BASE_VARIANT": "alpine",
        "COMPANY_NAME": "",
        "GO_STRIP": "",
        "VERSION": ""
      },
      "target": "binary",
      "platforms": [
        "local"
      ],
      "output": [
        "build"
      ]
    }
  }
}
```

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>