### PR TITLE
imagetools: handle manifest with nil platform

### DIFF
--- a/util/imagetools/printers.go
+++ b/util/imagetools/printers.go
@@ -59,7 +59,9 @@ func NewPrinter(ctx context.Context, opt Opt, name string, format string) (*Prin
 	switch manifest.MediaType {
 	case images.MediaTypeDockerSchema2ManifestList, ocispecs.MediaTypeImageIndex:
 		for _, m := range index.Manifests {
-			pforms = append(pforms, *m.Platform)
+			if m.Platform != nil {
+				pforms = append(pforms, *m.Platform)
+			}
 		}
 	default:
 		pforms = append(pforms, platforms.DefaultSpec())


### PR DESCRIPTION
Manifest with nil platform record causes a panic atm.

This is a v0.8 regression in case there are more patch releases.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>