### PR TITLE
root: filter out useless commandConn.CloseWrite warning message

### DIFF
--- a/commands/root.go
+++ b/commands/root.go
@@ -28,10 +28,22 @@ func NewRootCmd(name string, isPlugin bool, dockerCli command.Cli) *cobra.Comman
 		}
 	}
 
-	logrus.AddHook(logutil.NewFilter(
+	logrus.AddHook(logutil.NewFilter([]logrus.Level{
+		logrus.DebugLevel,
+	},
 		"serving grpc connection",
 		"stopping session",
 		"using default config store",
+	))
+
+	// filter out useless commandConn.CloseWrite warning message that can occur
+	// when listing builder instances with "buildx ls" for those that are
+	// unreachable: "commandConn.CloseWrite: commandconn: failed to wait: signal: killed"
+	// https://github.com/docker/cli/blob/3fb4fb83dfb5db0c0753a8316f21aea54dab32c5/cli/connhelper/commandconn/commandconn.go#L203-L214
+	logrus.AddHook(logutil.NewFilter([]logrus.Level{
+		logrus.WarnLevel,
+	},
+		"commandConn.CloseWrite:",
 	))
 
 	addCommands(cmd, dockerCli)

--- a/commands/root.go
+++ b/commands/root.go
@@ -28,6 +28,8 @@ func NewRootCmd(name string, isPlugin bool, dockerCli command.Cli) *cobra.Comman
 		}
 	}
 
+	logrus.SetFormatter(&logutil.Formatter{})
+
 	logrus.AddHook(logutil.NewFilter([]logrus.Level{
 		logrus.DebugLevel,
 	},

--- a/util/logutil/filter.go
+++ b/util/logutil/filter.go
@@ -7,22 +7,24 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func NewFilter(filters ...string) logrus.Hook {
+func NewFilter(levels []logrus.Level, filters ...string) logrus.Hook {
 	dl := logrus.New()
 	dl.SetOutput(ioutil.Discard)
 	return &logsFilter{
+		levels:        levels,
 		filters:       filters,
 		discardLogger: dl,
 	}
 }
 
 type logsFilter struct {
+	levels        []logrus.Level
 	filters       []string
 	discardLogger *logrus.Logger
 }
 
 func (d *logsFilter) Levels() []logrus.Level {
-	return []logrus.Level{logrus.DebugLevel}
+	return d.levels
 }
 
 func (d *logsFilter) Fire(entry *logrus.Entry) error {

--- a/util/logutil/format.go
+++ b/util/logutil/format.go
@@ -1,0 +1,16 @@
+package logutil
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+type Formatter struct {
+	logrus.TextFormatter
+}
+
+func (f *Formatter) Format(entry *logrus.Entry) ([]byte, error) {
+	return []byte(fmt.Sprintf("%s: %s\n", strings.ToUpper(entry.Level.String()), entry.Message)), nil
+}


### PR DESCRIPTION
relates to https://github.com/docker/buildx/issues/764#issuecomment-961198793
closes #813 

also while doing further tests for https://github.com/docker/cli/pull/3314 I encounter a case where some logs don't match the output format from docker/cli:

```shell
$ docker build ...
WARNING: Error loading config file: ...
WARN[0000] No output specified for docker-container driver. Build result will only remain in ...
```

now using cli writers for logrus and simplify output format for parity:

```shell
$ docker build ...
WARNING: Error loading config file: ...
WARNING: No output specified for docker-container driver. Build result will only remain in ...
```