### PR TITLE
docs: fix git protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,17 +97,17 @@ To remove this alias, run [`docker buildx uninstall`](docs/reference/buildx_unin
 
 ```console
 # Buildx 0.6+
-$ docker buildx bake "git://github.com/docker/buildx"
+$ docker buildx bake "https://github.com/docker/buildx.git"
 $ mkdir -p ~/.docker/cli-plugins
 $ mv ./bin/buildx ~/.docker/cli-plugins/docker-buildx
 
 # Docker 19.03+
-$ DOCKER_BUILDKIT=1 docker build --platform=local -o . "git://github.com/docker/buildx"
+$ DOCKER_BUILDKIT=1 docker build --platform=local -o . "https://github.com/docker/buildx.git"
 $ mkdir -p ~/.docker/cli-plugins
 $ mv buildx ~/.docker/cli-plugins/docker-buildx
 
 # Local 
-$ git clone git://github.com/docker/buildx && cd buildx
+$ git clone https://github.com/docker/buildx.git && cd buildx
 $ make install
 ```
 

--- a/docs/reference/buildx_bake.md
+++ b/docs/reference/buildx_bake.md
@@ -99,10 +99,10 @@ $ docker buildx bake -f docker-compose.dev.yaml backend database
 You can also use a remote `git` bake definition:
 
 ```console
-$ docker buildx bake "git://github.com/docker/cli#v20.10.11" --print
-#1 [internal] load git source git://github.com/docker/cli#v20.10.11
+$ docker buildx bake "https://github.com/docker/cli.git#v20.10.11" --print
+#1 [internal] load git source https://github.com/docker/cli.git#v20.10.11
 #1 0.745 e8f1871b077b64bcb4a13334b7146492773769f7       refs/tags/v20.10.11
-#1 2.022 From git://github.com/docker/cli
+#1 2.022 From https://github.com/docker/cli
 #1 2.022  * [new tag]         v20.10.11  -> v20.10.11
 #1 DONE 2.9s
 {
@@ -115,7 +115,7 @@ $ docker buildx bake "git://github.com/docker/cli#v20.10.11" --print
   },
   "target": {
     "binary": {
-      "context": "git://github.com/docker/cli#v20.10.11",
+      "context": "https://github.com/docker/cli.git#v20.10.11",
       "dockerfile": "Dockerfile",
       "args": {
         "BASE_VARIANT": "alpine",
@@ -134,7 +134,7 @@ $ docker buildx bake "git://github.com/docker/cli#v20.10.11" --print
 }
 ```
 
-As you can see the context is fixed to `git://github.com/docker/cli` even if
+As you can see the context is fixed to `https://github.com/docker/cli.git` even if
 [no context is actually defined](https://github.com/docker/cli/blob/2776a6d694f988c0c1df61cad4bfac0f54e481c8/docker-bake.hcl#L17-L26)
 in the definition.
 
@@ -155,7 +155,7 @@ EOT
 ```
 
 ```console
-$ docker buildx bake "git://github.com/tonistiigi/buildx#remote-test" --print
+$ docker buildx bake "https://github.com/tonistiigi/buildx.git#remote-test" --print
 {
   "target": {
     "default": {
@@ -169,7 +169,7 @@ $ docker buildx bake "git://github.com/tonistiigi/buildx#remote-test" --print
 
 ```console
 $ touch foo bar
-$ docker buildx bake "git://github.com/tonistiigi/buildx#remote-test"
+$ docker buildx bake "https://github.com/tonistiigi/buildx.git#remote-test"
 ...
  > [4/4] RUN ls -l && stop:
 #8 0.101 total 0
@@ -179,14 +179,14 @@ $ docker buildx bake "git://github.com/tonistiigi/buildx#remote-test"
 ```
 
 ```console
-$ docker buildx bake "git://github.com/tonistiigi/buildx#remote-test" "git://github.com/docker/cli#v20.10.11" --print
-#1 [internal] load git source git://github.com/tonistiigi/buildx#remote-test
+$ docker buildx bake "https://github.com/tonistiigi/buildx.git#remote-test" "https://github.com/docker/cli.git#v20.10.11" --print
+#1 [internal] load git source https://github.com/tonistiigi/buildx.git#remote-test
 #1 0.429 577303add004dd7efeb13434d69ea030d35f7888       refs/heads/remote-test
 #1 CACHED
 {
   "target": {
     "default": {
-      "context": "git://github.com/docker/cli#v20.10.11",
+      "context": "https://github.com/docker/cli.git#v20.10.11",
       "dockerfile": "Dockerfile",
       "dockerfile-inline": "FROM alpine\nWORKDIR /src\nCOPY . .\nRUN ls -l \u0026\u0026 stop\n"
     }
@@ -195,7 +195,7 @@ $ docker buildx bake "git://github.com/tonistiigi/buildx#remote-test" "git://git
 ```
 
 ```console
-$ docker buildx bake "git://github.com/tonistiigi/buildx#remote-test" "git://github.com/docker/cli#v20.10.11"
+$ docker buildx bake "https://github.com/tonistiigi/buildx.git#remote-test" "https://github.com/docker/cli.git#v20.10.11"
 ...
  > [4/4] RUN ls -l && stop:
 #8 0.136 drwxrwxrwx    5 root     root          4096 Jul 27 18:31 kubernetes


### PR DESCRIPTION
follow-up https://github.com/docker/buildx/pull/822#issuecomment-958006458

https://github.blog/2021-09-01-improving-git-protocol-security-github/

```
#1 0.234 fatal: remote error: 
#1 0.234   The unauthenticated git protocol on port 9418 is no longer supported.
#1 0.234 Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>