### PR TITLE
Only set default rootless image if it is not already customized

### DIFF
--- a/driver/kubernetes/factory.go
+++ b/driver/kubernetes/factory.go
@@ -108,7 +108,9 @@ func (f *factory) New(ctx context.Context, cfg driver.InitConfig) (driver.Driver
 			if err != nil {
 				return nil, err
 			}
-			deploymentOpt.Image = bkimage.DefaultRootlessImage
+			if _, isImage := cfg.DriverOpts["image"]; !isImage {
+				deploymentOpt.Image = bkimage.DefaultRootlessImage
+			}
 		case "nodeselector":
 			kvs := strings.Split(strings.Trim(v, `"`), ",")
 			s := map[string]string{}


### PR DESCRIPTION
Only change the image to the default rootless image when using the
--rootless option if the image has not already customized with the
--image option.

Fix #938

Signed-off-by: Douglas Borg <dougborg@apple.com>