### PR TITLE
bake: fix group resolution

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -378,7 +378,12 @@ func (c Config) group(name string, visited map[string]struct{}) []string {
 	visited[name] = struct{}{}
 	targets := make([]string, 0, len(g.Targets))
 	for _, t := range g.Targets {
-		targets = append(targets, c.group(t, visited)...)
+		tgroup := c.group(t, visited)
+		if len(tgroup) > 0 {
+			targets = append(targets, tgroup...)
+		} else {
+			targets = append(targets, t)
+		}
 	}
 	return targets
 }


### PR DESCRIPTION
follow-up #881

If a target has the same name as a group, it's resolution is skipped.

```hcl
group "foo" {
  targets = ["foo"]
}
target "foo" {
  dockerfile = "bar"
}
```

```
$ docker buildx bake foo --print
{
  "group": {
    "default": {
      "targets": [
        "foo"
      ]
    }
  },
  "target": {}
}
```

Now:

```
$ docker buildx bake foo --print
{
  "group": {
    "default": {
      "targets": [
        "foo"
      ]
    }
  },
  "target": {
    "foo": {
      "context": ".",
      "dockerfile": "bar"
    }
  }
}