### PR TITLE
disk usage: last accessed not displayed

### DIFF
--- a/commands/prune.go
+++ b/commands/prune.go
@@ -12,11 +12,11 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/go-units"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/util/appcontext"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/tonistiigi/units"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -119,7 +119,7 @@ func runPrune(dockerCli command.Cli, opts pruneOptions) error {
 	<-printed
 
 	tw = tabwriter.NewWriter(os.Stdout, 1, 8, 1, '\t', 0)
-	fmt.Fprintf(tw, "Total:\t%.2f\n", units.Bytes(total))
+	fmt.Fprintf(tw, "Total:\t%s\n", units.HumanSize(float64(total)))
 	tw.Flush()
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,6 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	github.com/theupdateframework/notary v0.6.1 // indirect
-	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea
 	github.com/zclconf/go-cty v1.7.1
 	go.opentelemetry.io/otel v1.0.0-RC1
 	go.opentelemetry.io/otel/trace v1.0.0-RC1

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -422,7 +422,6 @@ github.com/tonistiigi/fsutil
 github.com/tonistiigi/fsutil/prefix
 github.com/tonistiigi/fsutil/types
 # github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea
-## explicit
 github.com/tonistiigi/units
 # github.com/tonistiigi/vt100 v0.0.0-20210615222946-8066bb97264f
 github.com/tonistiigi/vt100


### PR DESCRIPTION
`LAST ACCESSED` is currently not displayed when `docker buildx du` is typed:

```console
$ docker buildx du
ID                                                                      RECLAIMABLE     SIZE            LAST ACCESSED
tfh97mauvv969bbf9alj95dnj*                                              true            528.48MB
zkflab60sf3z1b8lmbik9dyb1                                               true            454.48MB
3jef3cg8lwudcluhb5nahsvif*                                              true            398.66MB
ri0p36t0xhc6yor2304x07h3d*                                              true            160.39MB
5mk6axu5qiga7f6z750nayckn*                                              true            62.00MB
wd188ekm0g89savkrot6cjkf0*                                              true            61.98MB
8mwxxr5ay0m2a9jleth2nztqw*                                              true            47.17MB
512jhzfadd7o9df516eq0myqo*                                              true            47.12MB
k4e6d0h82sd6xwb1pedr0jk2w                                               true            30.41MB
687h2dhzh627elkjc8fswp9n7                                               true            30.40MB
yh6rmjcs31ldem3x11rnq967x                                               true            20.57MB
aqftc8mpanfm0yi59vlf6hr0m                                               true            14.79MB
rcb679xax2bxcxgo2lvuf6rq1                                               true            9.09MB
djlpzedli0plffj32hm5zqquj                                               true            1.71MB
duj1672h9xt2xp2fa9mecnlba                                               true            91.81kB
25a9cih7gdb3n9rn5ywuduxv7                                               true            81.92kB
imuvawazj7rv7knkh6g3g71ka*                                              true            20.48kB
jhj13u45ji8dczsezvi9ano4t                                               true            16.54kB
05pe0f2pv632qpuoj2b5flgvi                                               true            12.44kB
mitzbz3hsw9mnyqrho9l3yvr7                                               true            8.19kB
e4n0vwlqbx76whw1vtnbg0yet*                                              true            8.19kB
a01diuegxlvjrfxiufeagj4ae                                               true            8.19kB
20rm8n3924qent9bq73hy30ne*                                              true            8.19kB
Reclaimable:    1.87GB
Total:          1.87GB
```

This PR displays the last time a cache record has been accessed:

```console
$ docker buildx du
ID                                              RECLAIMABLE     SIZE            LAST ACCESSED
tfh97mauvv969bbf9alj95dnj*                      true            528.5MB         19 seconds ago
zkflab60sf3z1b8lmbik9dyb1                       true            454.5MB         3 minutes ago
3jef3cg8lwudcluhb5nahsvif*                      true            398.7MB         19 seconds ago
ri0p36t0xhc6yor2304x07h3d*                      true            160.4MB         26 seconds ago
5mk6axu5qiga7f6z750nayckn*                      true            62MB            2 minutes ago
wd188ekm0g89savkrot6cjkf0*                      true            61.98MB         2 minutes ago
8mwxxr5ay0m2a9jleth2nztqw*                      true            47.17MB         26 seconds ago
512jhzfadd7o9df516eq0myqo*                      true            47.12MB         26 seconds ago
k4e6d0h82sd6xwb1pedr0jk2w                       true            30.41MB         2 minutes ago
687h2dhzh627elkjc8fswp9n7                       true            30.4MB          26 seconds ago
yh6rmjcs31ldem3x11rnq967x                       true            20.57MB         26 seconds ago
aqftc8mpanfm0yi59vlf6hr0m                       true            14.79MB         2 minutes ago
rcb679xax2bxcxgo2lvuf6rq1                       true            9.086MB         3 minutes ago
djlpzedli0plffj32hm5zqquj                       true            1.711MB         3 minutes ago
duj1672h9xt2xp2fa9mecnlba                       true            91.81kB         26 seconds ago
25a9cih7gdb3n9rn5ywuduxv7                       true            81.92kB         26 seconds ago
imuvawazj7rv7knkh6g3g71ka*                      true            20.48kB         26 seconds ago
jhj13u45ji8dczsezvi9ano4t                       true            16.54kB         26 seconds ago
05pe0f2pv632qpuoj2b5flgvi                       true            12.44kB         3 minutes ago
mitzbz3hsw9mnyqrho9l3yvr7                       true            8.192kB         2 minutes ago
e4n0vwlqbx76whw1vtnbg0yet*                      true            8.192kB         26 seconds ago
a01diuegxlvjrfxiufeagj4ae                       true            8.192kB         26 seconds ago
20rm8n3924qent9bq73hy30ne*                      true            8.192kB         26 seconds ago
Reclaimable:    1.868GB
Total:          1.868GB
```

This also uses `github.com/docker/go-units` instead of `github.com/tonistiigi/units` to format the output.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>