### PR TITLE
hack: use single output dir

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,1 @@
 bin/
-cross-out/
-release-out/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ on:
 
 env:
   REPO_SLUG: "docker/buildx-bin"
-  RELEASE_OUT: "./release-out"
+  DESTDIR: "./bin"
 
 jobs:
   test:
@@ -48,7 +48,7 @@ jobs:
         name: Upload coverage
         uses: codecov/codecov-action@v3
         with:
-          file: ./coverage/coverage.txt
+          directory: ${{ env.DESTDIR }}/coverage
 
   prepare:
     runs-on: ubuntu-latest
@@ -107,7 +107,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: buildx
-          path: ${{ env.RELEASE_OUT }}/*
+          path: ${{ env.DESTDIR }}/release/*
           if-no-files-found: error
 
   bin-image:
@@ -170,18 +170,18 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: buildx
-          path: ${{ env.RELEASE_OUT }}
+          path: ${{ env.DESTDIR }}
       -
         name: Create checksums
         run: ./hack/hash-files
       -
         name: List artifacts
         run: |
-          tree -nh ${{ env.RELEASE_OUT }}
+          tree -nh ${{ env.DESTDIR }}
       -
         name: Check artifacts
         run: |
-          find ${{ env.RELEASE_OUT }} -type f -exec file -e ascii -- {} +
+          find ${{ env.DESTDIR }} -type f -exec file -e ascii -- {} +
       -
         name: GitHub Release
         if: startsWith(github.ref, 'refs/tags/v')
@@ -190,7 +190,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           draft: true
-          files: ${{ env.RELEASE_OUT }}/*
+          files: ${{ env.DESTDIR }}/*
 
   buildkit-edge:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,11 +18,12 @@ on:
       - 'README.md'
       - 'docs/**'
 
+env:
+  DESTDIR: "./bin"
+
 jobs:
   build:
     runs-on: ubuntu-20.04
-    env:
-      BIN_OUT: ./bin
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -43,13 +44,13 @@ jobs:
       -
         name: Rename binary
         run: |
-          mv ${{ env.BIN_OUT }}/buildx ${{ env.BIN_OUT }}/docker-buildx
+          mv ${{ env.DESTDIR }}/build/buildx ${{ env.DESTDIR }}/build/docker-buildx
       -
         name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
           name: binary
-          path: ${{ env.BIN_OUT }}
+          path: ${{ env.DESTDIR }}/build
           if-no-files-found: error
           retention-days: 7
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,1 @@
-bin
-coverage
-cross-out
-release-out
+/bin

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,6 @@ else
 	$(error "Buildx is required: https://github.com/docker/buildx#installing")
 endif
 
-export BIN_OUT = ./bin
-export RELEASE_OUT = ./release-out
-
 shell:
 	./hack/shell
 
@@ -22,7 +19,7 @@ binaries-cross:
 
 install: binaries
 	mkdir -p ~/.docker/cli-plugins
-	install bin/buildx ~/.docker/cli-plugins/docker-buildx
+	install bin/build/buildx ~/.docker/cli-plugins/docker-buildx
 
 release:
 	./hack/release

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,17 +1,14 @@
 variable "GO_VERSION" {
   default = "1.19"
 }
-variable "BIN_OUT" {
-  default = "./bin"
-}
-variable "RELEASE_OUT" {
-  default = "./release-out"
-}
 variable "DOCS_FORMATS" {
   default = "md"
 }
+variable "DESTDIR" {
+  default = "./bin"
+}
 
-// Special target: https://github.com/docker/metadata-action#bake-definition
+# Special target: https://github.com/docker/metadata-action#bake-definition
 target "meta-helper" {
   tags = ["docker/buildx-bin:local"]
 }
@@ -97,13 +94,13 @@ target "mod-outdated" {
 target "test" {
   inherits = ["_common"]
   target = "test-coverage"
-  output = ["./coverage"]
+  output = ["${DESTDIR}/coverage"]
 }
 
 target "binaries" {
   inherits = ["_common"]
   target = "binaries"
-  output = [BIN_OUT]
+  output = ["${DESTDIR}/build"]
   platforms = ["local"]
 }
 
@@ -127,7 +124,7 @@ target "binaries-cross" {
 target "release" {
   inherits = ["binaries-cross"]
   target = "release"
-  output = [RELEASE_OUT]
+  output = ["${DESTDIR}/release"]
 }
 
 target "image" {

--- a/hack/hash-files
+++ b/hack/hash-files
@@ -2,17 +2,21 @@
 
 set -eu -o pipefail
 
-: ${RELEASE_OUT=./release-out}
+: "${DESTDIR=./bin/release}"
+
+if [ ! -d "$DESTDIR" ]; then
+  exit 0
+fi
 
 # checksums
-if ! type shasum > /dev/null 2>&1; then
+if ! command shasum > /dev/null 2>&1; then
   echo >&2 "ERROR: shasum is required"
   exit 1
 fi
-find ./${RELEASE_OUT}/ -type f \( -iname "buildx-*" ! -iname "*darwin*" \) -print0 | sort -z | xargs -r0 shasum -a 256 -b | sed 's# .*/#  #' > ./${RELEASE_OUT}/checksums.txt
+find ./${DESTDIR}/ -type f \( -iname "buildx-*" ! -iname "*darwin*" \) -print0 | sort -z | xargs -r0 shasum -a 256 -b | sed 's# .*/#  #' > ./${DESTDIR}/checksums.txt
 
 # verify
 (
-  cd ./${RELEASE_OUT}
+  cd ./${DESTDIR}
   shasum -a 256 -U -c checksums.txt
 )

--- a/hack/release
+++ b/hack/release
@@ -2,10 +2,10 @@
 
 set -eu -o pipefail
 
-: ${BUILDX_CMD=docker buildx}
-: ${RELEASE_OUT=./release-out}
-: ${CACHE_FROM=}
-: ${CACHE_TO=}
+: "${BUILDX_CMD=docker buildx}"
+: "${DESTDIR=./bin/release}"
+: "${CACHE_FROM=}"
+: "${CACHE_TO=}"
 
 if [ -n "$CACHE_FROM" ]; then
   for cfrom in $CACHE_FROM; do
@@ -19,10 +19,10 @@ if [ -n "$CACHE_TO" ]; then
 fi
 
 # release
-(set -x ; ${BUILDX_CMD} bake "${cacheFlags[@]}" --set "*.output=$RELEASE_OUT" release)
+(set -x ; ${BUILDX_CMD} bake "${cacheFlags[@]}" --set "*.output=$DESTDIR" release)
 
 # wrap binaries
-mv -f ./${RELEASE_OUT}/**/* ./${RELEASE_OUT}/
-find ./${RELEASE_OUT} -type d -empty -delete
+mv -f ./${DESTDIR}/**/* ./${DESTDIR}/
+find ./${DESTDIR} -type d -empty -delete
 
 source ./hack/hash-files

--- a/hack/shell
+++ b/hack/shell
@@ -2,8 +2,8 @@
 
 set -e
 
-: ${BUILDX_CMD=docker buildx}
-: ${TMUX=}
+: "${BUILDX_CMD=docker buildx}"
+: "${TMUX=}"
 
 function clean {
   docker rmi $iid

--- a/hack/test-driver
+++ b/hack/test-driver
@@ -2,14 +2,14 @@
 
 set -eu -o pipefail
 
-: ${BUILDX_CMD=docker buildx}
-: ${BUILDKIT_IMAGE=moby/buildkit:buildx-stable-1}
-: ${BUILDKIT_CFG=}
-: ${DRIVER=docker-container}
-: ${DRIVER_OPT=}
-: ${ENDPOINT=}
-: ${MULTI_NODE=0}
-: ${PLATFORMS=linux/amd64,linux/arm64}
+: "${BUILDX_CMD=docker buildx}"
+: "${BUILDKIT_IMAGE=moby/buildkit:buildx-stable-1}"
+: "${BUILDKIT_CFG=}"
+: "${DRIVER=docker-container}"
+: "${DRIVER_OPT=}"
+: "${ENDPOINT=}"
+: "${MULTI_NODE=0}"
+: "${PLATFORMS=linux/amd64,linux/arm64}"
 
 function buildxCmd {
   (set -x ; $BUILDX_CMD "$@")

--- a/hack/update-docs
+++ b/hack/update-docs
@@ -2,11 +2,11 @@
 
 set -eu -o pipefail
 
-: ${BUILDX_CMD=docker buildx}
-: ${FORMATS=md}
+: "${BUILDX_CMD=docker buildx}"
+: "${FORMATS=md}"
 
 output=$(mktemp -d -t buildx-output.XXXXXXXXXX)
 (set -x ; DOCS_FORMATS=$FORMATS ${BUILDX_CMD} bake --set "*.output=$output" update-docs)
 rm -rf ./docs/reference/*
 cp -R "$output"/out/* ./docs/
-rm -rf $output
+rm -rf "$output"

--- a/hack/update-vendor
+++ b/hack/update-vendor
@@ -2,10 +2,10 @@
 
 set -eu -o pipefail
 
-: ${BUILDX_CMD=docker buildx}
+: "${BUILDX_CMD=docker buildx}"
 
 output=$(mktemp -d -t buildx-output.XXXXXXXXXX)
 (set -x ; ${BUILDX_CMD} bake --set "*.output=$output" update-vendor)
 rm -rf ./vendor
 cp -R "$output"/out/* .
-rm -rf $output
+rm -rf "$output"


### PR DESCRIPTION
reduce footprint in our gitignore by using a single output dir for build, cross and coverage. also remove unused `cross-out`. structure will look like this:

* `./bin/build`
* `./bin/coverage`
* `./bin/release`

can be overridden using the `DESTDIR` env var. name of this en var seems to be the more approriate in our case: https://www.gnu.org/prep/standards/html_node/DESTDIR.html.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>