### PR TITLE
chore: use no-cache-filter for outdated stage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,8 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
       -
         name: Test
         run: |
@@ -102,6 +104,7 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
         with:
+          version: latest
           driver-opts: image=moby/buildkit:master
           buildkitd-flags: --debug
       -

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -52,6 +52,11 @@ jobs:
         uses: docker/setup-qemu-action@v1
         if: matrix.driver == 'docker' || matrix.driver == 'docker-container'
       -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+      -
         name: Install buildx
         run: |
           make install

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -28,6 +28,11 @@ jobs:
         name: Checkout
         uses: actions/checkout@v2
       -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+      -
         name: Run
         run: |
           make ${{ matrix.target }}
@@ -40,6 +45,11 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
       -
         name: Run
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.3
+# syntax=docker/dockerfile:1.4
 
 ARG GO_VERSION=1.17
 ARG DOCKERD_VERSION=20.10.8

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -89,11 +89,7 @@ target "mod-outdated" {
   inherits = ["_common"]
   dockerfile = "./hack/dockerfiles/vendor.Dockerfile"
   target = "outdated"
-  args = {
-    // used to invalidate cache for outdated run stage
-    // can be dropped when https://github.com/moby/buildkit/issues/1213 fixed
-    _RANDOM = uuidv4()
-  }
+  no-cache-filter = ["outdated"]
   output = ["type=cacheonly"]
 }
 

--- a/docs/reference/buildx_build.md
+++ b/docs/reference/buildx_build.md
@@ -429,7 +429,7 @@ Attribute keys:
 - `src`, `source` - Secret filename. `id` used if unset.
 
 ```dockerfile
-# syntax=docker/dockerfile:1.3
+# syntax=docker/dockerfile:1.4
 FROM python:3
 RUN pip install awscli
 RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
@@ -448,7 +448,7 @@ Attribute keys:
 - `env` - Secret environment variable. `id` used if unset, otherwise will look for `src`, `source` if `id` unset.
 
 ```dockerfile
-# syntax=docker/dockerfile:1.3
+# syntax=docker/dockerfile:1.4
 FROM node:alpine
 RUN --mount=type=bind,target=. \
   --mount=type=secret,id=SECRET_TOKEN \
@@ -480,7 +480,7 @@ authentication (e.g., cloning a private repository).
 Example to access Gitlab using an SSH agent socket:
 
 ```dockerfile
-# syntax=docker/dockerfile:1.3
+# syntax=docker/dockerfile:1.4
 FROM alpine
 RUN apk add --no-cache openssh-client
 RUN mkdir -p -m 0700 ~/.ssh && ssh-keyscan gitlab.com >> ~/.ssh/known_hosts

--- a/hack/dockerfiles/authors.Dockerfile
+++ b/hack/dockerfiles/authors.Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.3-labs
+# syntax=docker/dockerfile:1.4
 
 FROM alpine:3.14 AS gen
 RUN apk add --no-cache git

--- a/hack/dockerfiles/docs.Dockerfile
+++ b/hack/dockerfiles/docs.Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.3-labs
+# syntax=docker/dockerfile:1.4
 
 ARG GO_VERSION=1.17
 ARG FORMATS=md,yaml

--- a/hack/dockerfiles/lint.Dockerfile
+++ b/hack/dockerfiles/lint.Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.3
+# syntax=docker/dockerfile:1.4
 
 ARG GO_VERSION=1.17
 

--- a/hack/dockerfiles/vendor.Dockerfile
+++ b/hack/dockerfiles/vendor.Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.3-labs
+# syntax=docker/dockerfile:1.4
 
 ARG GO_VERSION=1.17
 ARG MODOUTDATED_VERSION=v0.8.0

--- a/hack/dockerfiles/vendor.Dockerfile
+++ b/hack/dockerfiles/vendor.Dockerfile
@@ -39,7 +39,6 @@ EOT
 
 FROM psampaz/go-mod-outdated:${MODOUTDATED_VERSION} AS go-mod-outdated
 FROM base AS outdated
-ARG _RANDOM
 RUN --mount=target=.,ro \
   --mount=target=/go/pkg/mod,type=cache \
   --mount=from=go-mod-outdated,source=/home/go-mod-outdated,target=/usr/bin/go-mod-outdated \


### PR DESCRIPTION
follow-up #919

needs to be addressed when 0.8 GA (and available on GitHub runners). Also update our dockerfiles to use edge frontend image.