### PR TITLE
docs: add correct definition of prune --all flag

### DIFF
--- a/commands/prune.go
+++ b/commands/prune.go
@@ -138,7 +138,7 @@ func pruneCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	flags.BoolVarP(&options.all, "all", "a", false, "Remove all unused images, not just dangling ones")
+	flags.BoolVarP(&options.all, "all", "a", false, "Include internal/frontend images")
 	flags.Var(&options.filter, "filter", `Provide filter values (e.g., "until=24h")`)
 	flags.Var(&options.keepStorage, "keep-storage", "Amount of disk space to keep for cache")
 	flags.BoolVar(&options.verbose, "verbose", false, "Provide a more verbose output")

--- a/docs/reference/buildx_prune.md
+++ b/docs/reference/buildx_prune.md
@@ -11,7 +11,7 @@ Remove build cache
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| `-a`, `--all` |  |  | Remove all unused images, not just dangling ones |
+| `-a`, `--all` |  |  | Include internal/frontend images |
 | [`--builder`](#builder) | `string` |  | Override the configured builder instance |
 | `--filter` | `filter` |  | Provide filter values (e.g., `until=24h`) |
 | `-f`, `--force` |  |  | Do not prompt for confirmation |
@@ -20,6 +20,26 @@ Remove build cache
 
 
 <!---MARKER_GEN_END-->
+
+## Description
+
+Clears the build cache of the selected builder.
+
+You can finely control what cache data is kept using:
+
+- The `--filter=until=<duration>` flag to keep images that have been used in
+  the last `<duration>` time.
+
+  `<duration>` is a duration string, e.g. `24h` or `2h30m`, with allowable
+  units of `(h)ours`, `(m)inutes` and `(s)econds`.
+
+- The `--keep-storage=<size>` flag to keep `<size>` bytes of data in the cache.
+
+  `<size>` is a human-readable memory string, e.g. `128mb`, `2gb`, etc. Units
+  are case-insensitive.
+
+- The `--all` flag to allow clearing internal helper images and frontend images
+  set using the `#syntax=` directive or the `BUILDKIT_SYNTAX` build argument.
 
 ## Examples
 


### PR DESCRIPTION
The previous definition was the same as the docker images prune command and referenced dangling images, which isn't what the command does. This commit brings the command description more inline with the buildctl definition.

Additionally, add some more description of what the various flags do in our reference pages.