### PR TITLE
cli: fix standalone command behavior

### DIFF
--- a/cmd/buildx/tracing.go
+++ b/cmd/buildx/tracing.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"github.com/moby/buildkit/util/tracing/detect"
+	"go.opentelemetry.io/otel"
+
+	_ "github.com/moby/buildkit/util/tracing/detect/delegated"
+	_ "github.com/moby/buildkit/util/tracing/env"
+)
+
+func init() {
+	detect.ServiceName = "buildx"
+	// do not log tracing errors to stdio
+	otel.SetErrorHandler(skipErrors{})
+}
+
+type skipErrors struct{}
+
+func (skipErrors) Handle(err error) {}

--- a/commands/root.go
+++ b/commands/root.go
@@ -6,6 +6,7 @@ import (
 	imagetoolscmd "github.com/docker/buildx/commands/imagetools"
 	"github.com/docker/buildx/util/logutil"
 	"github.com/docker/cli-docs-tool/annotation"
+	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli-plugins/plugin"
 	"github.com/docker/cli/cli/command"
 	"github.com/sirupsen/logrus"
@@ -26,6 +27,14 @@ func NewRootCmd(name string, isPlugin bool, dockerCli command.Cli) *cobra.Comman
 		cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
 			return plugin.PersistentPreRunE(cmd, args)
 		}
+	} else {
+		// match plugin behavior for standalone mode
+		// https://github.com/docker/cli/blob/6c9eb708fa6d17765d71965f90e1c59cea686ee9/cli-plugins/plugin/plugin.go#L117-L127
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
+		cmd.TraverseChildren = true
+		cmd.DisableFlagsInUseLine = true
+		cli.DisableFlagsInUseLine(cmd)
 	}
 
 	logrus.SetFormatter(&logutil.Formatter{})


### PR DESCRIPTION
when buildx is invoked directly without the docker cli (standalone) and an error occurs during the build, the error message is returned along with the cobra help usage:

```Dockerfile
FROM qsdqsdalpine
RUN echo "Hello world!"
```

```
$ ~/.docker/cli-plugins/docker-buildx build .
...

#4 [auth] library/qsdqsdalpine:pull token for registry-1.docker.io
#4 DONE 0.0s

#3 [internal] load metadata for docker.io/library/qsdqsdalpine:latest
#3 ERROR: pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed
------
 > [internal] load metadata for docker.io/library/qsdqsdalpine:latest:
------
Error: failed to solve: qsdqsdalpine: pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed
Usage:
  /home/crazy/.docker/cli-plugins/docker-buildx build [OPTIONS] PATH | URL | - [flags]

Aliases:
  build, b

Flags:
      --add-host strings              Add a custom host-to-IP mapping (format: "host:ip")
      --allow strings                 Allow extra privileged entitlement (e.g., "network.host", "security.insecure")
      --build-arg stringArray         Set build-time variables
      --build-context stringArray     Additional build contexts (e.g., name=path)
      --cache-from stringArray        External cache sources (e.g., "user/app:cache", "type=local,src=path/to/dir")
      --cache-to stringArray          Cache export destinations (e.g., "user/app:cache", "type=local,dest=path/to/dir")
      --cgroup-parent string          Optional parent cgroup for the container
  -f, --file string                   Name of the Dockerfile (default: "PATH/Dockerfile")
  -h, --help                          help for build
      --iidfile string                Write the image ID to the file
      --label stringArray             Set metadata for an image
      --load                          Shorthand for "--output=type=docker"
      --metadata-file string          Write build result metadata to the file
      --network string                Set the networking mode for the "RUN" instructions during build (default "default")
      --no-cache                      Do not use cache when building the image
      --no-cache-filter stringArray   Do not cache specified stages
  -o, --output stringArray            Output destination (format: "type=local,dest=path")
      --platform stringArray          Set target platform for build
      --progress string               Set type of progress output ("auto", "plain", "tty"). Use plain to show container output (default "auto")
      --pull                          Always attempt to pull all referenced images
      --push                          Shorthand for "--output=type=registry"
  -q, --quiet                         Suppress the build output and print image ID on success
      --secret stringArray            Secret to expose to the build (format: "id=mysecret[,src=/local/secret]")
      --shm-size bytes                Size of "/dev/shm"
      --ssh stringArray               SSH agent socket or keys to expose to the build (format: "default|<id>[=<socket>|<key>[,<key>]]")
  -t, --tag stringArray               Name and optionally a tag (format: "name:tag")
      --target string                 Set the target build stage to build
      --ulimit ulimit                 Ulimit options (default [])

Global Flags:
      --builder string   Override the configured builder instance
```

This PR fixes this issue but also fix the behavior of the standalone command to match the plugin one. Atm BuildKit solver errdefs are not returned in standalone:

```
$ ~/.docker/cli-plugins/docker-buildx build .
...

#4 [auth] library/qsdqsdalpine:pull token for registry-1.docker.io
#4 DONE 0.0s

#3 [internal] load metadata for docker.io/library/qsdqsdalpine:latest
#3 ERROR: pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed
------
 > [internal] load metadata for docker.io/library/qsdqsdalpine:latest:
------
hello.Dockerfile:1
--------------------
   1 | >>> FROM qsdqsdalpine
   2 |
   3 |     RUN echo "Hello world!"
--------------------
error: failed to solve: qsdqsdalpine: pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed
```

Also moves the tracing logic in a dedicated file.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>