### PR TITLE
ci: enhance e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,8 +12,40 @@ on:
       - 'v[0-9]*'
 
 jobs:
+  build:
+    runs-on: ubuntu-20.04
+    env:
+      BIN_OUT: ./bin
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+      -
+        name: Build
+        uses: docker/bake-action@v1
+        with:
+          targets: binaries
+      -
+        name: Rename binary
+        run: |
+          mv ${{ env.BIN_OUT }}/buildx ${{ env.BIN_OUT }}/docker-buildx
+      -
+        name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: binary
+          path: ${{ env.BIN_OUT }}
+          if-no-files-found: error
+          retention-days: 7
+
   driver:
     runs-on: ubuntu-20.04
+    needs:
+      - build
     strategy:
       fail-fast: false
       matrix:
@@ -52,14 +84,15 @@ jobs:
         uses: docker/setup-qemu-action@v1
         if: matrix.driver == 'docker' || matrix.driver == 'docker-container'
       -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-        with:
-          version: latest
-      -
         name: Install buildx
+        uses: actions/download-artifact@v3
+        with:
+          name: binary
+          path: /home/runner/.docker/cli-plugins
+      -
+        name: Fix perms and check
         run: |
-          make install
+          chmod +x /home/runner/.docker/cli-plugins/docker-buildx
           docker buildx version
       -
         name: Init env vars


### PR DESCRIPTION
Avoid building buildx for each matrix input to save some compute and also avoid issues like https://github.com/docker/buildx/runs/6208393943?check_suite_focus=true

```
#3 resolve image config for docker.io/docker/dockerfile:1.4
#3 ERROR: failed to do request: Head "https://registry-1.docker.io/v2/docker/dockerfile/manifests/1.4": net/http: TLS handshake timeout
```

The new workflow will build buildx once and each matrix input will download the artifact.

cc @jedevc 

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>