### PR TITLE
Update golint to revive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,7 +18,7 @@ linters:
     - misspell
     - unused
     - varcheck
-    - golint
+    - revive
     - staticcheck
     - typecheck
     - structcheck
@@ -36,5 +36,5 @@ linters-settings:
 issues:
   exclude-rules:
     - linters:
-        - golint
+        - revive
       text: "stutters"

--- a/build/build.go
+++ b/build/build.go
@@ -585,7 +585,7 @@ func toSolveOpt(ctx context.Context, di DriverInfo, multiDriver bool, opt Option
 		so.FrontendAttrs["force-network-mode"] = opt.NetworkMode
 	case "", "default":
 	default:
-		return nil, nil, errors.Errorf("network mode %q not supported by buildkit. You can define a custom network for your builder using the network driver-opt in buildx create.", opt.NetworkMode)
+		return nil, nil, errors.Errorf("network mode %q not supported by buildkit - you can define a custom network for your builder using the network driver-opt in buildx create", opt.NetworkMode)
 	}
 
 	// setup extrahosts


### PR DESCRIPTION
Resolves the following message in golangci output:

> The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive.

Additionally, fix a minor linting issue discovered by revive.