### PR TITLE
chore: github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,137 @@
+# https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema
+name: Bug Report
+description: Report a bug
+labels:
+  - kind/bug
+  - status/triage
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to report a bug!
+        If this is a security issue please report it to the [Docker Security team](mailto:security@docker.com).
+
+  - type: checkboxes
+    attributes:
+      label: Contributing guidelines
+      description: |
+        Please read the contributing guidelines before proceeding.
+      options:
+        - label: I've read the [contributing guidelines](https://github.com/docker/buildx/blob/master/.github/CONTRIBUTING.md) and wholeheartedly agree
+          required: true
+
+  - type: checkboxes
+    attributes:
+      label: I've found a bug and checked that ...
+      description: |
+        Make sure that your request fulfills all of the following requirements.
+        If one requirement cannot be satisfied, explain in detail why.
+      options:
+        - label: ... the documentation does not mention anything about my problem
+        - label: ... there are no open or closed issues that are related to my problem
+
+  - type: textarea
+    attributes:
+      label: Description
+      description: |
+        Please provide a brief description of the bug in 1-2 sentences.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Expected behaviour
+      description: |
+        Please describe precisely what you'd expect to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Actual behaviour
+      description: |
+        Please describe precisely what is actually happening.
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Buildx version
+      description: |
+        Can be found using the `docker buildx version` command.
+        Example: `github.com/docker/buildx v0.8.1 5fac64c2c49dae1320f2b51f1a899ca451935554`
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Docker info
+      description: |
+        Output of `docker info`.
+      placeholder: |
+        ```
+        
+        ```
+      render: markdown
+
+  - type: textarea
+    attributes:
+      label: Builders list
+      description: |
+        Output of `docker buildx ls`.
+      placeholder: |
+        ```
+        
+        ```
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Configuration
+      description: |
+        Please provide a minimal Dockerfile, bake definition (if applicable) and invoked command to reproduce the bug.
+      placeholder: |
+        ```dockerfile
+        FROM alpine
+        echo hello
+        ```
+        
+        ```hcl
+        group "default" {
+          targets = ["app"]
+        }
+        target "app" {
+          dockerfile = "Dockerfile"
+          target = "build"
+        }
+        ```
+        
+        ```console
+        $ docker buildx build .
+        $ docker buildx bake
+        ```
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Logs
+      description: |
+        Please provide Buildx logs (also BuildKit logs if applicable).
+      placeholder: |
+        ```
+        
+        ```
+      render: markdown
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Additional info
+      description: |
+        Please provide any additional information that could be useful.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,12 @@
+# https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
+blank_issues_enabled: true
+contact_links:
+  - name: Questions and Discussions
+    url: https://github.com/docker/buildx/discussions/new
+    about: Use Github Discussions to ask questions and/or open discussion topics.
+  - name: Command line reference
+    url: https://docs.docker.com/engine/reference/commandline/buildx/
+    about: Read the command line reference.
+  - name: Documentation
+    url: https://docs.docker.com/build/
+    about: Read the documentation.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,15 @@
+# https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema
+name: Feature request
+description: Missing functionality? Come tell us about it!
+labels:
+  - kind/enhancement
+  - status/triage
+
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What is the feature you want to see?
+    validations:
+      required: true

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,12 @@
+# Reporting security issues
+
+The project maintainers take security seriously. If you discover a security
+issue, please bring it to their attention right away!
+
+**Please _DO NOT_ file a public issue**, instead send your report privately to
+[security@docker.com](mailto:security@docker.com).
+
+Security reports are greatly appreciated, and we will publicly thank you for it.
+We also like to send gifts&mdash;if you're into schwag, make sure to let
+us know. We currently do not offer a paid security bounty program, but are not
+ruling it out in the future.


### PR DESCRIPTION
adds a bug report [issue forms template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms).

will look like this:

![image](https://user-images.githubusercontent.com/1951866/221167061-9f907483-504f-4096-b872-ef901e465ca4.png)

___

![image](https://user-images.githubusercontent.com/1951866/165976940-f9174ac8-7a3b-4e0a-9c9b-2f173c63a954.png)

![image](https://user-images.githubusercontent.com/1951866/165976968-ed72a1b9-9f9d-4259-978d-0a7aeed5eae4.png)

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>