### PR TITLE
bake: add timestamp function

### DIFF
--- a/bake/hclparser/stdlib.go
+++ b/bake/hclparser/stdlib.go
@@ -1,12 +1,15 @@
 package hclparser
 
 import (
+	"time"
+
 	"github.com/hashicorp/go-cty-funcs/cidr"
 	"github.com/hashicorp/go-cty-funcs/crypto"
 	"github.com/hashicorp/go-cty-funcs/encoding"
 	"github.com/hashicorp/go-cty-funcs/uuid"
 	"github.com/hashicorp/hcl/v2/ext/tryfunc"
 	"github.com/hashicorp/hcl/v2/ext/typeexpr"
+	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
 	"github.com/zclconf/go-cty/cty/function/stdlib"
 )
@@ -96,6 +99,7 @@ var stdlibFunctions = map[string]function.Function{
 	"substr":                 stdlib.SubstrFunc,
 	"subtract":               stdlib.SubtractFunc,
 	"timeadd":                stdlib.TimeAddFunc,
+	"timestamp":              timestampFunc,
 	"title":                  stdlib.TitleFunc,
 	"trim":                   stdlib.TrimFunc,
 	"trimprefix":             stdlib.TrimPrefixFunc,
@@ -109,3 +113,14 @@ var stdlibFunctions = map[string]function.Function{
 	"values":                 stdlib.ValuesFunc,
 	"zipmap":                 stdlib.ZipmapFunc,
 }
+
+// timestampFunc constructs a function that returns a string representation of the current date and time.
+//
+// This function was imported from terraform's datetime utilities.
+var timestampFunc = function.New(&function.Spec{
+	Params: []function.Parameter{},
+	Type:   function.StaticReturnType(cty.String),
+	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+		return cty.StringVal(time.Now().UTC().Format(time.RFC3339)), nil
+	},
+})


### PR DESCRIPTION
Fix https://github.com/docker/buildx/issues/1201.

Terraform includes a `timestamp` function to get the current time. go-cty has imported a number of the timestamp functions to it's standard library in https://github.com/zclconf/go-cty/pull/37, however, this was one was not included:

> All but one of the "impure" functions fit into the cryptographic and filesystem categories I covered already anyway. The remaining one is timestamp, and I think it would be overkill to establish a new codebase just for that so maybe again it's sufficient to just copy-paste it into another application that needs it, as long as that application is prepared to deal with a function that doesn't return a stable result.

The result isn't fully stable, but user's should expect that, and can assign the result to a top-level variable and use that as a consistent timestamp throughout the file.