### PR TITLE
build: allow external Dockerfile on remote context

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -1164,7 +1164,7 @@ func LoadInputs(ctx context.Context, d driver.Driver, inp Inputs, pw progress.Wr
 
 	case urlutil.IsGitURL(inp.ContextPath), urlutil.IsURL(inp.ContextPath):
 		if inp.DockerfilePath == "-" {
-			return nil, errors.Errorf("Dockerfile from stdin is not supported with remote contexts")
+			dockerfileReader = inp.InStream
 		}
 		target.FrontendAttrs["context"] = inp.ContextPath
 	default:


### PR DESCRIPTION
Support Dockerfile from stdin ~or a local file~ with remote contexts. Fixes https://github.com/moby/moby/issues/38254 now that buildx is the only BuildKit client included in the Docker CLI (https://github.com/docker/cli/pull/3314).

Support for external Dockerfile on remote contexts was added to BuildKit in https://github.com/moby/buildkit/pull/947, which is included in the BuildKit v0.5.0 release and first vendored into Moby in https://github.com/moby/moby/pull/39132, included in v19.03.0. The client side was the only missing piece.