### PR TITLE
feat: add tolerations handling to kubernetes driver

### DIFF
--- a/docs/reference/buildx_create.md
+++ b/docs/reference/buildx_create.md
@@ -140,6 +140,7 @@ Passes additional driver-specific options. Details for each driver:
   - `limits.cpu` - Sets the limit CPU value specified in units of Kubernetes CPU. Example `limits.cpu=100m`, `limits.cpu=2`
   - `limits.memory` - Sets the limit memory value specified in bytes or with a valid suffix. Example `limits.memory=500Mi`, `limits.memory=4G`
   - `nodeselector="label1=value1,label2=value2"` - Sets the kv of `Pod` nodeSelector. No Defaults. Example `nodeselector=kubernetes.io/arch=arm64`
+  - `tolerations="key=foo,value=bar;key=foo2,operator=exists;key=foo3,effect=NoSchedule"` - Sets the `Pod` tolerations. Accepts the same values as the kube manifest tolerations. Key-value pairs are separated by `,`, tolerations are separated by `;`. No Defaults. Example `tolerations=operator=exists`
   - `rootless=(true|false)` - Run the container as a non-root user without `securityContext.privileged`. [Using Ubuntu host kernel is recommended](https://github.com/moby/buildkit/blob/master/docs/rootless.md). Defaults to false.
   - `loadbalance=(sticky|random)` - Load-balancing strategy. If set to "sticky", the pod is chosen using the hash of the context path. Defaults to "sticky"
   - `qemu.install=(true|false)` - Install QEMU emulation for multi platforms support.

--- a/driver/kubernetes/manifest/manifest.go
+++ b/driver/kubernetes/manifest/manifest.go
@@ -32,6 +32,7 @@ type DeploymentOpt struct {
 
 	Rootless       bool
 	NodeSelector   map[string]string
+	Tolerations    []corev1.Toleration
 	RequestsCPU    string
 	RequestsMemory string
 	LimitsCPU      string
@@ -157,6 +158,10 @@ func NewDeployment(opt *DeploymentOpt) (d *appsv1.Deployment, c []*corev1.Config
 
 	if len(opt.NodeSelector) > 0 {
 		d.Spec.Template.Spec.NodeSelector = opt.NodeSelector
+	}
+
+	if len(opt.Tolerations) > 0 {
+		d.Spec.Template.Spec.Tolerations = opt.Tolerations
 	}
 
 	if opt.RequestsCPU != "" {


### PR DESCRIPTION
This PR is to add support for Kubernetes tolerations. Should support all current tolerations options and adding multiple tolerations. This should cover the use cases listed in #377, but it doesn't add the full manifests support.

Adding full support to manifests would be a much more flexible option, but this should solve the main pain points listed in that ticket.
