### PR TITLE
imagetools: respect --builder flag

### DIFF
--- a/commands/imagetools/create.go
+++ b/commands/imagetools/create.go
@@ -255,7 +255,7 @@ func createCmd(dockerCli command.Cli, opts RootOptions) *cobra.Command {
 		Use:   "create [OPTIONS] [SOURCE] [SOURCE...]",
 		Short: "Create a new image based on source images",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			options.builder = opts.Builder
+			options.builder = *opts.Builder
 			return runCreate(dockerCli, options, args)
 		},
 	}

--- a/commands/imagetools/inspect.go
+++ b/commands/imagetools/inspect.go
@@ -66,7 +66,7 @@ func inspectCmd(dockerCli command.Cli, rootOpts RootOptions) *cobra.Command {
 		Short: "Show details of an image in the registry",
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			options.builder = rootOpts.Builder
+			options.builder = *rootOpts.Builder
 			return runInspect(dockerCli, options, args[0])
 		},
 	}

--- a/commands/imagetools/root.go
+++ b/commands/imagetools/root.go
@@ -6,7 +6,7 @@ import (
 )
 
 type RootOptions struct {
-	Builder string
+	Builder *string
 }
 
 func RootCmd(dockerCli command.Cli, opts RootOptions) *cobra.Command {

--- a/commands/root.go
+++ b/commands/root.go
@@ -74,7 +74,7 @@ func addCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		versionCmd(dockerCli),
 		pruneCmd(dockerCli, opts),
 		duCmd(dockerCli, opts),
-		imagetoolscmd.RootCmd(dockerCli, imagetoolscmd.RootOptions{Builder: opts.builder}),
+		imagetoolscmd.RootCmd(dockerCli, imagetoolscmd.RootOptions{Builder: &opts.builder}),
 	)
 }
 


### PR DESCRIPTION
The --builder flag was being ignored by imagetools because of pointer
problems. Essentially, because the root cmds aren't parsed immediately,
we need to pass a pointer to the builder string so that it can be
updated before the RunE function gets called.