### PR TITLE
fix typo in docs

### DIFF
--- a/docs/reference/buildx_bake.md
+++ b/docs/reference/buildx_bake.md
@@ -492,7 +492,7 @@ $ TAG=$(git rev-parse --short HEAD) docker buildx bake --print webapp
 
 #### Using the `add` function
 
-You can use [`go-cty` stdlib functions]([go-cty](https://github.com/zclconf/go-cty/tree/main/cty/function/stdlib)).
+You can use [`go-cty` stdlib functions](https://github.com/zclconf/go-cty/tree/main/cty/function/stdlib).
 Here we are using the `add` function.
 
 ```hcl


### PR DESCRIPTION
relates to https://github.com/docker/docker.github.io/pull/13488#issuecomment-961678105

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>