### PR TITLE
[v0.8] bake: allow dot in target names for compose

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -28,8 +28,10 @@ var (
 	httpPrefix                   = regexp.MustCompile(`^https?://`)
 	gitURLPathWithFragmentSuffix = regexp.MustCompile(`\.git(?:#.+)?$`)
 
-	validTargetNameChars = `[a-zA-Z0-9_-]+`
-	targetNamePattern    = regexp.MustCompile(`^` + validTargetNameChars + `$`)
+	validTargetNameChars        = `[a-zA-Z0-9_-]+`
+	validTargetNameCharsCompose = `[a-zA-Z0-9._-]+`
+	targetNamePattern           = regexp.MustCompile(`^` + validTargetNameChars + `$`)
+	targetNamePatternCompose    = regexp.MustCompile(`^` + validTargetNameCharsCompose + `$`)
 )
 
 type File struct {
@@ -964,6 +966,13 @@ func parseOutputType(str string) string {
 func validateTargetName(name string) error {
 	if !targetNamePattern.MatchString(name) {
 		return errors.Errorf("only %q are allowed", validTargetNameChars)
+	}
+	return nil
+}
+
+func validateTargetNameCompose(name string) error {
+	if !targetNamePatternCompose.MatchString(name) {
+		return errors.Errorf("only %q are allowed", validTargetNameCharsCompose)
 	}
 	return nil
 }

--- a/bake/compose.go
+++ b/bake/compose.go
@@ -60,7 +60,7 @@ func ParseCompose(dt []byte) (*Config, error) {
 				continue
 			}
 
-			if err = validateTargetName(s.Name); err != nil {
+			if err = validateTargetNameCompose(s.Name); err != nil {
 				return nil, errors.Wrapf(err, "invalid service name %q", s.Name)
 			}
 

--- a/bake/compose_test.go
+++ b/bake/compose_test.go
@@ -330,6 +330,10 @@ func TestServiceName(t *testing.T) {
 		},
 		{
 			svc:     "a.b",
+			wantErr: false,
+		},
+		{
+			svc:     "a?b",
 			wantErr: true,
 		},
 		{


### PR DESCRIPTION
This is a hotfix for v0.8 to unblock release and
restore backward compatibility. More proper fix
coming later.

replaces #1012

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>