### PR TITLE
docs: fix guides for docs.docker.com

### DIFF
--- a/docs/guides/cni-networking.md
+++ b/docs/guides/cni-networking.md
@@ -1,4 +1,8 @@
-# CNI networking
+---
+title: "CNI networking"
+description: "Enhance your builder with CNI networking"
+keywords: build, buildx, buildkit, cni, network
+---
 
 It can be useful to use a bridge network for your builder if for example you
 encounter a network port contention during multiple builds. If you're using
@@ -11,7 +15,7 @@ Now build this image:
 $ docker buildx build --tag buildkit-cni:local --load .
 ```
 
-Then [create a `docker-container` builder](../reference/buildx_create.md) that
+Then [create a `docker-container` builder](https://docs.docker.com/engine/reference/commandline/buildx_create/) that
 will use this image:
 
 ```console

--- a/docs/guides/custom-network.md
+++ b/docs/guides/custom-network.md
@@ -1,4 +1,8 @@
-# Using a custom network
+---
+title: "Using a custom network"
+description: "Create and use a custom network for your build"
+keywords: build, buildx, buildkit, network
+---
 
 [Create a network](https://docs.docker.com/engine/reference/commandline/network_create/)
 named `foonet`:
@@ -7,8 +11,8 @@ named `foonet`:
 $ docker network create foonet
 ```
 
-[Create a `docker-container` builder](../reference/buildx_create.md) named
-`mybuilder` that will use this network:
+[Create a `docker-container` builder](https://docs.docker.com/engine/reference/commandline/buildx_create/)
+named `mybuilder` that will use this network:
 
 ```console
 $ docker buildx create --use \
@@ -17,7 +21,7 @@ $ docker buildx create --use \
   --driver-opt "network=foonet"
 ```
 
-Boot and [inspect `mybuilder`](../reference/buildx_inspect.md):
+Boot and [inspect `mybuilder`](https://docs.docker.com/engine/reference/commandline/buildx_inspect/):
 
 ```console
 $ docker buildx inspect --bootstrap
@@ -26,23 +30,9 @@ $ docker buildx inspect --bootstrap
 [Inspect the builder container](https://docs.docker.com/engine/reference/commandline/inspect/)
 and see what network is being used:
 
+{% raw %}
 ```console
 $ docker inspect buildx_buildkit_mybuilder0 --format={{.NetworkSettings.Networks}}
 map[foonet:0xc00018c0c0]
 ```
-
-## What's `buildx_buildkit_mybuilder0`?
-
-`buildx_buildkit_mybuilder0` is the container name. It can be broken down like this:
-
-* `buildx_buildkit_` is a hardcoded prefix
-* `mybuilder0` is the name of the node (defaults to builder name + position in the list of nodes)
-
-```console
-$ docker buildx ls
-NAME/NODE     DRIVER/ENDPOINT                        STATUS                 PLATFORMS
-mybuilder *   docker-container
-  mybuilder0  unix:///var/run/docker.sock            running                linux/amd64, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/mips64le, linux/mips64, linux/arm/v7, linux/arm/v6     
-default       docker
-  default     default                                running                linux/amd64, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/arm/v7, linux/arm/v6
-```
+{% endraw %}

--- a/docs/guides/custom-registry-config.md
+++ b/docs/guides/custom-registry-config.md
@@ -1,6 +1,10 @@
-# Using a custom registry configuration
+---
+title: "Using a custom registry configuration"
+description: "Set registry configuration in your builder"
+keywords: build, buildx, buildkit, registry
+---
 
-If you [create a `docker-container` or `kubernetes` builder](../reference/buildx_create.md) and
+If you [create a `docker-container` or `kubernetes` builder](https://docs.docker.com/engine/reference/commandline/buildx_create/) and
 have specified certificates for registries in the [BuildKit daemon configuration](https://github.com/moby/buildkit/blob/master/docs/buildkitd.toml.md),
 the files will be copied into the container under `/etc/buildkit/certs` and
 configuration will be updated to reflect that.
@@ -8,7 +12,8 @@ configuration will be updated to reflect that.
 Take the following `buildkitd.toml` configuration that will be used for
 pushing an image to this registry using self-signed certificates:
 
-```toml"
+```toml
+# /etc/buildkitd.toml
 debug = true
 [registry."myregistry.com"]
   ca=["/etc/certs/myregistry.pem"]
@@ -16,11 +21,10 @@ debug = true
     key="/etc/certs/myregistry_key.pem"
     cert="/etc/certs/myregistry_cert.pem"
 ```
-> `/etc/buildkitd.toml`
 
 Here we have configured a self-signed certificate for `myregistry.com` registry.
 
-Now [create a `docker-container` builder](../reference/buildx_create.md)
+Now [create a `docker-container` builder](https://docs.docker.com/engine/reference/commandline/buildx_create/)
 that will use this BuildKit configuration:
 
 ```console

--- a/docs/guides/opentelemetry.md
+++ b/docs/guides/opentelemetry.md
@@ -1,4 +1,8 @@
-# OpenTelemetry support
+---
+title: "OpenTelemetry support"
+description: "OpenTelemetry support for your builder"
+keywords: build, buildx, buildkit, opentelemetry, tracing
+---
 
 To capture the trace to [Jaeger](https://github.com/jaegertracing/jaeger), set
 `JAEGER_TRACE` environment variable to the collection address using a `driver-opt`.
@@ -9,7 +13,7 @@ First create a Jaeger container:
 $ docker run -d --name jaeger -p "6831:6831/udp" -p "16686:16686" jaegertracing/all-in-one
 ```
 
-Then [create a `docker-container` builder](../reference/buildx_create.md)
+Then [create a `docker-container` builder](https://docs.docker.com/engine/reference/commandline/buildx_create/)
 that will use the Jaeger instance via the `JAEGER_TRACE` env var:
 
 ```console
@@ -20,7 +24,7 @@ $ docker buildx create --use \
   --driver-opt "env.JAEGER_TRACE=localhost:6831"
 ```
 
-Boot and [inspect `mybuilder`](../reference/buildx_inspect.md):
+Boot and [inspect `mybuilder`](https://docs.docker.com/engine/reference/commandline/buildx_inspect/):
 
 ```console
 $ docker buildx inspect --bootstrap
@@ -28,4 +32,4 @@ $ docker buildx inspect --bootstrap
 
 Buildx commands should be traced at `http://127.0.0.1:16686/`:
 
-![](https://user-images.githubusercontent.com/1951866/124468052-ef085400-dd98-11eb-84ab-7ac8e261dd52.png)
+![OpenTelemetry Buildx Bake](https://user-images.githubusercontent.com/1951866/124468052-ef085400-dd98-11eb-84ab-7ac8e261dd52.png)

--- a/docs/guides/registry-mirror.md
+++ b/docs/guides/registry-mirror.md
@@ -1,19 +1,25 @@
-# Registry mirror
+---
+title: "Registry mirror"
+description: "Using a registry mirror in your build"
+keywords: build, buildx, buildkit, registry
+---
 
 You can define a registry mirror to use for your builds by providing a [BuildKit daemon configuration](https://github.com/moby/buildkit/blob/master/docs/buildkitd.toml.md)
-while creating a builder with the [`--config` flags](../reference/buildx_create.md#config).
+while creating a builder with the [`--config` flags](https://docs.docker.com/engine/reference/commandline/buildx_create/#config).
 
 ```toml
+# /etc/buildkitd.toml
 debug = true
 [registry."docker.io"]
   mirrors = ["mirror.gcr.io"]
 ```
-> `/etc/buildkitd.toml`
 
-> :information_source: `debug = true` has been added to be able to debug requests
-in the BuildKit daemon and see if the mirror is effectively used.
+> **Notes**
+>
+> `debug = true` has been added to be able to debug requests
+> in the BuildKit daemon and see if the mirror is effectively used.
 
-Then [create a `docker-container` builder](../reference/buildx_create.md)
+Then [create a `docker-container` builder](https://docs.docker.com/engine/reference/commandline/buildx_create/)
 that will use this BuildKit configuration:
 
 ```console
@@ -23,7 +29,7 @@ $ docker buildx create --use \
   --config /etc/buildkitd.toml
 ```
 
-Boot and [inspect `mybuilder`](../reference/buildx_inspect.md):
+Boot and [inspect `mybuilder`](https://docs.docker.com/engine/reference/commandline/buildx_inspect/):
 
 ```console
 $ docker buildx inspect --bootstrap

--- a/docs/guides/resource-limiting.md
+++ b/docs/guides/resource-limiting.md
@@ -1,18 +1,22 @@
-# Resource limiting
+---
+title: "Resource limiting"
+description: "Max parallelism and limit on TCP connection in your build"
+keywords: build, buildx, buildkit, compute, network
+---
 
 ## Max parallelism
 
 You can limit the parallelism of the BuildKit solver, which is particularly useful
 for low-powered machines, using a [BuildKit daemon configuration](https://github.com/moby/buildkit/blob/master/docs/buildkitd.toml.md)
-while creating a builder with the [`--config` flags](../reference/buildx_create.md#config).
+while creating a builder with the [`--config` flags](https://docs.docker.com/engine/reference/commandline/buildx_create/#config).
 
 ```toml
+# /etc/buildkitd.toml
 [worker.oci]
   max-parallelism = 4
 ```
-> `/etc/buildkitd.toml`
 
-Now you can [create a `docker-container` builder](../reference/buildx_create.md)
+Now you can [create a `docker-container` builder](https://docs.docker.com/engine/reference/commandline/buildx_create/)
 that will use this BuildKit configuration to limit parallelism.
 
 ```console


### PR DESCRIPTION
Fix guides docs so we can include them on docs.docker.com.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>