### PR TITLE
Remove uses of deprecated io/ioutil

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - gofmt
     - govet
     - deadcode
+    - depguard
     - goimports
     - ineffassign
     - misspell
@@ -22,6 +23,15 @@ linters:
     - typecheck
     - structcheck
   disable-all: true
+
+linters-settings:
+  depguard:
+    list-type: blacklist
+    include-go-root: true
+    packages:
+      # The io/ioutil package has been deprecated.
+      # https://go.dev/doc/go1.16#ioutil
+      - io/ioutil
 
 issues:
   exclude-rules:

--- a/bake/bake.go
+++ b/bake/bake.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/csv"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -65,12 +65,12 @@ func ReadLocalFiles(names []string) ([]File, error) {
 		var dt []byte
 		var err error
 		if n == "-" {
-			dt, err = ioutil.ReadAll(os.Stdin)
+			dt, err = io.ReadAll(os.Stdin)
 			if err != nil {
 				return nil, err
 			}
 		} else {
-			dt, err = ioutil.ReadFile(n)
+			dt, err = os.ReadFile(n)
 			if err != nil {
 				if isDefault && errors.Is(err, os.ErrNotExist) {
 					continue

--- a/build/build.go
+++ b/build/build.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -771,7 +770,7 @@ func Build(ctx context.Context, drivers []DriverInfo, opt map[string]Options, do
 						dgst = v
 					}
 					if opt.ImageIDFile != "" {
-						return ioutil.WriteFile(opt.ImageIDFile, []byte(dgst), 0644)
+						return os.WriteFile(opt.ImageIDFile, []byte(dgst), 0644)
 					}
 					return nil
 				}
@@ -820,7 +819,7 @@ func Build(ctx context.Context, drivers []DriverInfo, opt map[string]Options, do
 								return err
 							}
 							if opt.ImageIDFile != "" {
-								if err := ioutil.WriteFile(opt.ImageIDFile, []byte(desc.Digest), 0644); err != nil {
+								if err := os.WriteFile(opt.ImageIDFile, []byte(desc.Digest), 0644); err != nil {
 									return err
 								}
 							}
@@ -1086,7 +1085,7 @@ func remoteDigestWithMoby(ctx context.Context, d driver.Driver, name string) (st
 }
 
 func createTempDockerfile(r io.Reader) (string, error) {
-	dir, err := ioutil.TempDir("", "dockerfile")
+	dir, err := os.MkdirTemp("", "dockerfile")
 	if err != nil {
 		return "", err
 	}
@@ -1145,7 +1144,7 @@ func LoadInputs(ctx context.Context, d driver.Driver, inp Inputs, pw progress.Wr
 				}
 				// stdin is dockerfile
 				dockerfileReader = buf
-				inp.ContextPath, _ = ioutil.TempDir("", "empty-dir")
+				inp.ContextPath, _ = os.MkdirTemp("", "empty-dir")
 				toRemove = append(toRemove, inp.ContextPath)
 				target.LocalDirs["context"] = inp.ContextPath
 			}
@@ -1464,13 +1463,13 @@ func tryNodeIdentifier(configDir string) (out string) {
 			if _, err := rand.Read(b); err != nil {
 				return out
 			}
-			if err := ioutil.WriteFile(sessionFile, []byte(hex.EncodeToString(b)), 0600); err != nil {
+			if err := os.WriteFile(sessionFile, []byte(hex.EncodeToString(b)), 0600); err != nil {
 				return out
 			}
 		}
 	}
 
-	dt, err := ioutil.ReadFile(sessionFile)
+	dt, err := os.ReadFile(sessionFile)
 	if err == nil {
 		return string(dt)
 	}

--- a/build/url.go
+++ b/build/url.go
@@ -2,7 +2,7 @@ package build
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/docker/buildx/driver"
@@ -53,11 +53,11 @@ func createTempDockerfileFromURL(ctx context.Context, d driver.Driver, url strin
 		if err != nil {
 			return nil, err
 		}
-		dir, err := ioutil.TempDir("", "buildx")
+		dir, err := os.MkdirTemp("", "buildx")
 		if err != nil {
 			return nil, err
 		}
-		if err := ioutil.WriteFile(filepath.Join(dir, "Dockerfile"), dt, 0600); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), dt, 0600); err != nil {
 			return nil, err
 		}
 		out = dir

--- a/commands/imagetools/create.go
+++ b/commands/imagetools/create.go
@@ -3,7 +3,7 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/docker/buildx/store"
@@ -38,7 +38,7 @@ func runCreate(dockerCli command.Cli, in createOptions, args []string) error {
 
 	fileArgs := make([]string, len(in.files))
 	for i, f := range in.files {
-		dt, err := ioutil.ReadFile(f)
+		dt, err := os.ReadFile(f)
 		if err != nil {
 			return err
 		}

--- a/driver/docker-container/driver.go
+++ b/driver/docker-container/driver.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"
@@ -90,7 +89,7 @@ func (d *Driver) create(ctx context.Context, l progress.SubLogger) error {
 		if err != nil {
 			return err
 		}
-		_, err = io.Copy(ioutil.Discard, rc)
+		_, err = io.Copy(io.Discard, rc)
 		return err
 	}); err != nil {
 		// image pulling failed, check if it exists in local image store.

--- a/driver/kubernetes/context/endpoint_test.go
+++ b/driver/kubernetes/context/endpoint_test.go
@@ -1,7 +1,6 @@
 package context
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -42,7 +41,7 @@ var testStoreCfg = store.NewConfig(
 )
 
 func TestSaveLoadContexts(t *testing.T) {
-	storeDir, err := ioutil.TempDir("", "test-load-save-k8-context")
+	storeDir, err := os.MkdirTemp("", "test-load-save-k8-context")
 	require.NoError(t, err)
 	defer os.RemoveAll(storeDir)
 	store := store.New(storeDir, testStoreCfg)
@@ -50,7 +49,7 @@ func TestSaveLoadContexts(t *testing.T) {
 	require.NoError(t, save(store, testEndpoint("https://test", "test", nil, nil, nil, true), "raw-notls-skip"))
 	require.NoError(t, save(store, testEndpoint("https://test", "test", []byte("ca"), []byte("cert"), []byte("key"), true), "raw-tls"))
 
-	kcFile, err := ioutil.TempFile(os.TempDir(), "test-load-save-k8-context")
+	kcFile, err := os.CreateTemp(os.TempDir(), "test-load-save-k8-context")
 	require.NoError(t, err)
 	defer os.Remove(kcFile.Name())
 	defer kcFile.Close()
@@ -147,7 +146,7 @@ func save(s store.Writer, ep Endpoint, name string) error {
 }
 
 func TestSaveLoadGKEConfig(t *testing.T) {
-	storeDir, err := ioutil.TempDir("", t.Name())
+	storeDir, err := os.MkdirTemp("", t.Name())
 	require.NoError(t, err)
 	defer os.RemoveAll(storeDir)
 	store := store.New(storeDir, testStoreCfg)
@@ -172,7 +171,7 @@ func TestSaveLoadGKEConfig(t *testing.T) {
 }
 
 func TestSaveLoadEKSConfig(t *testing.T) {
-	storeDir, err := ioutil.TempDir("", t.Name())
+	storeDir, err := os.MkdirTemp("", t.Name())
 	require.NoError(t, err)
 	defer os.RemoveAll(storeDir)
 	store := store.New(storeDir, testStoreCfg)
@@ -197,7 +196,7 @@ func TestSaveLoadEKSConfig(t *testing.T) {
 }
 
 func TestSaveLoadK3SConfig(t *testing.T) {
-	storeDir, err := ioutil.TempDir("", t.Name())
+	storeDir, err := os.MkdirTemp("", t.Name())
 	require.NoError(t, err)
 	defer os.RemoveAll(storeDir)
 	store := store.New(storeDir, testStoreCfg)

--- a/driver/kubernetes/context/save.go
+++ b/driver/kubernetes/context/save.go
@@ -1,7 +1,7 @@
 package context
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/docker/cli/cli/context"
 	"k8s.io/client-go/tools/clientcmd"
@@ -63,7 +63,7 @@ func FromKubeConfig(kubeconfig, kubeContext, namespaceOverride string) (Endpoint
 
 func readFileOrDefault(path string, defaultValue []byte) ([]byte, error) {
 	if path != "" {
-		return ioutil.ReadFile(path)
+		return os.ReadFile(path)
 	}
 	return defaultValue, nil
 }

--- a/driver/manager.go
+++ b/driver/manager.go
@@ -2,7 +2,7 @@ package driver
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -40,7 +40,7 @@ func (k KubeClientConfigInCluster) ClientConfig() (*rest.Config, error) {
 }
 
 func (k KubeClientConfigInCluster) Namespace() (string, bool, error) {
-	namespace, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	namespace, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 	if err != nil {
 		return "", false, err
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -46,7 +45,7 @@ type Txn struct {
 
 func (t *Txn) List() ([]*NodeGroup, error) {
 	pp := filepath.Join(t.s.root, "instances")
-	fis, err := ioutil.ReadDir(pp)
+	fis, err := os.ReadDir(pp)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +74,7 @@ func (t *Txn) NodeGroupByName(name string) (*NodeGroup, error) {
 	if err != nil {
 		return nil, err
 	}
-	dt, err := ioutil.ReadFile(filepath.Join(t.s.root, "instances", name))
+	dt, err := os.ReadFile(filepath.Join(t.s.root, "instances", name))
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +143,7 @@ func (t *Txn) reset(key string) error {
 }
 
 func (t *Txn) Current(key string) (*NodeGroup, error) {
-	dt, err := ioutil.ReadFile(filepath.Join(t.s.root, "current"))
+	dt, err := os.ReadFile(filepath.Join(t.s.root, "current"))
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return nil, err
@@ -175,7 +174,7 @@ func (t *Txn) Current(key string) (*NodeGroup, error) {
 
 	h := toHash(key)
 
-	dt, err = ioutil.ReadFile(filepath.Join(t.s.root, "defaults", h))
+	dt, err = os.ReadFile(filepath.Join(t.s.root, "defaults", h))
 	if err != nil {
 		if os.IsNotExist(err) {
 			t.reset(key)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -12,7 +11,7 @@ import (
 
 func TestEmptyStartup(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := ioutil.TempDir("", "buildx-store")
+	tmpdir, err := os.MkdirTemp("", "buildx-store")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -30,7 +29,7 @@ func TestEmptyStartup(t *testing.T) {
 
 func TestNodeLocking(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := ioutil.TempDir("", "buildx-store")
+	tmpdir, err := os.MkdirTemp("", "buildx-store")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -65,7 +64,7 @@ func TestNodeLocking(t *testing.T) {
 
 func TestNodeManagement(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := ioutil.TempDir("", "buildx-store")
+	tmpdir, err := os.MkdirTemp("", "buildx-store")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 

--- a/util/logutil/filter.go
+++ b/util/logutil/filter.go
@@ -1,7 +1,7 @@
 package logutil
 
 import (
-	"io/ioutil"
+	"io"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -9,7 +9,7 @@ import (
 
 func NewFilter(levels []logrus.Level, filters ...string) logrus.Hook {
 	dl := logrus.New()
-	dl.SetOutput(ioutil.Discard)
+	dl.SetOutput(io.Discard)
 	return &logsFilter{
 		levels:        levels,
 		filters:       filters,

--- a/util/progress/fromreader.go
+++ b/util/progress/fromreader.go
@@ -2,7 +2,6 @@ package progress
 
 import (
 	"io"
-	"io/ioutil"
 	"time"
 
 	"github.com/moby/buildkit/client"
@@ -24,7 +23,7 @@ func FromReader(w Writer, name string, rc io.ReadCloser) {
 		Vertexes: []*client.Vertex{&vtx},
 	})
 
-	_, err := io.Copy(ioutil.Discard, rc)
+	_, err := io.Copy(io.Discard, rc)
 
 	tm2 := time.Now()
 	vtx2 := vtx

--- a/util/progress/printer.go
+++ b/util/progress/printer.go
@@ -3,7 +3,6 @@ package progress
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 	"sync"
 
@@ -88,7 +87,7 @@ func NewPrinter(ctx context.Context, w io.Writer, out console.File, mode string)
 		var c console.Console
 		switch mode {
 		case PrinterModeQuiet:
-			w = ioutil.Discard
+			w = io.Discard
 		case PrinterModeAuto, PrinterModeTty:
 			if cons, err := console.ConsoleFromFile(out); err == nil {
 				c = cons


### PR DESCRIPTION
The package has been deprecated since Go 1.16: https://go.dev/doc/go1.16#ioutil