### PR TITLE
docs(bake): fix target fields and show type

### DIFF
--- a/docs/guides/bake/file-definition.md
+++ b/docs/guides/bake/file-definition.md
@@ -43,23 +43,26 @@ $ docker buildx bake webapp-dev
 Complete list of valid target fields available for [HCL](#hcl-definition) and
 [JSON](#json-definition) definitions:
 
-* `args`
-* `cache-from`
-* `cache-to`
-* `context`
-* `contexts`
-* `dockerfile`
-* `inherits`
-* `labels`
-* `no-cache`
-* `no-cache-filter`
-* `output`
-* `platform`
-* `pull`
-* `secrets`
-* `ssh`
-* `tags`
-* `target`
+| Name                | Type   | Description                                                                                                                                     |
+|---------------------|--------|-------------------------------------------------------------------------------------------------------------------------------------------------|
+| `inherits`          | List   | [Inherit build options](#merging-and-inheritance) from other targets                                                                            |
+| `args`              | Map    | Set build-time variables (same as [`--build-arg` flag](https://docs.docker.com/engine/reference/commandline/buildx_build/))                     |
+| `cache-from`        | List   | External cache sources (same as [`--cache-from` flag](https://docs.docker.com/engine/reference/commandline/buildx_build/))                      |
+| `cache-to`          | List   | Cache export destinations (same as [`--cache-to` flag](https://docs.docker.com/engine/reference/commandline/buildx_build/))                     |
+| `context`           | String | Set of files located in the specified path or URL                                                                                               |
+| `contexts`          | Map    | Additional build contexts (same as [`--build-context` flag](https://docs.docker.com/engine/reference/commandline/buildx_build/))                |
+| `dockerfile`        | String | Name of the Dockerfile (same as [`--file` flag](https://docs.docker.com/engine/reference/commandline/buildx_build/))                            |
+| `dockerfile-inline` | String | Inline Dockerfile content                                                                                                                       |
+| `labels`            | Map    | Set metadata for an image (same as [`--label` flag](https://docs.docker.com/engine/reference/commandline/buildx_build/))                        |
+| `no-cache`          | Bool   | Do not use cache when building the image (same as [`--no-cache` flag](https://docs.docker.com/engine/reference/commandline/buildx_build/))      |
+| `no-cache-filter`   | List   | Do not cache specified stages (same as [`--no-cache-filter` flag](https://docs.docker.com/engine/reference/commandline/buildx_build/))          |
+| `output`            | List   | Output destination (same as [`--output` flag](https://docs.docker.com/engine/reference/commandline/buildx_build/))                              |
+| `platforms`         | List   | Set target platforms for build (same as [`--platform` flag](https://docs.docker.com/engine/reference/commandline/buildx_build/))                |
+| `pull`              | Bool   | Always attempt to pull all referenced images (same as [`--pull` flag](https://docs.docker.com/engine/reference/commandline/buildx_build/))      |
+| `secret`            | List   | Secret to expose to the build (same as [`--secret` flag](https://docs.docker.com/engine/reference/commandline/buildx_build/))                   |
+| `ssh`               | List   | SSH agent socket or keys to expose to the build (same as [`--ssh` flag](https://docs.docker.com/engine/reference/commandline/buildx_build/))    |
+| `tags`              | List   | Name and optionally a tag in the format `name:tag` (same as [`--tag` flag](https://docs.docker.com/engine/reference/commandline/buildx_build/)) |
+| `target`            | String | Set the target build stage to build (same as [`--target` flag](https://docs.docker.com/engine/reference/commandline/buildx_build/))             |
 
 ### Group
 

--- a/docs/reference/buildx_bake.md
+++ b/docs/reference/buildx_bake.md
@@ -172,9 +172,11 @@ Complete list of overridable fields:
 * `dockerfile`
 * `labels`
 * `no-cache`
+* `no-cache-filter`
 * `output`
 * `platform`
 * `pull`
+* `push`
 * `secrets`
 * `ssh`
 * `tags`


### PR DESCRIPTION
fixes #1192 

There is also some confusion around the list of valid target fields available and the overrides with the `--set` flag:

```hcl
target foo {
  secret = ["..."]
}
```

```console
$ docker buildx bake --set *.secrets=...
```

In the bake definition we have `secret` and in the override `secrets` for example.

I think we should align that in a follow-up if it makes sense:

* `no-cache-filter` > `no-cache-filters`
* `output` > `outputs`
* `secret` > `secrets`
* `ssh` > `sshs` (don't like this one :neutral_face:)

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>