### PR TITLE
inspect: fix printing of driver options

### DIFF
--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -98,11 +98,10 @@ func runInspect(dockerCli command.Cli, in inspectOptions) error {
 
 			var driverOpts []string
 			for k, v := range n.DriverOpts {
-				driverOpts = append(driverOpts, fmt.Sprintf("\t%s=%s\n", k, v))
+				driverOpts = append(driverOpts, fmt.Sprintf("%s=%q", k, v))
 			}
-
 			if len(driverOpts) > 0 {
-				fmt.Fprintf(w, "Driver Options: %s", strings.Join(driverOpts, ","))
+				fmt.Fprintf(w, "Driver Options:\t%s\n", strings.Join(driverOpts, " "))
 			}
 
 			if err := ngi.drivers[i].di.Err; err != nil {


### PR DESCRIPTION
follow-up https://github.com/docker/buildx/pull/1003#issuecomment-1084286643

current behavior:

```
Name:   builder
Driver: docker-container

Nodes:
Name:            builder0
Endpoint:        unix:///var/run/docker.sock
Driver Options:  env.BUILDKIT_STEP_LOG_MAX_SIZE=-1
,                env.BUILDKIT_STEP_LOG_MAX_SPEED=-1
,                env.JAEGER_TRACE=localhost:6831
,                image=moby/buildkit:master
,                network=host
Status:          running
Flags:           --debug --allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host
Platforms:       linux/amd64, linux/amd64/v2, linux/amd64/v3, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/mips64le, linux/mips64, linux/arm/v7, linux/arm/v6
```

now:

```
Name:   builder
Driver: docker-container

Nodes:
Name:           builder0
Endpoint:       unix:///var/run/docker.sock
Driver Options: env.BUILDKIT_STEP_LOG_MAX_SIZE="-1" env.BUILDKIT_STEP_LOG_MAX_SPEED="-1" env.JAEGER_TRACE="localhost:6831" image="moby/buildkit:master" network="host"
Status:         running
Flags:          --debug --allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host
Platforms:      linux/amd64, linux/amd64/v2, linux/amd64/v3, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/mips64le, linux/mips64, linux/arm/v7, linux/arm/v6
```

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>