### PR TITLE
enable other exporters if docker driver uses containerd

### DIFF
--- a/driver/docker/driver.go
+++ b/driver/docker/driver.go
@@ -66,9 +66,9 @@ func (d *Driver) Features() map[driver.Feature]bool {
 		}
 	}
 	return map[driver.Feature]bool{
-		driver.OCIExporter:    false,
-		driver.DockerExporter: false,
-		driver.CacheExport:    false,
+		driver.OCIExporter:    useContainerdSnapshotter,
+		driver.DockerExporter: useContainerdSnapshotter,
+		driver.CacheExport:    useContainerdSnapshotter,
 		driver.MultiPlatform:  useContainerdSnapshotter,
 	}
 }


### PR DESCRIPTION
follow-up for #1260

Even if these are not supported atm, I think this is the intention, so buildx should try to use all these features.

@ndeloof @crazy-max 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>