### PR TITLE
Relax to io.Writer requirement for NewPrinter

### DIFF
--- a/commands/bake.go
+++ b/commands/bake.go
@@ -76,7 +76,7 @@ func runBake(dockerCli command.Cli, targets []string, in bakeOptions) (err error
 
 	ctx2, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	printer := progress.NewPrinter(ctx2, os.Stderr, in.progress)
+	printer := progress.NewPrinter(ctx2, os.Stderr, os.Stderr, in.progress)
 
 	defer func() {
 		if printer != nil {

--- a/commands/build.go
+++ b/commands/build.go
@@ -239,7 +239,7 @@ func buildTargets(ctx context.Context, dockerCli command.Cli, opts map[string]bu
 	ctx2, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 
-	printer := progress.NewPrinter(ctx2, os.Stderr, progressMode)
+	printer := progress.NewPrinter(ctx2, os.Stderr, os.Stderr, progressMode)
 
 	resp, err := build.Build(ctx, dis, opts, dockerAPI(dockerCli), confutil.ConfigDir(dockerCli), printer)
 	err1 := printer.Wait()

--- a/commands/util.go
+++ b/commands/util.go
@@ -414,7 +414,7 @@ func boot(ctx context.Context, ngi *nginfo) (bool, error) {
 		return false, nil
 	}
 
-	printer := progress.NewPrinter(context.TODO(), os.Stderr, "auto")
+	printer := progress.NewPrinter(context.TODO(), os.Stderr, os.Stderr, "auto")
 
 	baseCtx := ctx
 	eg, _ := errgroup.WithContext(ctx)

--- a/util/progress/printer.go
+++ b/util/progress/printer.go
@@ -41,7 +41,7 @@ func (p *Printer) Warnings() []client.VertexWarning {
 	return p.warnings
 }
 
-func NewPrinter(ctx context.Context, out console.File, mode string) *Printer {
+func NewPrinter(ctx context.Context, w io.Writer, out console.File, mode string) *Printer {
 	statusCh := make(chan *client.SolveStatus)
 	doneCh := make(chan struct{})
 
@@ -56,7 +56,6 @@ func NewPrinter(ctx context.Context, out console.File, mode string) *Printer {
 
 	go func() {
 		var c console.Console
-		var w io.Writer = out
 		switch mode {
 		case PrinterModeQuiet:
 			w = ioutil.Discard


### PR DESCRIPTION
- Wanted to just provide `io.Writer` in the plain log output case