### PR TITLE
Show summary of build warnings.

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -1,9 +1,11 @@
 package commands
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,7 +24,9 @@ import (
 	"github.com/docker/go-units"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/session/auth/authprovider"
+	"github.com/moby/buildkit/solver/errdefs"
 	"github.com/moby/buildkit/util/appcontext"
+	"github.com/morikuni/aec"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -245,7 +249,49 @@ func buildTargets(ctx context.Context, dockerCli command.Cli, opts map[string]bu
 		}
 	}
 
+	printWarnings(os.Stderr, printer.Warnings(), progressMode)
+
 	return resp[defaultTargetName].ExporterResponse["containerimage.digest"], err
+}
+
+func printWarnings(w io.Writer, warnings []client.VertexWarning, mode string) {
+	if len(warnings) == 0 || mode == progress.PrinterModeQuiet {
+		return
+	}
+	fmt.Fprintf(w, "\n ")
+	sb := &bytes.Buffer{}
+	if len(warnings) == 1 {
+		fmt.Fprintf(sb, "1 warning found")
+	} else {
+		fmt.Fprintf(sb, "%d warnings found", len(warnings))
+	}
+	if logrus.GetLevel() < logrus.DebugLevel {
+		fmt.Fprintf(sb, " (use --debug to expand)")
+	}
+	fmt.Fprintf(sb, ":\n")
+	fmt.Fprint(w, aec.Apply(sb.String(), aec.YellowF))
+
+	for _, warn := range warnings {
+		fmt.Fprintf(w, " - %s\n", warn.Short)
+		if logrus.GetLevel() < logrus.DebugLevel {
+			continue
+		}
+		for _, d := range warn.Detail {
+			fmt.Fprintf(w, "%s\n", d)
+		}
+		if warn.URL != "" {
+			fmt.Fprintf(w, "More info: %s\n", warn.URL)
+		}
+		if warn.SourceInfo != nil && warn.Range != nil {
+			src := errdefs.Source{
+				Info:   warn.SourceInfo,
+				Ranges: warn.Range,
+			}
+			src.Print(w)
+		}
+		fmt.Fprintf(w, "\n")
+
+	}
 }
 
 func newBuildOptions() buildOptions {

--- a/commands/root.go
+++ b/commands/root.go
@@ -4,9 +4,11 @@ import (
 	"os"
 
 	imagetoolscmd "github.com/docker/buildx/commands/imagetools"
+	"github.com/docker/buildx/util/logutil"
 	"github.com/docker/cli-docs-tool/annotation"
 	"github.com/docker/cli/cli-plugins/plugin"
 	"github.com/docker/cli/cli/command"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -25,6 +27,12 @@ func NewRootCmd(name string, isPlugin bool, dockerCli command.Cli) *cobra.Comman
 			return plugin.PersistentPreRunE(cmd, args)
 		}
 	}
+
+	logrus.AddHook(logutil.NewFilter(
+		"serving grpc connection",
+		"stopping session",
+		"using default config store",
+	))
 
 	addCommands(cmd, dockerCli)
 	return cmd

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/jinzhu/inflection v0.0.0-20180308033659-04140366298a // indirect
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
 	github.com/moby/buildkit v0.9.1-0.20211215010209-539be1708964
+	github.com/morikuni/aec v1.0.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.2-0.20210819154149-5ad6f50d6283
 	github.com/pelletier/go-toml v1.9.4

--- a/util/logutil/filter.go
+++ b/util/logutil/filter.go
@@ -1,0 +1,36 @@
+package logutil
+
+import (
+	"io/ioutil"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+func NewFilter(filters ...string) logrus.Hook {
+	dl := logrus.New()
+	dl.SetOutput(ioutil.Discard)
+	return &logsFilter{
+		filters:       filters,
+		discardLogger: dl,
+	}
+}
+
+type logsFilter struct {
+	filters       []string
+	discardLogger *logrus.Logger
+}
+
+func (d *logsFilter) Levels() []logrus.Level {
+	return []logrus.Level{logrus.DebugLevel}
+}
+
+func (d *logsFilter) Fire(entry *logrus.Entry) error {
+	for _, f := range d.filters {
+		if strings.Contains(entry.Message, f) {
+			entry.Logger = d.discardLogger
+			return nil
+		}
+	}
+	return nil
+}

--- a/util/logutil/pause.go
+++ b/util/logutil/pause.go
@@ -1,0 +1,52 @@
+package logutil
+
+import (
+	"bytes"
+	"io"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+func Pause(l *logrus.Logger) func() {
+	// initialize formatter with original terminal settings
+	l.Formatter.Format(logrus.NewEntry(l))
+
+	bw := newBufferedWriter(l.Out)
+	l.SetOutput(bw)
+	return func() {
+		bw.resume()
+	}
+}
+
+type bufferedWriter struct {
+	mu  sync.Mutex
+	buf *bytes.Buffer
+	w   io.Writer
+}
+
+func newBufferedWriter(w io.Writer) *bufferedWriter {
+	return &bufferedWriter{
+		buf: bytes.NewBuffer(nil),
+		w:   w,
+	}
+}
+
+func (bw *bufferedWriter) Write(p []byte) (int, error) {
+	bw.mu.Lock()
+	defer bw.mu.Unlock()
+	if bw.buf == nil {
+		return bw.w.Write(p)
+	}
+	return bw.buf.Write(p)
+}
+
+func (bw *bufferedWriter) resume() {
+	bw.mu.Lock()
+	defer bw.mu.Unlock()
+	if bw.buf == nil {
+		return
+	}
+	io.Copy(bw.w, bw.buf)
+	bw.buf = nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -354,6 +354,7 @@ github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.1
 github.com/modern-go/reflect2
 # github.com/morikuni/aec v1.0.0
+## explicit
 github.com/morikuni/aec
 # github.com/opencontainers/go-digest v1.0.0
 ## explicit


### PR DESCRIPTION
In addition to showing warning where it happens show a summary after build has completed.

```
> docker buildx build .
...
 1 warning found (use --debug to expand):
 - Empty continuation line found in: RUN date &&     sleep 4 &&     date && echo $GREETING
```

with `--debug`

```
...
 1 warning found:
 - Empty continuation line found in: RUN date &&     sleep 4 &&     date && echo $GREETING
Empty continuation lines will become errors in a future release
More info: https://github.com/moby/moby/pull/33719
Dockerfile:11
--------------------
   9 |         sleep 4 && \
  10 |     
  11 | >>>     date && echo $GREETING
  12 |     RUN true
  13 |      
--------------------
```

Also fix the issue with progressbar and logging both printing to terminal at same time. Now logs are buffered while the terminal is active.

Additional commit suppresses some useless debug logs from vendored components.