### PR TITLE
add note about variable syntax in json

### DIFF
--- a/docs/reference/buildx_bake.md
+++ b/docs/reference/buildx_bake.md
@@ -450,6 +450,28 @@ target "webapp" {
 }
 ```
 
+alternatively, in json format:
+
+```json
+{
+  "variable": {
+    "TAG": {
+      "default": "latest"
+    }
+  }
+  "group": {
+    "default": {
+      "targets": ["webapp"]
+    }
+  },
+  "target": {
+    "webapp": {
+      "tags": ["docker.io/username/webapp:${TAG}"]
+    }
+  }
+}
+```
+
 ```console
 $ docker buildx bake --print webapp
 {


### PR DESCRIPTION
In addition to HCL, variables can also be defined in json.
I believe it might be useful, yet I did not see it documented anywhere. The solution is based on Hashicorp Packer documentation.