### PR TITLE
bake: additional support for named context on remote inputs

### DIFF
--- a/bake/bake_test.go
+++ b/bake/bake_test.go
@@ -386,8 +386,8 @@ func TestReadContexts(t *testing.T) {
 	ctxs := bo["app"].Inputs.NamedContexts
 	require.Equal(t, 2, len(ctxs))
 
-	require.Equal(t, "baz", ctxs["foo"])
-	require.Equal(t, "def", ctxs["abc"])
+	require.Equal(t, "baz", ctxs["foo"].Path)
+	require.Equal(t, "def", ctxs["abc"].Path)
 
 	m, _, err = ReadTargets(ctx, []File{fp}, []string{"app"}, []string{"app.contexts.foo=bay", "base.contexts.ghi=jkl"}, nil)
 	require.NoError(t, err)
@@ -402,9 +402,9 @@ func TestReadContexts(t *testing.T) {
 	ctxs = bo["app"].Inputs.NamedContexts
 	require.Equal(t, 3, len(ctxs))
 
-	require.Equal(t, "bay", ctxs["foo"])
-	require.Equal(t, "def", ctxs["abc"])
-	require.Equal(t, "jkl", ctxs["ghi"])
+	require.Equal(t, "bay", ctxs["foo"].Path)
+	require.Equal(t, "def", ctxs["abc"].Path)
+	require.Equal(t, "jkl", ctxs["ghi"].Path)
 
 	// test resetting base values
 	m, _, err = ReadTargets(ctx, []File{fp}, []string{"app"}, []string{"app.contexts.foo="}, nil)
@@ -419,7 +419,7 @@ func TestReadContexts(t *testing.T) {
 
 	ctxs = bo["app"].Inputs.NamedContexts
 	require.Equal(t, 1, len(ctxs))
-	require.Equal(t, "def", ctxs["abc"])
+	require.Equal(t, "def", ctxs["abc"].Path)
 }
 
 func TestReadContextFromTargetUnknown(t *testing.T) {

--- a/commands/build.go
+++ b/commands/build.go
@@ -480,11 +480,11 @@ func listToMap(values []string, defaultEnv bool) map[string]string {
 	return result
 }
 
-func parseContextNames(values []string) (map[string]string, error) {
+func parseContextNames(values []string) (map[string]build.NamedContext, error) {
 	if len(values) == 0 {
 		return nil, nil
 	}
-	result := make(map[string]string, len(values))
+	result := make(map[string]build.NamedContext, len(values))
 	for _, value := range values {
 		kv := strings.SplitN(value, "=", 2)
 		if len(kv) != 2 {
@@ -495,7 +495,7 @@ func parseContextNames(values []string) (map[string]string, error) {
 			return nil, errors.Wrapf(err, "invalid context name %s", kv[0])
 		}
 		name := strings.TrimSuffix(reference.FamiliarString(named), ":latest")
-		result[name] = kv[1]
+		result[name] = build.NamedContext{Path: kv[1]}
 	}
 	return result, nil
 }


### PR DESCRIPTION
- Update named context paths to be relative of remote inputs
- Add basic validation that named paths don't escape the current working directory when loaded from remote sources.