### PR TITLE
bake: load .env file from working dir for compose files

### DIFF
--- a/bake/compose_test.go
+++ b/bake/compose_test.go
@@ -41,7 +41,7 @@ secrets:
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(c.Groups))
-	require.Equal(t, c.Groups[0].Name, "default")
+	require.Equal(t, "default", c.Groups[0].Name)
 	sort.Strings(c.Groups[0].Targets)
 	require.Equal(t, []string{"db", "webapp"}, c.Groups[0].Targets)
 
@@ -58,8 +58,8 @@ secrets:
 	require.Equal(t, "Dockerfile-alternate", *c.Targets[1].Dockerfile)
 	require.Equal(t, 1, len(c.Targets[1].Args))
 	require.Equal(t, "123", c.Targets[1].Args["buildno"])
-	require.Equal(t, c.Targets[1].CacheFrom, []string{"type=local,src=path/to/cache"})
-	require.Equal(t, c.Targets[1].CacheTo, []string{"type=local,dest=path/to/cache"})
+	require.Equal(t, []string{"type=local,src=path/to/cache"}, c.Targets[1].CacheFrom)
+	require.Equal(t, []string{"type=local,dest=path/to/cache"}, c.Targets[1].CacheTo)
 	require.Equal(t, "none", *c.Targets[1].NetworkMode)
 	require.Equal(t, []string{
 		"id=token,env=ENV_TOKEN",
@@ -124,9 +124,9 @@ services:
 	sort.Slice(c.Targets, func(i, j int) bool {
 		return c.Targets[i].Name < c.Targets[j].Name
 	})
-	require.Equal(t, c.Targets[0].Name, "db")
+	require.Equal(t, "db", c.Targets[0].Name)
 	require.Equal(t, "db", *c.Targets[0].Target)
-	require.Equal(t, c.Targets[1].Name, "webapp")
+	require.Equal(t, "webapp", c.Targets[1].Name)
 	require.Equal(t, "webapp", *c.Targets[1].Target)
 }
 
@@ -154,9 +154,9 @@ services:
 
 	c, err := ParseCompose(dt)
 	require.NoError(t, err)
-	require.Equal(t, c.Targets[0].Args["FOO"], "bar")
-	require.Equal(t, c.Targets[0].Args["BAR"], "zzz_foo")
-	require.Equal(t, c.Targets[0].Args["BRB"], "FOO")
+	require.Equal(t, "bar", c.Targets[0].Args["FOO"])
+	require.Equal(t, "zzz_foo", c.Targets[0].Args["BAR"])
+	require.Equal(t, "FOO", c.Targets[0].Args["BRB"])
 }
 
 func TestInconsistentComposeFile(t *testing.T) {
@@ -210,7 +210,7 @@ services:
 
 	c, err := ParseCompose(dt)
 	require.NoError(t, err)
-	require.Equal(t, c.Targets[0].Tags, []string{"foo", "bar"})
+	require.Equal(t, []string{"foo", "bar"}, c.Targets[0].Tags)
 }
 
 func TestDependsOnList(t *testing.T) {
@@ -304,19 +304,19 @@ services:
 	sort.Slice(c.Targets, func(i, j int) bool {
 		return c.Targets[i].Name < c.Targets[j].Name
 	})
-	require.Equal(t, c.Targets[0].Args, map[string]string{"CT_ECR": "foo", "CT_TAG": "bar"})
-	require.Equal(t, c.Targets[0].Tags, []string{"ct-addon:baz", "ct-addon:foo", "ct-addon:alp"})
-	require.Equal(t, c.Targets[0].Platforms, []string{"linux/amd64", "linux/arm64"})
-	require.Equal(t, c.Targets[0].CacheFrom, []string{"user/app:cache", "type=local,src=path/to/cache"})
-	require.Equal(t, c.Targets[0].CacheTo, []string{"user/app:cache", "type=local,dest=path/to/cache"})
-	require.Equal(t, c.Targets[0].Pull, newBool(true))
-	require.Equal(t, c.Targets[0].Contexts, map[string]string{"alpine": "docker-image://alpine:3.13"})
-	require.Equal(t, c.Targets[1].Tags, []string{"ct-fake-aws:bar"})
-	require.Equal(t, c.Targets[1].Secrets, []string{"id=mysecret,src=/local/secret", "id=mysecret2,src=/local/secret2"})
-	require.Equal(t, c.Targets[1].SSH, []string{"default"})
-	require.Equal(t, c.Targets[1].Platforms, []string{"linux/arm64"})
-	require.Equal(t, c.Targets[1].Outputs, []string{"type=docker"})
-	require.Equal(t, c.Targets[1].NoCache, newBool(true))
+	require.Equal(t, map[string]string{"CT_ECR": "foo", "CT_TAG": "bar"}, c.Targets[0].Args)
+	require.Equal(t, []string{"ct-addon:baz", "ct-addon:foo", "ct-addon:alp"}, c.Targets[0].Tags)
+	require.Equal(t, []string{"linux/amd64", "linux/arm64"}, c.Targets[0].Platforms)
+	require.Equal(t, []string{"user/app:cache", "type=local,src=path/to/cache"}, c.Targets[0].CacheFrom)
+	require.Equal(t, []string{"user/app:cache", "type=local,dest=path/to/cache"}, c.Targets[0].CacheTo)
+	require.Equal(t, newBool(true), c.Targets[0].Pull)
+	require.Equal(t, map[string]string{"alpine": "docker-image://alpine:3.13"}, c.Targets[0].Contexts)
+	require.Equal(t, []string{"ct-fake-aws:bar"}, c.Targets[1].Tags)
+	require.Equal(t, []string{"id=mysecret,src=/local/secret", "id=mysecret2,src=/local/secret2"}, c.Targets[1].Secrets)
+	require.Equal(t, []string{"default"}, c.Targets[1].SSH)
+	require.Equal(t, []string{"linux/arm64"}, c.Targets[1].Platforms)
+	require.Equal(t, []string{"type=docker"}, c.Targets[1].Outputs)
+	require.Equal(t, newBool(true), c.Targets[1].NoCache)
 }
 
 func TestComposeExtDedup(t *testing.T) {
@@ -345,9 +345,9 @@ services:
 	c, err := ParseCompose(dt)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(c.Targets))
-	require.Equal(t, c.Targets[0].Tags, []string{"ct-addon:foo", "ct-addon:baz"})
-	require.Equal(t, c.Targets[0].CacheFrom, []string{"user/app:cache", "type=local,src=path/to/cache"})
-	require.Equal(t, c.Targets[0].CacheTo, []string{"user/app:cache", "type=local,dest=path/to/cache"})
+	require.Equal(t, []string{"ct-addon:foo", "ct-addon:baz"}, c.Targets[0].Tags)
+	require.Equal(t, []string{"user/app:cache", "type=local,src=path/to/cache"}, c.Targets[0].CacheFrom)
+	require.Equal(t, []string{"user/app:cache", "type=local,dest=path/to/cache"}, c.Targets[0].CacheTo)
 }
 
 func TestEnv(t *testing.T) {
@@ -377,7 +377,7 @@ services:
 
 	c, err := ParseCompose(dt)
 	require.NoError(t, err)
-	require.Equal(t, c.Targets[0].Args, map[string]string{"CT_ECR": "foo", "FOO": "bsdf -csdf", "NODE_ENV": "test"})
+	require.Equal(t, map[string]string{"CT_ECR": "foo", "FOO": "bsdf -csdf", "NODE_ENV": "test"}, c.Targets[0].Args)
 }
 
 func TestPorts(t *testing.T) {

--- a/docs/guides/bake/compose-file.md
+++ b/docs/guides/bake/compose-file.md
@@ -94,6 +94,56 @@ limitations with the compose format:
 * Specifying variables or global scope attributes is not yet supported
 * `inherits` service field is not supported, but you can use [YAML anchors](https://docs.docker.com/compose/compose-file/#fragments) to reference other services like the example above
 
+## `.env` file
+
+You can declare default environment variables in an environment file named
+`.env`. This file will be loaded from the current working directory,
+where the command is executed and applied to compose definitions passed
+with `-f`.
+
+```yaml
+# docker-compose.yml
+services:
+  webapp:
+    image: docker.io/username/webapp:${TAG:-v1.0.0}
+    build:
+      dockerfile: Dockerfile
+```
+
+```
+# .env
+TAG=v1.1.0
+```
+
+```console
+$ docker buildx bake --print
+```
+```json
+{
+  "group": {
+    "default": {
+      "targets": [
+        "webapp"
+      ]
+    }
+  },
+  "target": {
+    "webapp": {
+      "context": ".",
+      "dockerfile": "Dockerfile",
+      "tags": [
+        "docker.io/username/webapp:v1.1.0"
+      ]
+    }
+  }
+}
+```
+
+> **Note**
+>
+> System environment variables take precedence over environment variables
+> in `.env` file.
+
 ## Extension field with `x-bake`
 
 Even if some fields are not (yet) available in the compose specification, you


### PR DESCRIPTION
fixes #282
carry https://github.com/docker/buildx/pull/489

Loads `.env` file if available in the working directory for compose files. The file format is the same as the compose library: https://github.com/compose-spec/compose-go/tree/master/dotenv.