### PR TITLE
build: fix setting iidfile with multi-node push

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -732,7 +732,9 @@ func Build(ctx context.Context, drivers []DriverInfo, opt map[string]Options, do
 								return err
 							}
 							if opt.ImageIDFile != "" {
-								return ioutil.WriteFile(opt.ImageIDFile, []byte(desc.Digest), 0644)
+								if err := ioutil.WriteFile(opt.ImageIDFile, []byte(desc.Digest), 0644); err != nil {
+									return err
+								}
 							}
 
 							itpush := imagetools.New(imagetools.Opt{


### PR DESCRIPTION
I can't see any reason for this early return. It breaks using iidfile together with push on multi-node case.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>