### PR TITLE
store snapshot of config files on create

### DIFF
--- a/commands/util.go
+++ b/commands/util.go
@@ -225,7 +225,7 @@ func driversForNodeGroup(ctx context.Context, dockerCli command.Cli, ng *store.N
 					}
 				}
 
-				d, err := driver.GetDriver(ctx, "buildx_buildkit_"+n.Name, f, dockerapi, dockerCli.ConfigFile(), kcc, n.Flags, n.ConfigFile, n.DriverOpts, n.Platforms, contextPathHash)
+				d, err := driver.GetDriver(ctx, "buildx_buildkit_"+n.Name, f, dockerapi, dockerCli.ConfigFile(), kcc, n.Flags, n.Files, n.DriverOpts, n.Platforms, contextPathHash)
 				if err != nil {
 					di.Err = err
 					return nil
@@ -360,7 +360,7 @@ func getDefaultDrivers(ctx context.Context, dockerCli command.Cli, defaultOnly b
 		}
 	}
 
-	d, err := driver.GetDriver(ctx, "buildx_buildkit_default", nil, dockerCli.Client(), dockerCli.ConfigFile(), nil, nil, "", nil, nil, contextPathHash)
+	d, err := driver.GetDriver(ctx, "buildx_buildkit_default", nil, dockerCli.Client(), dockerCli.ConfigFile(), nil, nil, nil, nil, nil, contextPathHash)
 	if err != nil {
 		return nil, err
 	}

--- a/driver/docker/factory.go
+++ b/driver/docker/factory.go
@@ -44,7 +44,7 @@ func (f *factory) New(ctx context.Context, cfg driver.InitConfig) (driver.Driver
 	if cfg.DockerAPI == nil {
 		return nil, errors.Errorf("docker driver requires docker API access")
 	}
-	if cfg.ConfigFile != "" {
+	if len(cfg.Files) > 0 {
 		return nil, errors.Errorf("setting config file is not supported for docker driver, use dockerd configuration file")
 	}
 

--- a/driver/kubernetes/factory.go
+++ b/driver/kubernetes/factory.go
@@ -2,7 +2,6 @@ package kubernetes
 
 import (
 	"context"
-	"os"
 	"strconv"
 	"strings"
 
@@ -78,12 +77,8 @@ func (f *factory) New(ctx context.Context, cfg driver.InitConfig) (driver.Driver
 
 	deploymentOpt.Qemu.Image = bkimage.QemuImage
 
-	if cfg.ConfigFile != "" {
-		buildkitConfig, err := os.ReadFile(cfg.ConfigFile)
-		if err != nil {
-			return nil, err
-		}
-		deploymentOpt.BuildkitConfig = buildkitConfig
+	if cfg, ok := cfg.Files["buildkitd.toml"]; ok {
+		deploymentOpt.BuildkitConfig = cfg
 	}
 
 	loadbalance := LoadbalanceSticky

--- a/driver/kubernetes/factory.go
+++ b/driver/kubernetes/factory.go
@@ -73,13 +73,10 @@ func (f *factory) New(ctx context.Context, cfg driver.InitConfig) (driver.Driver
 		BuildkitFlags: cfg.BuildkitFlags,
 		Rootless:      false,
 		Platforms:     cfg.Platforms,
+		ConfigFiles:   cfg.Files,
 	}
 
 	deploymentOpt.Qemu.Image = bkimage.QemuImage
-
-	if cfg, ok := cfg.Files["buildkitd.toml"]; ok {
-		deploymentOpt.BuildkitConfig = cfg
-	}
 
 	loadbalance := LoadbalanceSticky
 
@@ -142,7 +139,7 @@ func (f *factory) New(ctx context.Context, cfg driver.InitConfig) (driver.Driver
 		}
 	}
 
-	d.deployment, d.configMap, err = manifest.NewDeployment(deploymentOpt)
+	d.deployment, d.configMaps, err = manifest.NewDeployment(deploymentOpt)
 	if err != nil {
 		return nil, err
 	}

--- a/driver/manager.go
+++ b/driver/manager.go
@@ -53,7 +53,7 @@ type InitConfig struct {
 	DockerAPI        dockerclient.APIClient
 	KubeClientConfig KubeClientConfig
 	BuildkitFlags    []string
-	ConfigFile       string
+	Files            map[string][]byte
 	DriverOpts       map[string]string
 	Auth             Auth
 	Platforms        []specs.Platform
@@ -103,17 +103,17 @@ func GetFactory(name string, instanceRequired bool) Factory {
 	return nil
 }
 
-func GetDriver(ctx context.Context, name string, f Factory, api dockerclient.APIClient, auth Auth, kcc KubeClientConfig, flags []string, config string, do map[string]string, platforms []specs.Platform, contextPathHash string) (Driver, error) {
+func GetDriver(ctx context.Context, name string, f Factory, api dockerclient.APIClient, auth Auth, kcc KubeClientConfig, flags []string, files map[string][]byte, do map[string]string, platforms []specs.Platform, contextPathHash string) (Driver, error) {
 	ic := InitConfig{
 		DockerAPI:        api,
 		KubeClientConfig: kcc,
 		Name:             name,
 		BuildkitFlags:    flags,
-		ConfigFile:       config,
 		DriverOpts:       do,
 		Auth:             auth,
 		Platforms:        platforms,
 		ContextPathHash:  contextPathHash,
+		Files:            files,
 	}
 	if f == nil {
 		var err error


### PR DESCRIPTION
Files can be reused when container needs to be booted again.

The second commit enables config files for k8s. @morlay PTAL. If something is wrong we can remove the second commit or you can push a fix to this PR.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>