### PR TITLE
chore: dependabot to keep gha up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    open-pull-requests-limit: 10
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+      - "bot"


### PR DESCRIPTION
adds dependabot to keep the github actions being used in our workflows up to date.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>