### PR TITLE
ci: open pr on docs repo only on release

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -1,8 +1,8 @@
-name: docs
+name: docs-release
 
 on:
   release:
-    types: [ published ]
+    types: [ released ]
 
 jobs:
   open-pr:


### PR DESCRIPTION
`published` event is not right in our case as we don't want to open a pr on docs repo for pre-releases.

more info: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release

cc @glours

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>