### PR TITLE
build: enhance warning message when no output specified

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -332,6 +332,7 @@ func (c Config) loadLinks(name string, t *Target, m map[string]*Target, o map[st
 					return err
 				}
 				t2.Outputs = nil
+				t2.linked = true
 				m[target] = t2
 			}
 			if err := c.loadLinks(target, t2, m, o, visited); err != nil {
@@ -528,6 +529,9 @@ type Target struct {
 	NetworkMode      *string           `json:"-" hcl:"-"`
 	NoCacheFilter    []string          `json:"no-cache-filter,omitempty" hcl:"no-cache-filter,optional"`
 	// IMPORTANT: if you add more fields here, do not forget to update newOverrides and README.
+
+	// linked is a private field to mark a target used as a linked one
+	linked bool
 }
 
 func (t *Target) normalize() {
@@ -869,6 +873,7 @@ func toBuildOpt(t *Target, inp *Input) (*build.Options, error) {
 		NoCacheFilter: t.NoCacheFilter,
 		Pull:          pull,
 		NetworkMode:   networkMode,
+		Linked:        t.linked,
 	}
 
 	platforms, err := platformutil.Parse(t.Platforms)


### PR DESCRIPTION
fixes #968

fix the issue where no output warning message is being displayed for linked targets and also enhance this message to display which targets don't have an output specified.

```hcl
# docker-bake.hcl

target "base" {
  dockerfile = "baseapp.Dockerfile"
  args = {
    basefoo = "bar"
  }
}

target "base2" {
  dockerfile = "baseapp.Dockerfile"
  args = {
    basefoo = "bar3"
  }
}

target "app" {
  contexts = {
    baseapp = "target:base"
  }
}
```

```dockerfile
# Dockerfile
FROM baseapp
RUN echo "Hello world"
```

```dockerfile
# baseapp.Dockerfile
FROM alpine
WORKDIR /src
```

```console
$ docker buildx bake --set app.tags=user/app:latest --set app.output=type=cacheonly app
...
#5 [app 1/2] FROM docker.io/library/alpine@sha256:686d8c9dfa6f3ccfc8230bc3178d23f84eeaf7e457f36f271ab1acc53015037c
#5 resolve docker.io/library/alpine@sha256:686d8c9dfa6f3ccfc8230bc3178d23f84eeaf7e457f36f271ab1acc53015037c 0.0s done
#5 DONE 0.1s

#8 [base 2/2] WORKDIR /src
#8 CACHED

#9 [app 1/2] RUN echo "Hello world"
#9 CACHED

#8 [app 2/2] WORKDIR /src
#8 CACHED
```

```console
$ docker buildx bake --set app.tags=user/app:latest --set app.output=type=cacheonly app base2
...
#7 [app 1/2] FROM docker.io/library/alpine@sha256:686d8c9dfa6f3ccfc8230bc3178d23f84eeaf7e457f36f271ab1acc53015037c
#7 resolve docker.io/library/alpine@sha256:686d8c9dfa6f3ccfc8230bc3178d23f84eeaf7e457f36f271ab1acc53015037c 0.0s done
#7 DONE 0.1s

#8 [app 2/2] WORKDIR /src
#8 CACHED
WARNING: No output specified for base2 target(s) with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
```

```console
$ docker buildx bake base base2
...
#6 [base2 1/2] FROM docker.io/library/alpine@sha256:686d8c9dfa6f3ccfc8230bc3178d23f84eeaf7e457f36f271ab1acc53015037c
#6 resolve docker.io/library/alpine@sha256:686d8c9dfa6f3ccfc8230bc3178d23f84eeaf7e457f36f271ab1acc53015037c 0.0s done
#6 DONE 0.0s

#7 [base 2/2] WORKDIR /src
#7 CACHED
WARNING: No output specified for base, base2 target(s) with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
```

```console
$ docker buildx build --build-context baseapp=docker-image://alpine .
WARNING: No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 85B done
#1 DONE 0.0s

#2 [internal] load .dockerignore
#2 transferring context: 2B done
#2 DONE 0.1s
...
```

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>