### PR TITLE
Clarify inspect documentation

### DIFF
--- a/docs/reference/buildx_inspect.md
+++ b/docs/reference/buildx_inspect.md
@@ -43,6 +43,10 @@ name of the builder to inspect to get information about that builder.
 The following example shows information about a builder instance named
 `elated_tesla`:
 
+> **Note**
+> 
+> Asterisk `*` next to node build platform(s) indicate they had been set manually during `buildx create`. Otherwise, it had been autodetected.
+
 ```console
 $ docker buildx inspect elated_tesla
 
@@ -58,5 +62,5 @@ Platforms: linux/amd64
 Name:      elated_tesla1
 Endpoint:  ssh://ubuntu@1.2.3.4
 Status:    running
-Platforms: linux/arm64, linux/arm/v7, linux/arm/v6
+Platforms: linux/arm64*, linux/arm/v7, linux/arm/v6
 ```


### PR DESCRIPTION
Documentation gap was found in issue #1105. In `buildx inspect` command output, asterisks `*` next to platforms listed indicate such platforms had been set manually set in `buildx create`.

This behavior was previously not documented, therefore this PR updates documentation to include it.