### PR TITLE
Update link to High-level build options with Bake

### DIFF
--- a/docs/reference/buildx_bake.md
+++ b/docs/reference/buildx_bake.md
@@ -34,7 +34,7 @@ Build from a file
 Bake is a high-level build command. Each specified target will run in parallel
 as part of the build.
 
-Read [High-level build options with Bake](https://docs.docker.com/build/bake/)
+Read [High-level build options with Bake](https://github.com/docker/buildx#high-level-build-options)
 guide for introduction to writing bake files.
 
 > **Note**


### PR DESCRIPTION
Current link is invalid, so I replaced it with the High-level build options
from https://docs.docker.com/engine/reference/commandline/buildx_bake/