### PR TITLE
chore: invalidate cache for outdated run stage

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -89,6 +89,11 @@ target "mod-outdated" {
   inherits = ["_common"]
   dockerfile = "./hack/dockerfiles/vendor.Dockerfile"
   target = "outdated"
+  args = {
+    // used to invalidate cache for outdated run stage
+    // can be dropped when https://github.com/moby/buildkit/issues/1213 fixed
+    _RANDOM = uuidv4()
+  }
   output = ["type=cacheonly"]
 }
 

--- a/hack/dockerfiles/vendor.Dockerfile
+++ b/hack/dockerfiles/vendor.Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.3-labs
 
 ARG GO_VERSION=1.17
+ARG MODOUTDATED_VERSION=v0.8.0
 
 FROM golang:${GO_VERSION}-alpine AS base
 RUN apk add --no-cache git rsync
@@ -36,8 +37,9 @@ if [ -n "$(git status --porcelain -- go.mod go.sum vendor)" ]; then
 fi
 EOT
 
-FROM psampaz/go-mod-outdated:v0.8.0 AS go-mod-outdated
+FROM psampaz/go-mod-outdated:${MODOUTDATED_VERSION} AS go-mod-outdated
 FROM base AS outdated
+ARG _RANDOM
 RUN --mount=target=.,ro \
   --mount=target=/go/pkg/mod,type=cache \
   --mount=from=go-mod-outdated,source=/home/go-mod-outdated,target=/usr/bin/go-mod-outdated \


### PR DESCRIPTION
Invalidate cache for outdated run stage. Can be dropped when https://github.com/moby/buildkit/issues/1213 is fixed.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>