### PR TITLE
ci: build with stable buildkit image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,6 @@ on:
 
 env:
   REPO_SLUG: "docker/buildx-bin"
-  REPO_SLUG_ORIGIN: "moby/buildkit:master"
   RELEASE_OUT: "./release-out"
 
 jobs:
@@ -31,8 +30,6 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-        with:
-          driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
       -
         name: Test
         run: |
@@ -90,3 +87,26 @@ jobs:
         with:
           draft: true
           files: ${{ env.RELEASE_OUT }}/*
+
+  buildkit-edge:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          driver-opts: image=moby/buildkit:master
+          buildkitd-flags: --debug
+      -
+        # Just run a bake target to check eveything runs fine
+        name: Build
+        uses: docker/bake-action@v1
+        with:
+          targets: binaries-cross


### PR DESCRIPTION
follow-up https://github.com/moby/buildkit/pull/2491#issuecomment-1010123172

Our actual pipeline is using a bleeding edge release of the BuildKit image which might introduce bugs unrelated to buildx like https://github.com/docker/buildx/runs/4777886890?check_suite_focus=true#step:7:135:

```
error: failed to solve: process "/bin/sh -c set -x; xx-go build -ldflags \"$(cat /tmp/.ldflags) ${LDFLAGS}\" -o /usr/bin/buildx ./cmd/buildx &&   xx-verify --static /usr/bin/buildx" did not complete successfully: failed to mount /tmp/buildkit-mount2802602399: [{Type:overlay Source:overlay Options:[index=off workdir=/var/lib/buildkit/runc-overlayfs/snapshots/snapshots/24/work upperdir=/var/lib/buildkit/runc-overlayfs/snapshots/snapshots/24/fs lowerdir=/var/lib/buildkit/runc-overlayfs/snapshots/snapshots/15/fs:/var/lib/buildkit/runc-overlayfs/snapshots/snapshots/14/fs:/var/lib/buildkit/runc-overlayfs/snapshots/snapshots/13/fs:/var/lib/buildkit/runc-overlayfs/snapshots/snapshots/12/fs:/var/lib/buildkit/runc-overlayfs/snapshots/snapshots/11/fs:/var/lib/buildkit/runc-overlayfs/snapshots/snapshots/10/fs:/var/lib/buildkit/runc-overlayfs/snapshots/snapshots/9/fs:/var/lib/buildkit/runc-overlayfs/snapshots/snapshots/6/fs redirect_dir=off]}]: no such file or directory
```

This PR removes it for the main build job but also adds a small job to keep using it to detect this kind of behavior in the future.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>