### PR TITLE
bake: add named contexts keys

### DIFF
--- a/docs/reference/buildx_bake.md
+++ b/docs/reference/buildx_bake.md
@@ -339,7 +339,7 @@ target "db" {
 
 Complete list of valid target fields:
 
-`args`, `cache-from`, `cache-to`, `context`, `dockerfile`, `inherits`, `labels`,
+`args`, `cache-from`, `cache-to`, `context`, `contexts`, `dockerfile`, `inherits`, `labels`,
 `no-cache`, `output`, `platform`, `pull`, `secrets`, `ssh`, `tags`, `target`
 
 ### Global scope attributes

--- a/docs/reference/buildx_bake.md
+++ b/docs/reference/buildx_bake.md
@@ -799,6 +799,78 @@ $ docker buildx bake --print app
 }
 ```
 
+### Defining additional build contexts and linking targets
+
+In addition to the main `context` key that defines the build context each target can also define additional named contexts with a map defined with key `contexts`. These values map to the `--build-context` flag in the [build command](buildx_build.md#build-context).
+
+Inside the Dockerfile these contexts can be used with the `FROM` instruction or `--from` flag.
+
+The value can be a local source directory, container image (with docker-image:// prefix), Git URL, HTTP URL or a name of another target in the Bake file (with target: prefix).
+
+#### Pinning alpine image
+
+```Dockerfile
+# Dockerfile
+FROM alpine
+RUN echo "Hello world"
+```
+
+```hcl
+# docker-bake.hcl
+target "app" {
+    contexts = {
+        alpine = "docker-image://alpine:3.13"
+    }
+}
+```
+
+#### Using a secondary source directory
+
+```Dockerfile
+# Dockerfile
+
+FROM scratch AS src
+
+FROM golang
+COPY --from=src . .
+```
+
+```hcl
+# docker-bake.hcl
+target "app" {
+    contexts = {
+        src = "../path/to/source"
+    }
+}
+```
+
+#### Using a result of one target as a base image in another target
+
+To use a result of one target as a build context of another, specity the target name with `target:` prefix.
+
+```Dockerfile
+# Dockerfile
+FROM baseapp
+RUN echo "Hello world"
+```
+
+```hcl
+# docker-bake.hcl
+
+target "base" {
+    dockerfile = "baseapp.Dockerfile"
+}
+
+target "app" {
+    contexts = {
+        baseapp = "target:base"
+    }
+}
+```
+
+Please note that in most cases you should just use a single multi-stage Dockerfile with multiple targets for similar behavior. This case is recommended when you have multiple Dockerfiles that can't be easily merged into one.
+
+
 ### Extension field with Compose
 
 [Special extension](https://github.com/compose-spec/compose-spec/blob/master/spec.md#extension)

--- a/util/waitmap/waitmap.go
+++ b/util/waitmap/waitmap.go
@@ -1,0 +1,74 @@
+package waitmap
+
+import (
+	"context"
+	"sync"
+)
+
+type Map struct {
+	mu sync.RWMutex
+	m  map[string]interface{}
+	ch map[string]chan struct{}
+}
+
+func New() *Map {
+	return &Map{
+		m:  make(map[string]interface{}),
+		ch: make(map[string]chan struct{}),
+	}
+}
+
+func (m *Map) Set(key string, value interface{}) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.m[key] = value
+
+	if ch, ok := m.ch[key]; ok {
+		if ch != nil {
+			close(ch)
+		}
+	}
+	m.ch[key] = nil
+}
+
+func (m *Map) Get(ctx context.Context, keys ...string) (map[string]interface{}, error) {
+	if len(keys) == 0 {
+		return map[string]interface{}{}, nil
+	}
+
+	if len(keys) > 1 {
+		out := make(map[string]interface{})
+		for _, key := range keys {
+			mm, err := m.Get(ctx, key)
+			if err != nil {
+				return nil, err
+			}
+			out[key] = mm[key]
+		}
+		return out, nil
+	}
+
+	key := keys[0]
+	m.mu.Lock()
+	ch, ok := m.ch[key]
+	if !ok {
+		ch = make(chan struct{})
+		m.ch[key] = ch
+	}
+
+	if ch != nil {
+		m.mu.Unlock()
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ch:
+			m.mu.Lock()
+		}
+	}
+
+	res := m.m[key]
+	m.mu.Unlock()
+
+	return map[string]interface{}{key: res}, nil
+}

--- a/util/waitmap/waitmap_test.go
+++ b/util/waitmap/waitmap_test.go
@@ -1,0 +1,64 @@
+package waitmap
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAfter(t *testing.T) {
+	m := New()
+
+	m.Set("foo", "bar")
+	m.Set("bar", "baz")
+
+	ctx := context.TODO()
+	v, err := m.Get(ctx, "foo", "bar")
+	require.NoError(t, err)
+
+	require.Equal(t, 2, len(v))
+	require.Equal(t, "bar", v["foo"])
+	require.Equal(t, "baz", v["bar"])
+
+	v, err = m.Get(ctx, "foo")
+	require.NoError(t, err)
+	require.Equal(t, 1, len(v))
+	require.Equal(t, "bar", v["foo"])
+}
+
+func TestTimeout(t *testing.T) {
+	m := New()
+
+	m.Set("foo", "bar")
+
+	ctx, cancel := context.WithTimeout(context.TODO(), 100*time.Millisecond)
+	defer cancel()
+
+	_, err := m.Get(ctx, "bar")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, context.DeadlineExceeded))
+}
+
+func TestBlocking(t *testing.T) {
+	m := New()
+
+	m.Set("foo", "bar")
+
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		m.Set("bar", "baz")
+		time.Sleep(50 * time.Millisecond)
+		m.Set("baz", "abc")
+	}()
+
+	ctx := context.TODO()
+	v, err := m.Get(ctx, "foo", "bar", "baz")
+	require.NoError(t, err)
+	require.Equal(t, 3, len(v))
+	require.Equal(t, "bar", v["foo"])
+	require.Equal(t, "baz", v["bar"])
+	require.Equal(t, "abc", v["baz"])
+}


### PR DESCRIPTION
fixes #926

Enable using named contexts in bake targets. The naming is consistent with build args, and `--build-context` and `--build-arg` are similar and both take key-value pairts.

~Still working on creating contexts from other targets that is a bit complex. That can be a follow-up PR.~ Added to same PR. Targets can be linked with `target:` prefix.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>