### PR TITLE
Add an flag to buildx rm to keep the buildkitd daemon running

### DIFF
--- a/docs/reference/buildx_rm.md
+++ b/docs/reference/buildx_rm.md
@@ -12,6 +12,7 @@ Remove a builder instance
 | Name | Description |
 | --- | --- |
 | [`--builder string`](#builder) | Override the configured builder instance |
+| [`--keep-daemon`](#keep-daemon) | Keep the buildkitd daemon running |
 | [`--keep-state`](#keep-state) | Keep BuildKit state |
 
 
@@ -32,3 +33,8 @@ Same as [`buildx --builder`](buildx.md#builder).
 
 Keep BuildKit state, so it can be reused by a new builder with the same name.
 Currently, only supported by the [`docker-container` driver](buildx_create.md#driver).
+
+### <a name="keep-daemon"></a> Keep the buildkitd daemon running (--keep-daemon)
+
+Keep the buildkitd daemon running after the buildx context is removed. This is useful when you manage buildkitd daemons and buildx contexts independently.
+Currently, only supported by the [`docker-container` and `kubernetes` drivers](buildx_create.md#driver).

--- a/driver/docker/driver.go
+++ b/driver/docker/driver.go
@@ -33,7 +33,7 @@ func (d *Driver) Stop(ctx context.Context, force bool) error {
 	return nil
 }
 
-func (d *Driver) Rm(ctx context.Context, force bool, rmVolume bool) error {
+func (d *Driver) Rm(ctx context.Context, force, rmVolume, rmDaemon bool) error {
 	return nil
 }
 

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -54,7 +54,7 @@ type Driver interface {
 	Bootstrap(context.Context, progress.Logger) error
 	Info(context.Context) (*Info, error)
 	Stop(ctx context.Context, force bool) error
-	Rm(ctx context.Context, force bool, rmVolume bool) error
+	Rm(ctx context.Context, force, rmVolume, rmDaemon bool) error
 	Client(ctx context.Context) (*client.Client, error)
 	Features() map[Feature]bool
 	IsMobyDriver() bool

--- a/driver/kubernetes/driver.go
+++ b/driver/kubernetes/driver.go
@@ -165,7 +165,11 @@ func (d *Driver) Stop(ctx context.Context, force bool) error {
 	return nil
 }
 
-func (d *Driver) Rm(ctx context.Context, force bool, rmVolume bool) error {
+func (d *Driver) Rm(ctx context.Context, force, rmVolume, rmDaemon bool) error {
+	if !rmDaemon {
+		return nil
+	}
+
 	if err := d.deploymentClient.Delete(ctx, d.deployment.Name, metav1.DeleteOptions{}); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return errors.Wrapf(err, "error while calling deploymentClient.Delete for %q", d.deployment.Name)


### PR DESCRIPTION
This PR adds the flag  `--keep-buildkitd` to the `buildx rm` command to preserve the buildkitd daemon after the buildx context is deleted.

This flag can be useful when someone uses the `kubernetes` driver and manages the `buildkit` deployment outside of `buildx`.

```bash
docker buildx rm --help

  Usage:  docker buildx rm [NAME]
  
  Remove a builder instance
  
  Options:
        --builder string   Override the configured builder instance
        --keep-buildkitd   Keep the buildkitd daemon running
        --keep-state       Keep BuildKit state
```

Fixes #794

Signed-off-by: Mayeul Blanzat <mayeul.blanzat@datadoghq.com>