### PR TITLE
ci: add concurrency check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,9 @@
 name: build
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,5 +1,9 @@
 name: e2e
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,5 +1,9 @@
 name: validate
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
follow-up https://github.com/moby/buildkit/pull/2899

add concurrency check in our workflows to ensure that only a single workflow using the same concurrency group will run at a time. it allows to reduce job build queue in our pipeline.

more info: https://docs.github.com/en/actions/using-jobs/using-concurrency

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>