### PR TITLE
add jedevc to maintainers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -152,6 +152,7 @@ made through a pull request.
 		people = [
 			"akihirosuda",
 			"crazy-max",
+			"jedevc",
 			"tiborvass",
 			"tonistiigi",
 		]
@@ -187,6 +188,11 @@ made through a pull request.
 	Name = "Kevin Alvarez"
 	Email = "contact@crazymax.dev"
 	GitHub = "crazy-max"
+
+	[people.jedevc]
+	Name = "Justin Chadwell"
+	Email = "me@jedevc.com"
+	GitHub = "jedevc"
 
 	[people.thajeztah]
 	Name = "Sebastiaan van Stijn"


### PR DESCRIPTION
@jedevc has made many great contributions to the repository, eg. [remote driver](https://github.com/docker/buildx/pull/1078) or [imagetools multi-repo support](https://github.com/docker/buildx/pull/1137) . Welcome to maintainers!

@AkihiroSuda @crazy-max @tiborvass 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>