### PR TITLE
invoke: add messages

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -709,10 +709,10 @@ func Invoke(ctx context.Context, cfg ContainerConfig) error {
 }
 
 func Build(ctx context.Context, drivers []DriverInfo, opt map[string]Options, docker DockerAPI, configDir string, w progress.Writer) (resp map[string]*client.SolveResponse, err error) {
-	return BuildWithResultHandler(ctx, drivers, opt, docker, configDir, w, nil)
+	return BuildWithResultHandler(ctx, drivers, opt, docker, configDir, w, nil, false)
 }
 
-func BuildWithResultHandler(ctx context.Context, drivers []DriverInfo, opt map[string]Options, docker DockerAPI, configDir string, w progress.Writer, resultHandleFunc func(driverIndex int, rCtx *ResultContext)) (resp map[string]*client.SolveResponse, err error) {
+func BuildWithResultHandler(ctx context.Context, drivers []DriverInfo, opt map[string]Options, docker DockerAPI, configDir string, w progress.Writer, resultHandleFunc func(driverIndex int, rCtx *ResultContext), allowNoOutput bool) (resp map[string]*client.SolveResponse, err error) {
 	if len(drivers) == 0 {
 		return nil, errors.Errorf("driver required for build")
 	}
@@ -737,7 +737,7 @@ func BuildWithResultHandler(ctx context.Context, drivers []DriverInfo, opt map[s
 				noOutputTargets = append(noOutputTargets, name)
 			}
 		}
-		if len(noOutputTargets) > 0 {
+		if len(noOutputTargets) > 0 && !allowNoOutput {
 			var warnNoOutputBuf bytes.Buffer
 			warnNoOutputBuf.WriteString("No output specified ")
 			if len(noOutputTargets) == 1 && noOutputTargets[0] == "default" {

--- a/monitor/monitor_test.go
+++ b/monitor/monitor_test.go
@@ -131,7 +131,7 @@ func TestMuxIO(t *testing.T) {
 				outBufs = append(outBufs, outBuf)
 				outs = append(outs, ioSetOutContext{out, nil, nil})
 			}
-			mio := newMuxIO(in, outs, tt.initIdx, "")
+			mio := newMuxIO(in, outs, tt.initIdx, func(prev int, res int) string { return "" })
 			for _, i := range tt.inputs {
 				// Add input to muxIO
 				istr, writeback := i(mio)


### PR DESCRIPTION
FIxes #1258

> On initial launch of the debug container, a message should be printed "Launching interactive container. Press Ctrl-a-c to switch to monitor console".

```console
# buildx build --builder=test --invoke sh /tmp/ctx2
[+] Building 3.8s (5/5) FINISHED                                          
 => [internal] load build definition from Dockerfile                 0.1s
 => => transferring dockerfile: 74B                                  0.0s
 => [internal] load .dockerignore                                    0.0s
 => => transferring context: 2B                                      0.0s
 => [internal] load metadata for docker.io/library/busybox:latest    3.2s
 => [1/2] FROM docker.io/library/busybox@sha256:ef320ff10026a50cf5f  0.4s
 => => resolve docker.io/library/busybox@sha256:ef320ff10026a50cf5f  0.0s
 => => sha256:50783e0dfb64b73019e973e7bce2c0d5a 773.26kB / 773.26kB  0.2s
 => => extracting sha256:50783e0dfb64b73019e973e7bce2c0d5a882301b78  0.1s
 => [2/2] RUN echo hello > /hello                                    0.2s
Launching interactive container. Press Ctrl-a-c to switch to monitor console
/ # 
```

> There should be "help" command that lists the currently available commands. Typing unknown command should also show help or show "Run help to see all supported commands".

```console
(buildx) help

Available commads are:
  reload   reloads the context and build it.
  rollback re-runs the interactive container with initial rootfs contents.
  exit     exits monitor.
  help     shows this message.
```

> Output warnings should be suppressed then running --invoke. "WARNING: No output specified " is not relevant.

Fixed to supress the warning if `--invoke` is specified.

> After issuing "rollback" command would be nice to show message "Interactive container was restarted. Press Ctrl-a-c to switch to the new container".

```console
(buildx) rollback
Interactive container was restarted. Press Ctrl-a-c to switch to the new container
```

> On monitor mode, if there is no active container and Ctrl-a-c is pressed, a message could show "No running interactive containers. You can start one by issuing rollback command".

```console
/ # exit
Switched IO
(buildx) [Type C-a-c here] No running interactive containers. You can start one by issuing rollback command
```
