### PR TITLE
docs: fix link

### DIFF
--- a/docs/guides/drivers/kubernetes.md
+++ b/docs/guides/drivers/kubernetes.md
@@ -117,9 +117,9 @@ ensuring better local cache utilization.
 
 For more information on scalability, see the options for [buildx create](https://docs.docker.com/engine/reference/commandline/buildx_create/#driver-opt).
 
-## Multi-arch builds
+## Multi-platform builds
 
-The kubernetes buildx driver has support for creating [multi-architecture images](https://docs.docker.com/build/buildx/#build-multi-platform-images),
+The kubernetes buildx driver has support for creating [multi-platform images](https://docs.docker.com/build/buildx/multi-platform-images/),
 for easily building for multiple platforms at once.
 
 ### QEMU


### PR DESCRIPTION
related https://github.com/docker/docker.github.io/pull/15262

```
#16 141.8 - ./_site/build/buildx/drivers/kubernetes/index.html
#16 141.8   *  linking to internal hash #build-multi-platform-images that does not exist (line 235)
#16 141.8      <a href="/build/buildx/#build-multi-platform-images">multi-architecture images</a>
```

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>