### PR TITLE
hclparser: strip out blocks for json files

### DIFF
--- a/bake/hcl_test.go
+++ b/bake/hcl_test.go
@@ -745,3 +745,13 @@ target "two" {
 	require.Equal(t, c.Targets[1].Name, "two")
 	require.Equal(t, map[string]string{"b": "pre-jkl"}, c.Targets[1].Args)
 }
+
+func TestEmptyVariableJSON(t *testing.T) {
+	dt := []byte(`{
+	  "variable": {
+	    "VAR": {}
+	  }
+	}`)
+	_, err := ParseFile(dt, "docker-bake.json")
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Body.JustAttributes cannot distinguish between blocks and attributes for JSON files, so the variable block could be included in the list of attributes returned.

This patch ensures that JSON and HCL files behave the same way by removing all known block types first, from the provided config schema and then from a generated definitions schema.

Fixes #1051