### PR TITLE
Prevent crash when Exporter is not TracerDelegate

### DIFF
--- a/driver/docker-container/driver.go
+++ b/driver/docker-container/driver.go
@@ -341,11 +341,17 @@ func (d *Driver) Client(ctx context.Context) (*client.Client, error) {
 		return nil, err
 	}
 
-	td, _ := exp.(client.TracerDelegate)
+	clientOpts := []client.ClientOpt{
+		client.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return conn, nil
+		}),
+	}
 
-	return client.New(ctx, "", client.WithContextDialer(func(context.Context, string) (net.Conn, error) {
-		return conn, nil
-	}), client.WithTracerDelegate(td))
+	if td, _ := exp.(client.TracerDelegate); td != nil {
+		clientOpts = append(clientOpts, client.WithTracerDelegate(td))
+	}
+
+	return client.New(ctx, "", clientOpts...)
 }
 
 func (d *Driver) Factory() driver.Factory {

--- a/driver/kubernetes/driver.go
+++ b/driver/kubernetes/driver.go
@@ -211,11 +211,17 @@ func (d *Driver) Client(ctx context.Context) (*client.Client, error) {
 		return nil, err
 	}
 
-	td, _ := exp.(client.TracerDelegate)
+	clientOpts := []client.ClientOpt{
+		client.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return conn, nil
+		}),
+	}
 
-	return client.New(ctx, "", client.WithContextDialer(func(context.Context, string) (net.Conn, error) {
-		return conn, nil
-	}), client.WithTracerDelegate(td))
+	if td, _ := exp.(client.TracerDelegate); td != nil {
+		clientOpts = append(clientOpts, client.WithTracerDelegate(td))
+	}
+
+	return client.New(ctx, "", clientOpts...)
 }
 
 func (d *Driver) Factory() driver.Factory {


### PR DESCRIPTION
There is no enforcing Exporter + TracerDelegate via type system nor by rigorous runtime checking.
Thus the code previously crashed since `withTracerDelegate` (nor any callers) check whether embedded `TracerDelegate` is `nil`.
Now only passes `withTracerDelegate` if it can actually be called.