### PR TITLE
Imagetools multiple repositories

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -925,7 +925,21 @@ func BuildWithResultHandler(ctx context.Context, drivers []DriverInfo, opt map[s
 
 							itpull := imagetools.New(imageopt)
 
-							dt, desc, err := itpull.Combine(ctx, names[0], descs)
+							ref, err := reference.ParseNormalizedNamed(names[0])
+							if err != nil {
+								return err
+							}
+							ref = reference.TagNameOnly(ref)
+
+							srcs := make([]*imagetools.Source, len(descs))
+							for i, desc := range descs {
+								srcs[i] = &imagetools.Source{
+									Desc: desc,
+									Ref:  ref,
+								}
+							}
+
+							dt, desc, err := itpull.Combine(ctx, srcs)
 							if err != nil {
 								return err
 							}

--- a/commands/imagetools/create.go
+++ b/commands/imagetools/create.go
@@ -78,9 +78,6 @@ func runCreate(dockerCli command.Cli, in createOptions, args []string) error {
 	if len(repos) == 0 {
 		return errors.Errorf("no repositories specified, please set a reference in tag or source")
 	}
-	if len(repos) > 1 {
-		return errors.Errorf("multiple repositories currently not supported, found %v", repos)
-	}
 
 	var defaultRepo *string
 	if len(repos) == 1 {
@@ -92,7 +89,7 @@ func runCreate(dockerCli command.Cli, in createOptions, args []string) error {
 	for i, s := range srcs {
 		if s.Ref == nil && s.Desc.MediaType == "" && s.Desc.Digest != "" {
 			if defaultRepo == nil {
-				return errors.Errorf("multiple repositories specified, cannot determine default from %v", repos)
+				return errors.Errorf("multiple repositories specified, cannot infer repository for %q", args[i])
 			}
 
 			n, err := reference.ParseNormalizedNamed(*defaultRepo)
@@ -181,6 +178,10 @@ func runCreate(dockerCli command.Cli, in createOptions, args []string) error {
 	r = imagetools.New(imageopt)
 
 	for _, t := range tags {
+		if err := r.Copy(ctx, srcs, t); err != nil {
+			return err
+		}
+
 		if err := r.Push(ctx, t, desc, dt); err != nil {
 			return err
 		}

--- a/docs/reference/buildx_imagetools_create.md
+++ b/docs/reference/buildx_imagetools_create.md
@@ -15,6 +15,7 @@ Create a new image based on source images
 | [`--builder`](#builder) | `string` |  | Override the configured builder instance |
 | [`--dry-run`](#dry-run) |  |  | Show final image instead of pushing |
 | [`-f`](#file), [`--file`](#file) | `stringArray` |  | Read source descriptor from file |
+| `--progress` | `string` | `auto` | Set type of progress output (`auto`, `plain`, `tty`). Use plain to show container output |
 | [`-t`](#tag), [`--tag`](#tag) | `stringArray` |  | Set reference for new image |
 
 

--- a/util/imagetools/create.go
+++ b/util/imagetools/create.go
@@ -170,30 +170,23 @@ func (r *Resolver) Push(ctx context.Context, ref reference.Named, desc ocispec.D
 	return err
 }
 
-func (r *Resolver) Copy(ctx context.Context, srcs []*Source, dest reference.Named) error {
+func (r *Resolver) Copy(ctx context.Context, src *Source, dest reference.Named) error {
 	dest = reference.TagNameOnly(dest)
 	p, err := r.resolver().Pusher(ctx, dest.String())
 	if err != nil {
 		return err
 	}
 
-	for _, src := range srcs {
-		if reference.Domain(src.Ref) == reference.Domain(dest) && reference.Path(src.Ref) == reference.Path(dest) {
-			continue
-		}
-
-		srcRef := reference.TagNameOnly(src.Ref)
-		f, err := r.resolver().Fetcher(ctx, srcRef.String())
-		if err != nil {
-			return err
-		}
-
-		err = contentutil.CopyChain(ctx, contentutil.FromPusher(p), contentutil.FromFetcher(f), src.Desc)
-		if err != nil {
-			return err
-		}
+	srcRef := reference.TagNameOnly(src.Ref)
+	f, err := r.resolver().Fetcher(ctx, srcRef.String())
+	if err != nil {
+		return err
 	}
 
+	err = contentutil.CopyChain(ctx, contentutil.FromPusher(p), contentutil.FromFetcher(f), src.Desc)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
Fixes #486

This PR introduces support for multiple repositories: this allows creating manifest lists with manifests pulled from multiple other locations.

This is split into two commits:
- The first refactors surrounding code to ensure that multiple repositories are recognized - this has changed some of the API surface, making the private `src` struct public to allow keeping the oci descriptor next to where it can be fetched from.
- The second to actually copy the manifests around to the new repository, and enable the multiple repositories feature 