### PR TITLE
docker api: use helper to parse context docker endpoint metadata

### DIFF
--- a/commands/util.go
+++ b/commands/util.go
@@ -107,8 +107,6 @@ func driversForNodeGroup(ctx context.Context, dockerCli command.Cli, ng *store.N
 					di.Err = err
 					return nil
 				}
-				// TODO: replace the following line with dockerclient.WithAPIVersionNegotiation option in clientForEndpoint
-				dockerapi.NegotiateAPIVersion(ctx)
 
 				contextStore := dockerCli.ContextStore()
 
@@ -183,13 +181,9 @@ func clientForEndpoint(dockerCli command.Cli, name string) (dockerclient.APIClie
 	}
 	for _, l := range list {
 		if l.Name == name {
-			dep, ok := l.Endpoints["docker"]
-			if !ok {
-				return nil, errors.Errorf("context %q does not have a Docker endpoint", name)
-			}
-			epm, ok := dep.(docker.EndpointMeta)
-			if !ok {
-				return nil, errors.Errorf("endpoint %q is not of type EndpointMeta, %T", dep, dep)
+			epm, err := docker.EndpointFromContext(l)
+			if err != nil {
+				return nil, err
 			}
 			ep, err := docker.WithTLSData(dockerCli.ContextStore(), name, epm)
 			if err != nil {


### PR DESCRIPTION
follow-up https://github.com/docker/buildx/issues/1249#issuecomment-1205162020

Use `docker.EndpointFromContext` to parse context docker endpoint metadata.

Also remove `dockerapi.NegotiateAPIVersion(ctx)` which is already provided by `ep.ClientOpts()`: https://github.com/docker/cli/blob/f1615facb1ca44e4336ab20e621315fc2cfb845a/cli/context/docker/load.go#L124.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>