### PR TITLE
fix missing '*' in checksums.txt

### DIFF
--- a/hack/release
+++ b/hack/release
@@ -17,4 +17,4 @@ if ! type shasum > /dev/null 2>&1; then
   echo >&2 "ERROR: shasum is required"
   exit 1
 fi
-find ./${RELEASE_OUT}/ -type f \( -iname "buildx-*" ! -iname "*darwin*" \) -print0 | sort -z | xargs -r0 shasum -a 256 -b | sed 's# .*/# #' > ./${RELEASE_OUT}/checksums.txt
+find ./${RELEASE_OUT}/ -type f \( -iname "buildx-*" ! -iname "*darwin*" \) -print0 | sort -z | xargs -r0 shasum -a 256 -b | sed 's# .*/# *#' > ./${RELEASE_OUT}/checksums.txt


### PR DESCRIPTION
the created checksums.txt file is not properly formatted.
this fixes the Creation of the checksums for the build artifacts
fixes https://github.com/docker/buildx/issues/1070