### PR TITLE
create: load default buildkit config if none specified

### DIFF
--- a/commands/create.go
+++ b/commands/create.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/buildx/store"
 	"github.com/docker/buildx/store/storeutil"
 	"github.com/docker/buildx/util/cobrautil"
+	"github.com/docker/buildx/util/confutil"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/google/shlex"
@@ -191,6 +192,16 @@ func runCreate(dockerCli command.Cli, in createOptions, args []string) error {
 		if err != nil {
 			return err
 		}
+
+		if in.configFile == "" {
+			// if buildkit config is not provided, check if the default one is
+			// available and use it
+			if f, ok := confutil.DefaultConfigFile(dockerCli); ok {
+				logrus.Warnf("Using default BuildKit config in %s", f)
+				in.configFile = f
+			}
+		}
+
 		if err := ng.Update(in.nodeName, ep, in.platform, setEp, in.actionAppend, flags, in.configFile, m); err != nil {
 			return err
 		}

--- a/docs/reference/buildx_create.md
+++ b/docs/reference/buildx_create.md
@@ -79,6 +79,11 @@ Specifies the configuration file for the buildkitd daemon to use. The configurat
 can be overridden by [`--buildkitd-flags`](#buildkitd-flags).
 See an [example buildkitd configuration file](https://github.com/moby/buildkit/blob/master/docs/buildkitd.toml.md).
 
+If the configuration file is not specified, will look for one by default in:
+* `$BUILDX_CONFIG/buildkitd.default.toml`
+* `$DOCKER_CONFIG/buildx/buildkitd.default.toml`
+* `~/.docker/buildx/buildkitd.default.toml`
+
 Note that if you create a `docker-container` builder and have specified
 certificates for registries in the `buildkitd.toml` configuration, the files
 will be copied into the container under `/etc/buildkit/certs` and configuration

--- a/util/confutil/config.go
+++ b/util/confutil/config.go
@@ -2,6 +2,7 @@ package confutil
 
 import (
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/docker/cli/cli/command"
@@ -22,6 +23,15 @@ func ConfigDir(dockerCli command.Cli) string {
 	buildxConfig := filepath.Join(filepath.Dir(dockerCli.ConfigFile().Filename), "buildx")
 	logrus.Debugf("using default config store %q", buildxConfig)
 	return buildxConfig
+}
+
+// DefaultConfigFile returns the default BuildKit configuration file path
+func DefaultConfigFile(dockerCli command.Cli) (string, bool) {
+	f := path.Join(ConfigDir(dockerCli), "buildkitd.default.toml")
+	if _, err := os.Stat(f); err == nil {
+		return f, true
+	}
+	return "", false
 }
 
 // loadConfigTree loads BuildKit config toml tree


### PR DESCRIPTION
fixes https://github.com/docker/setup-buildx-action/issues/127

if configuration file is not specified, will look for one by default in:
* `$BUILDX_CONFIG/buildkitd.default.toml`
* `$DOCKER_CONFIG/buildx/buildkitd.default.toml`
* `~/.docker/buildx/buildkitd.default.toml`

this can be useful when a user session should inherit from the same configuration when a builder is created without bothering specifying the config path.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>