### PR TITLE
ls: dedup instances from store and context

### DIFF
--- a/commands/create.go
+++ b/commands/create.go
@@ -101,6 +101,19 @@ func runCreate(dockerCli command.Cli, in createOptions, args []string) error {
 		}
 	}
 
+	if !in.actionLeave && !in.actionAppend {
+		contexts, err := dockerCli.ContextStore().List()
+		if err != nil {
+			return err
+		}
+		for _, c := range contexts {
+			if c.Name == name {
+				logrus.Warnf("instance name %q already exists as context builder", name)
+				break
+			}
+		}
+	}
+
 	ng, err := txn.NodeGroupByName(name)
 	if err != nil {
 		if os.IsNotExist(errors.Cause(err)) {

--- a/commands/util.go
+++ b/commands/util.go
@@ -390,6 +390,15 @@ func loadNodeGroupData(ctx context.Context, dockerCli command.Cli, ngi *nginfo) 
 	return nil
 }
 
+func hasNodeGroup(list []*nginfo, ngi *nginfo) bool {
+	for _, l := range list {
+		if ngi.ng.Name == l.ng.Name {
+			return true
+		}
+	}
+	return false
+}
+
 func dockerAPI(dockerCli command.Cli) *api {
 	return &api{dockerCli: dockerCli}
 }


### PR DESCRIPTION
```
$ docker context create foo
foo
Successfully created context "foo"
$ docker buildx create --name foo
foo
```

```
$ docker buildx ls
NAME/NODE        DRIVER/ENDPOINT                        STATUS                 PLATFORMS
builder2 *       docker-container
  builder20      unix:///var/run/docker.sock            running                linux/amd64, linux/amd64/v2, linux/amd64/v3, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/mips64le, linux/mips64, linux/arm/v7, linux/arm/v6
foo              docker-container
  foo0           unix:///var/run/docker.sock            inactive
desktop-linux                                           protocol not available
desktop-windows                                         protocol not available
foo              docker
  foo            foo                                    running                linux/amd64, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/arm/v7, linux/arm/v6
default          docker
  default        default                                running                linux/amd64, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/arm/v7, linux/arm/v6
```

do not add a context builder to the list if one from the store with the same name exists. An instance from the store takes precedence over context builders so don't think we should display both of them:

```
$ docker buildx ls
NAME/NODE        DRIVER/ENDPOINT                        STATUS                 BUILDKIT PLATFORMS
builder2 *       docker-container
  builder20      unix:///var/run/docker.sock            running                394ccf8  linux/amd64, linux/amd64/v2, linux/amd64/v3, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/mips64le, linux/mips64, linux/arm/v7, linux/arm/v6
foo              docker-container
  foo0           unix:///var/run/docker.sock            inactive
default          docker
  default        default                                running                20.10.14 linux/amd64, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/arm/v7, linux/arm/v6        
desktop-linux                                           protocol not available
desktop-windows                                         protocol not available
```

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>