### PR TITLE
bake: fix metadata output with named context

### DIFF
--- a/commands/bake.go
+++ b/commands/bake.go
@@ -157,6 +157,22 @@ func runBake(dockerCli command.Cli, targets []string, in bakeOptions) (err error
 					return err
 				}
 			}
+		} else if len(grps) == 1 {
+			if len(grps[0].Targets) == 1 {
+				if err := writeMetadataFile(in.metadataFile, decodeExporterResponse(resp[grps[0].Targets[0]].ExporterResponse)); err != nil {
+					return err
+				}
+			} else {
+				dt := make(map[string]interface{})
+				for _, t := range grps[0].Targets {
+					if r, ok := resp[t]; ok {
+						dt[t] = decodeExporterResponse(r.ExporterResponse)
+					}
+				}
+				if err := writeMetadataFile(in.metadataFile, dt); err != nil {
+					return err
+				}
+			}
 		} else {
 			dt := make(map[string]interface{})
 			for t, r := range resp {


### PR DESCRIPTION
while testing moby/buildkit#2684, I encountered an issue where metadata output using named context is not associated with its specified target correctly.

```Dockerfile
# base.Dockerfile
FROM alpine
ENV FOO=bar
ADD https://raw.githubusercontent.com/moby/moby/master/README.md /
RUN echo first > /out
```

```Dockerfile
# Dockerfile
FROM base AS build
RUN echo "foo is $FOO" > /foo
FROM busybox
COPY --from=build /foo /out /
```

Current behavior:

```console
$ docker buildx bake --metadata-file metadata.json --set *.args.foo=bar --set *.args.bar=foo app
$ cat metadata.json
```
```json
{
  "app": {
    "containerimage.buildinfo": {
      "frontend": "dockerfile.v0",
      "attrs": {
        "context:baseapp": "input:0-base",
        "filename": "Dockerfile",
        "source": "docker/dockerfile-upstream:master-labs"
      },
      "deps": {
        "0-base": {
          "frontend": "dockerfile.v0",
          "attrs": {
            "build-arg:basefoo": "bar",
            "filename": "baseapp.Dockerfile"
          },
          "sources": [
            {
              "type": "docker-image",
              "ref": "docker.io/library/alpine:3.15",
              "pin": "sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300"
            }
          ]
        }
      }
    }
  },
  "base": {
    "containerimage.buildinfo": {
      "frontend": "dockerfile.v0",
      "attrs": {
        "build-arg:basefoo": "bar",
        "filename": "baseapp.Dockerfile"
      },
      "sources": [
        {
          "type": "docker-image",
          "ref": "docker.io/library/alpine:3.15",
          "pin": "sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300"
        }
      ]
    }
  }
}
```

Here `base` target should not be displayed as it is used as named context for `app`. With this fix:

```console
$ docker buildx bake --metadata-file metadata.json --set *.args.foo=bar --set *.args.bar=foo app
$ cat metadata.json
```
```json
{
  "containerimage.buildinfo": {
    "frontend": "dockerfile.v0",
    "attrs": {
      "build-arg:bar": "foo",
      "build-arg:foo": "bar",
      "context:baseapp": "input:0-base",
      "filename": "Dockerfile"
    },
    "sources": [
      {
        "type": "docker-image",
        "ref": "docker.io/library/busybox:latest",
        "pin": "sha256:34c3559bbdedefd67195e766e38cfbb0fcabff4241dbee3f390fd6e3310f5ebc"
      },
      {
        "type": "http",
        "ref": "https://raw.githubusercontent.com/moby/moby/master/README.md",
        "pin": "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c"
      }
    ],
    "deps": {
      "0-base": {
        "frontend": "dockerfile.v0",
        "attrs": {
          "build-arg:bar": "foo",
          "build-arg:basefoo": "bar",
          "build-arg:foo": "bar",
          "filename": "baseapp.Dockerfile"
        },
        "sources": [
          {
            "type": "docker-image",
            "ref": "docker.io/library/alpine:latest",
            "pin": "sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300"
          }
        ]
      }
    }
  }
}
```

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>