### PR TITLE
vendor: v20.10.3-0.20220803220330-418ca3b4d46f (v22.06.0-dev)

### DIFF
--- a/driver/kubernetes/context/load_test.go
+++ b/driver/kubernetes/context/load_test.go
@@ -5,18 +5,15 @@ import (
 	"testing"
 
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/cli/cli/config/configfile"
 	cliflags "github.com/docker/cli/cli/flags"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestDefaultContextInitializer(t *testing.T) {
-	cli, err := command.NewDockerCli()
-	require.NoError(t, err)
 	os.Setenv("KUBECONFIG", "./fixtures/test-kubeconfig")
 	defer os.Unsetenv("KUBECONFIG")
-	ctx, err := command.ResolveDefaultContext(&cliflags.CommonOptions{}, &configfile.ConfigFile{}, command.DefaultContextStoreConfig(), cli.Err())
+	ctx, err := command.ResolveDefaultContext(&cliflags.CommonOptions{}, command.DefaultContextStoreConfig())
 	require.NoError(t, err)
 	assert.Equal(t, "default", ctx.Meta.Name)
 	assert.Equal(t, "zoinx", ctx.Meta.Endpoints[KubernetesEndpoint].(EndpointMeta).DefaultNamespace)

--- a/go.mod
+++ b/go.mod
@@ -155,7 +155,7 @@ require (
 )
 
 replace (
-	github.com/docker/cli => github.com/docker/cli v20.10.3-0.20220721163225-f1615facb1ca+incompatible // master (v22.06-dev)
+	github.com/docker/cli => github.com/docker/cli v20.10.3-0.20220803220330-418ca3b4d46f+incompatible // master (v22.06-dev)
 	github.com/docker/docker => github.com/docker/docker v20.10.3-0.20220720171342-a60b458179aa+incompatible // 22.06 branch (v22.06-dev)
 	k8s.io/api => k8s.io/api v0.22.4
 	k8s.io/apimachinery => k8s.io/apimachinery v0.22.4

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/distribution/distribution/v3 v3.0.0-20220725133111-4bf3547399eb h1:oCCuuU3kMO3sjZH/p7LamvQNW9SWoT4yQuMGcdSxGAE=
 github.com/distribution/distribution/v3 v3.0.0-20220725133111-4bf3547399eb/go.mod h1:28YO/VJk9/64+sTGNuYaBjWxrXTPrj0C0XmgTIOjxX4=
-github.com/docker/cli v20.10.3-0.20220721163225-f1615facb1ca+incompatible h1:Dd/CSOpM6U0thw3xNPlw6m+5/4VOexEcgKlL38haGgk=
-github.com/docker/cli v20.10.3-0.20220721163225-f1615facb1ca+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v20.10.3-0.20220803220330-418ca3b4d46f+incompatible h1:iKanFYBu6Cum7d9j8JGTw2s/d7hUAcXRkEcp2m8b6Qc=
+github.com/docker/cli v20.10.3-0.20220803220330-418ca3b4d46f+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli-docs-tool v0.5.0 h1:EjGwI6EyB7YemHCC7R8mwXszJTbuq0T0pFuDC5bMhcE=
 github.com/docker/cli-docs-tool v0.5.0/go.mod h1:zMjqTFCU361PRh8apiXzeAZ1Q/xupbIwTusYpzCXS/o=
 github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=

--- a/vendor/github.com/docker/cli/cli/command/cli_options.go
+++ b/vendor/github.com/docker/cli/cli/command/cli_options.go
@@ -1,13 +1,10 @@
 package command
 
 import (
-	"fmt"
 	"io"
 	"os"
 	"strconv"
 
-	"github.com/docker/cli/cli/context/docker"
-	"github.com/docker/cli/cli/context/store"
 	"github.com/docker/cli/cli/streams"
 	"github.com/moby/term"
 )
@@ -78,19 +75,6 @@ func WithContentTrustFromEnv() DockerCliOption {
 func WithContentTrust(enabled bool) DockerCliOption {
 	return func(cli *DockerCli) error {
 		cli.contentTrust = enabled
-		return nil
-	}
-}
-
-// WithContextEndpointType add support for an additional typed endpoint in the context store
-// Plugins should use this to store additional endpoints configuration in the context store
-func WithContextEndpointType(endpointName string, endpointType store.TypeGetter) DockerCliOption {
-	return func(cli *DockerCli) error {
-		switch endpointName {
-		case docker.DockerEndpoint:
-			return fmt.Errorf("cannot change %q endpoint type", endpointName)
-		}
-		cli.contextStoreConfig.SetEndpoint(endpointName, endpointType)
 		return nil
 	}
 }

--- a/vendor/github.com/docker/cli/cli/command/defaultcontextstore.go
+++ b/vendor/github.com/docker/cli/cli/command/defaultcontextstore.go
@@ -2,9 +2,7 @@ package command
 
 import (
 	"fmt"
-	"io"
 
-	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/context/docker"
 	"github.com/docker/cli/cli/context/store"
 	cliflags "github.com/docker/cli/cli/flags"
@@ -45,7 +43,7 @@ type EndpointDefaultResolver interface {
 }
 
 // ResolveDefaultContext creates a Metadata for the current CLI invocation parameters
-func ResolveDefaultContext(opts *cliflags.CommonOptions, config *configfile.ConfigFile, storeconfig store.Config, stderr io.Writer) (*DefaultContext, error) {
+func ResolveDefaultContext(opts *cliflags.CommonOptions, config store.Config) (*DefaultContext, error) {
 	contextTLSData := store.ContextTLSData{
 		Endpoints: make(map[string]store.EndpointTLSData),
 	}
@@ -66,7 +64,7 @@ func ResolveDefaultContext(opts *cliflags.CommonOptions, config *configfile.Conf
 		contextTLSData.Endpoints[docker.DockerEndpoint] = *dockerEP.TLSData.ToStoreTLSData()
 	}
 
-	if err := storeconfig.ForeachEndpointType(func(n string, get store.TypeGetter) error {
+	if err := config.ForeachEndpointType(func(n string, get store.TypeGetter) error {
 		if n == docker.DockerEndpoint { // handled above
 			return nil
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -117,7 +117,7 @@ github.com/davecgh/go-spew/spew
 ## explicit; go 1.18
 github.com/distribution/distribution/v3/digestset
 github.com/distribution/distribution/v3/reference
-# github.com/docker/cli v20.10.17+incompatible => github.com/docker/cli v20.10.3-0.20220721163225-f1615facb1ca+incompatible
+# github.com/docker/cli v20.10.17+incompatible => github.com/docker/cli v20.10.3-0.20220803220330-418ca3b4d46f+incompatible
 ## explicit
 github.com/docker/cli/cli
 github.com/docker/cli/cli-plugins/manager
@@ -1010,7 +1010,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# github.com/docker/cli => github.com/docker/cli v20.10.3-0.20220721163225-f1615facb1ca+incompatible
+# github.com/docker/cli => github.com/docker/cli v20.10.3-0.20220803220330-418ca3b4d46f+incompatible
 # github.com/docker/docker => github.com/docker/docker v20.10.3-0.20220720171342-a60b458179aa+incompatible
 # k8s.io/api => k8s.io/api v0.22.4
 # k8s.io/apimachinery => k8s.io/apimachinery v0.22.4


### PR DESCRIPTION
(checking if ~https://github.com/docker/cli/pull/3510~ https://github.com/docker/cli/pull/3715 doesn't
break anything)

vendor: v20.10.3-0.20220803220330-418ca3b4d46f (v22.06.0-dev)

full diff: https://github.com/docker/cli/compare/f1615facb1ca...418ca3b4d46fed752d771cf96483664a631d8197

relevant changes;

- cli/command: remove unused args from ResolveDefaultContext()
- consider empty DOCKER_HOST and DOCKER_CONTEXT env-vars equivalent to "not set"
- cli: set timeout connection ping on sockets as well



