### PR TITLE
buildx: log errors in initializing builders

### DIFF
--- a/commands/create.go
+++ b/commands/create.go
@@ -242,6 +242,11 @@ func runCreate(dockerCli command.Cli, in createOptions, args []string) error {
 	if err = loadNodeGroupData(timeoutCtx, dockerCli, ngi); err != nil {
 		return err
 	}
+	for _, info := range ngi.drivers {
+		if err := info.di.Err; err != nil {
+			logrus.Errorf("failed to initialize builder %s (%s): %s", ng.Name, info.di.Name, err)
+		}
+	}
 
 	if in.bootstrap {
 		if _, err = boot(ctx, ngi); err != nil {

--- a/store/nodegroup.go
+++ b/store/nodegroup.go
@@ -110,6 +110,44 @@ func (ng *NodeGroup) Update(name, endpoint string, platforms []string, endpoints
 	return nil
 }
 
+func (ng *NodeGroup) Copy() *NodeGroup {
+	nodes := make([]Node, len(ng.Nodes))
+	for i, node := range ng.Nodes {
+		nodes[i] = *node.Copy()
+	}
+	return &NodeGroup{
+		Name:    ng.Name,
+		Driver:  ng.Driver,
+		Nodes:   nodes,
+		Dynamic: ng.Dynamic,
+	}
+}
+
+func (n *Node) Copy() *Node {
+	platforms := []specs.Platform{}
+	copy(platforms, n.Platforms)
+	flags := []string{}
+	copy(flags, n.Flags)
+	driverOpts := map[string]string{}
+	for k, v := range n.DriverOpts {
+		driverOpts[k] = v
+	}
+	files := map[string][]byte{}
+	for k, v := range n.Files {
+		vv := []byte{}
+		copy(vv, v)
+		files[k] = vv
+	}
+	return &Node{
+		Name:       n.Name,
+		Endpoint:   n.Endpoint,
+		Platforms:  platforms,
+		Flags:      flags,
+		DriverOpts: driverOpts,
+		Files:      files,
+	}
+}
+
 func (ng *NodeGroup) validateDuplicates(ep string, idx int) error {
 	i := 0
 	for _, n := range ng.Nodes {


### PR DESCRIPTION
Previously, errors within the driver config would not be reported to the user until they tried to use the driver, even though they are easily accessible from the node group info.

For example:

```console
# before
$ buildx create --bootstrap --name=kube --driver=kubernetes --driver-opt=namespace=buildkit,replicas=4,loadbalance=test
kube

# after
$ buildx create --bootstrap --name=kube --driver=kubernetes --driver-opt=namespace=buildkit,replicas=4,loadbalance=test
ERROR: failed to initialize builder kube (kube0): invalid loadbalance "test"
kube
```

This is in a similar vein to #1188