### PR TITLE
Add --frontend flag

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -63,6 +63,7 @@ type Options struct {
 	CgroupParent  string
 	Exports       []client.ExportEntry
 	ExtraHosts    []string
+	Frontend      string
 	ImageIDFile   string
 	Labels        map[string]string
 	NetworkMode   string
@@ -413,6 +414,11 @@ func toSolveOpt(ctx context.Context, di DriverInfo, multiDriver bool, opt Option
 		CacheExports:        cacheTo,
 		CacheImports:        cacheFrom,
 		AllowedEntitlements: opt.Allow,
+	}
+
+	if opt.Frontend != "" {
+		so.Frontend = "gateway.v0"
+		so.FrontendAttrs["source"] = opt.Frontend
 	}
 
 	if opt.CgroupParent != "" {

--- a/commands/build.go
+++ b/commands/build.go
@@ -50,6 +50,7 @@ type buildOptions struct {
 	cgroupParent  string
 	contexts      []string
 	extraHosts    []string
+	frontend      string
 	imageIDFile   string
 	labels        []string
 	networkMode   string
@@ -125,6 +126,7 @@ func runBuild(dockerCli command.Cli, in buildOptions) (err error) {
 		BuildArgs:     listToMap(in.buildArgs, true),
 		ExtraHosts:    in.extraHosts,
 		ImageIDFile:   in.imageIDFile,
+		Frontend:      in.frontend,
 		Labels:        listToMap(in.labels, false),
 		NetworkMode:   in.networkMode,
 		NoCache:       noCache,
@@ -358,6 +360,8 @@ func buildCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 	flags.SetAnnotation("file", annotation.ExternalURL, []string{"https://docs.docker.com/engine/reference/commandline/build/#specify-a-dockerfile--f"})
 
 	flags.StringVar(&options.imageIDFile, "iidfile", "", "Write the image ID to the file")
+
+	flags.StringVar(&options.frontend, "frontend", "", "Set custom frontend to use for build")
 
 	flags.StringArrayVar(&options.labels, "label", []string{}, "Set metadata for an image")
 

--- a/docs/reference/buildx_build.md
+++ b/docs/reference/buildx_build.md
@@ -24,6 +24,7 @@ Start a build
 | [`--cache-to`](#cache-to) | `stringArray` |  | Cache export destinations (e.g., `user/app:cache`, `type=local,dest=path/to/dir`) |
 | [`--cgroup-parent`](https://docs.docker.com/engine/reference/commandline/build/#use-a-custom-parent-cgroup---cgroup-parent) | `string` |  | Optional parent cgroup for the container |
 | [`-f`](https://docs.docker.com/engine/reference/commandline/build/#specify-a-dockerfile--f), [`--file`](https://docs.docker.com/engine/reference/commandline/build/#specify-a-dockerfile--f) | `string` |  | Name of the Dockerfile (default: `PATH/Dockerfile`) |
+| `--frontend` | `string` |  | Set custom frontend to use for build |
 | `--iidfile` | `string` |  | Write the image ID to the file |
 | `--label` | `stringArray` |  | Set metadata for an image |
 | [`--load`](#load) |  |  | Shorthand for `--output=type=docker` |


### PR DESCRIPTION
Allow for specifying a custom frontend image as a command line argument using the gateway.v0 frontend.

This would be quite useful for local testing hacked-on frontends, which `buildctl` already provides functionality for :tada: