### PR TITLE
docs(guide): color output controls

### DIFF
--- a/docs/guides/color-output.md
+++ b/docs/guides/color-output.md
@@ -1,0 +1,24 @@
+---
+title: "Color output controls"
+description: "Modifying colors of progress output"
+keywords: build, buildx, buildkit
+---
+
+Buildx has support for modifying the colors that are used to output information
+to the terminal. You can set the environment variable `BUILDKIT_COLORS` to
+something like `run=123,20,245:error=yellow:cancel=blue:warning=white` to set
+the colors that you would like to use:
+
+![Progress output custom colors](https://user-images.githubusercontent.com/1951866/180584033-24522385-cafd-4a54-a4a2-18f5ce74eb27.png)
+
+Setting `NO_COLOR` to anything will disable any colorized output as recommended
+by [no-color.org](https://no-color.org/):
+
+![Progress output no color](https://user-images.githubusercontent.com/1951866/180584037-e28f9997-dd4c-49cf-8b26-04864815de19.png)
+
+> **Note**
+>
+> Parsing errors will be reported but ignored. This will result in default
+> color values being used where needed.
+
+See also [the list of pre-defined colors](https://github.com/moby/buildkit/blob/master/util/progress/progressui/colors.go).

--- a/docs/reference/buildx_bake.md
+++ b/docs/reference/buildx_bake.md
@@ -121,26 +121,7 @@ $ docker buildx bake -f docker-bake.hcl --print db
 
 ### <a name="progress"></a> Set type of progress output (--progress)
 
-Same as [`build --progress`](buildx_build.md#progress). Set type of progress
-output (auto, plain, tty). Use plain to show container output (default "auto").
-
-> You can also use the `BUILDKIT_PROGRESS` environment variable to set its value.
-
-The following example uses `plain` output during the build:
-
-```console
-$ docker buildx bake --progress=plain
-
-#2 [backend internal] load build definition from Dockerfile.test
-#2 sha256:de70cb0bb6ed8044f7b9b1b53b67f624e2ccfb93d96bb48b70c1fba562489618
-#2 ...
-
-#1 [database internal] load build definition from Dockerfile.test
-#1 sha256:453cb50abd941762900a1212657a35fc4aad107f5d180b0ee9d93d6b74481bce
-#1 transferring dockerfile: 36B done
-#1 DONE 0.1s
-...
-```
+Same as [`build --progress`](buildx_build.md#progress).
 
 ### <a name="pull"></a> Always attempt to pull a newer version of the image (--pull)
 

--- a/docs/reference/buildx_build.md
+++ b/docs/reference/buildx_build.md
@@ -415,8 +415,9 @@ $ docker buildx build --platform=darwin .
 Set type of progress output (auto, plain, tty). Use plain to show container
 output (default "auto").
 
-> You can also use the `BUILDKIT_PROGRESS` environment variable to set
-> its value.
+> **Note**
+>
+> You can also use the `BUILDKIT_PROGRESS` environment variable to set its value.
 
 The following example uses `plain` output during the build:
 
@@ -432,6 +433,11 @@ $ docker buildx build --load --progress=plain .
 #2 DONE 0.0s
 ...
 ```
+
+> **Note**
+>
+> Check also our [Color output controls guide](https://docs.docker.com/build/guides/color-output/)
+> for modifying the colors that are used to output information to the terminal.
 
 ### <a name="push"></a> Push the build result to a registry (--push)
 


### PR DESCRIPTION
follow-up #1226

behavior lgtm:

![image](https://user-images.githubusercontent.com/1951866/180584033-24522385-cafd-4a54-a4a2-18f5ce74eb27.png)

![image](https://user-images.githubusercontent.com/1951866/180584037-e28f9997-dd4c-49cf-8b26-04864815de19.png)

but looks like the [example in README of BuildKit repo](https://github.com/moby/buildkit#color-output-controls) is not correct:

```console
$ BUILDKIT_COLORS="run=blue;cancel=yellow;warn=orange;error=123,12,0" docker buildx bake
WARN[0000] Could not parse BUILDKIT_COLORS component: run=blue;cancel=yellow;warn=orange;error=123,12,0  error="A valid entry must have exactly two fields"
```

should be `run=blue:cancel=yellow:warn=orange:error=123,12,0` as correct separator but then:

```console
$ BUILDKIT_COLORS="run=blue:cancel=yellow:warn=orange:error=123,12,0" docker buildx bake
WARN[0000] Unknown color value found in BUILDKIT_COLORS: warn=orange  error="Colors must be a name from the pre-defined list or a valid 3-part RGB value"
```

`orange` does not exist in pre-defined colors.

cc @spkane

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>