### PR TITLE
build: fix multi-node builds with mixed platforms

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -189,6 +189,10 @@ func splitToDriverPairs(availablePlatforms map[string]int, opt map[string]Option
 			pp = append(pp, p)
 			mm[idx] = pp
 		}
+		// if no platform is specified, use first driver
+		if len(mm) == 0 {
+			mm[0] = nil
+		}
 		dps := make([]driverPair, 0, 2)
 		for idx, pp := range mm {
 			dps = append(dps, driverPair{driverIndex: idx, platforms: pp})


### PR DESCRIPTION
Fixes #978

This issue appears when building multiple targets with bake on a multi-node builder where some targets specify platforms and some don't.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>