### PR TITLE
bake: restrict target name

### DIFF
--- a/bake/bake_test.go
+++ b/bake/bake_test.go
@@ -788,3 +788,58 @@ group "default" {
 		})
 	}
 }
+
+func TestTargetName(t *testing.T) {
+	ctx := context.TODO()
+	cases := []struct {
+		target  string
+		wantErr bool
+	}{
+		{
+			target:  "a",
+			wantErr: false,
+		},
+		{
+			target:  "abc",
+			wantErr: false,
+		},
+		{
+			target:  "a/b",
+			wantErr: true,
+		},
+		{
+			target:  "a.b",
+			wantErr: true,
+		},
+		{
+			target:  "_a",
+			wantErr: false,
+		},
+		{
+			target:  "a_b",
+			wantErr: false,
+		},
+		{
+			target:  "AbC",
+			wantErr: false,
+		},
+		{
+			target:  "AbC-0123",
+			wantErr: false,
+		},
+	}
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.target, func(t *testing.T) {
+			_, _, err := ReadTargets(ctx, []File{{
+				Name: "docker-bake.hcl",
+				Data: []byte(`target "` + tt.target + `" {}`),
+			}}, []string{tt.target}, nil, nil)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/bake/compose.go
+++ b/bake/compose.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/compose-spec/compose-go/loader"
 	compose "github.com/compose-spec/compose-go/types"
+	"github.com/pkg/errors"
 )
 
 func parseCompose(dt []byte) (*compose.Project, error) {
@@ -57,6 +58,10 @@ func ParseCompose(dt []byte) (*Config, error) {
 					return nil, fmt.Errorf("compose file invalid: service %s has neither an image nor a build context specified. At least one must be provided", s.Name)
 				}
 				continue
+			}
+
+			if err = validateTargetName(s.Name); err != nil {
+				return nil, errors.Wrapf(err, "invalid service name %q", s.Name)
 			}
 
 			var contextPathP *string

--- a/bake/compose_test.go
+++ b/bake/compose_test.go
@@ -314,3 +314,55 @@ func newBool(val bool) *bool {
 	b := val
 	return &b
 }
+
+func TestServiceName(t *testing.T) {
+	cases := []struct {
+		svc     string
+		wantErr bool
+	}{
+		{
+			svc:     "a",
+			wantErr: false,
+		},
+		{
+			svc:     "abc",
+			wantErr: false,
+		},
+		{
+			svc:     "a.b",
+			wantErr: true,
+		},
+		{
+			svc:     "_a",
+			wantErr: false,
+		},
+		{
+			svc:     "a_b",
+			wantErr: false,
+		},
+		{
+			svc:     "AbC",
+			wantErr: false,
+		},
+		{
+			svc:     "AbC-0123",
+			wantErr: false,
+		},
+	}
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.svc, func(t *testing.T) {
+			_, err := ParseCompose([]byte(`
+services:
+  ` + tt.svc + `:
+    build:
+      context: .
+`))
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/bake/hcl.go
+++ b/bake/hcl.go
@@ -3,7 +3,7 @@ package bake
 import (
 	"strings"
 
-	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclparse"
 	"github.com/moby/buildkit/solver/errdefs"
 	"github.com/moby/buildkit/solver/pb"


### PR DESCRIPTION
fixes #888

This fix adds a restriction `[a-zA-Z0-9_-]+`
for target name. This is pretty much the same as the
container name restriction in moby.

___

```yaml
# docker-compose.yml
services:
  a.bc:
    build:
      context: .
```

```shell
$ docker buildx bake --print
error: invalid service name "a.bc": only "[a-zA-Z0-9_-]+" are allowed
```

___

```hcl
// docker-bake.hcl
group "default" {
  targets = ["a.bc"]
}

target "a.bc" {
  context = "."
}
```

```shell
$ docker buildx bake --print
docker-bake.hcl:5
--------------------
   3 |     }
   4 |
   5 | >>> target "a.bc" {
   6 |       context = "."
   7 |     }
--------------------
error: docker-bake.hcl:5,8-14: Invalid name; only "[a-zA-Z0-9_-]+" are allowed
```

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>