### PR TITLE
bake: restore consistent output for metadata

### DIFF
--- a/commands/bake.go
+++ b/commands/bake.go
@@ -150,21 +150,13 @@ func runBake(dockerCli command.Cli, targets []string, in bakeOptions) (err error
 		return wrapBuildError(err, true)
 	}
 
-	if len(in.metadataFile) > 0 && resp != nil {
-		if len(resp) == 1 {
-			for _, r := range resp {
-				if err := writeMetadataFile(in.metadataFile, decodeExporterResponse(r.ExporterResponse)); err != nil {
-					return err
-				}
-			}
-		} else {
-			dt := make(map[string]interface{})
-			for t, r := range resp {
-				dt[t] = decodeExporterResponse(r.ExporterResponse)
-			}
-			if err := writeMetadataFile(in.metadataFile, dt); err != nil {
-				return err
-			}
+	if len(in.metadataFile) > 0 {
+		dt := make(map[string]interface{})
+		for t, r := range resp {
+			dt[t] = decodeExporterResponse(r.ExporterResponse)
+		}
+		if err := writeMetadataFile(in.metadataFile, dt); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
Metadata formatting should not depend on the number
of targets.

Reverts this change from https://github.com/docker/buildx/pull/946/files#diff-3f9c21dce82a82fae6d5ca096e77e5ddcf0eccd7051f815b452ec26fbfeb314bR154

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>