### PR TITLE
docker-container: restart-policy opt

### DIFF
--- a/driver/docker-container/driver.go
+++ b/driver/docker-container/driver.go
@@ -44,17 +44,18 @@ type Driver struct {
 
 	// if you add fields, remember to update docs:
 	// https://github.com/docker/docs/blob/main/content/build/drivers/docker-container.md
-	netMode      string
-	image        string
-	memory       opts.MemBytes
-	memorySwap   opts.MemSwapBytes
-	cpuQuota     int64
-	cpuPeriod    int64
-	cpuShares    int64
-	cpusetCpus   string
-	cpusetMems   string
-	cgroupParent string
-	env          []string
+	netMode       string
+	image         string
+	memory        opts.MemBytes
+	memorySwap    opts.MemSwapBytes
+	cpuQuota      int64
+	cpuPeriod     int64
+	cpuShares     int64
+	cpusetCpus    string
+	cpusetMems    string
+	cgroupParent  string
+	restartPolicy container.RestartPolicy
+	env           []string
 }
 
 func (d *Driver) IsMobyDriver() bool {
@@ -121,7 +122,8 @@ func (d *Driver) create(ctx context.Context, l progress.SubLogger) error {
 	useInit := true // let it cleanup exited processes created by BuildKit's container API
 	return l.Wrap("creating container "+d.Name, func() error {
 		hc := &container.HostConfig{
-			Privileged: true,
+			Privileged:    true,
+			RestartPolicy: d.restartPolicy,
 			Mounts: []mount.Mount{
 				{
 					Type:   mount.TypeVolume,

--- a/driver/docker-container/factory.go
+++ b/driver/docker-container/factory.go
@@ -7,12 +7,14 @@ import (
 	"strings"
 
 	"github.com/docker/buildx/driver"
+	dockeropts "github.com/docker/cli/opts"
 	dockerclient "github.com/docker/docker/client"
 	"github.com/pkg/errors"
 )
 
 const prioritySupported = 30
 const priorityUnsupported = 70
+const defaultRestartPolicy = "unless-stopped"
 
 func init() {
 	driver.Register(&factory{})
@@ -40,7 +42,15 @@ func (f *factory) New(ctx context.Context, cfg driver.InitConfig) (driver.Driver
 	if cfg.DockerAPI == nil {
 		return nil, errors.Errorf("%s driver requires docker API access", f.Name())
 	}
-	d := &Driver{factory: f, InitConfig: cfg}
+	rp, err := dockeropts.ParseRestartPolicy(defaultRestartPolicy)
+	if err != nil {
+		return nil, err
+	}
+	d := &Driver{
+		factory:       f,
+		InitConfig:    cfg,
+		restartPolicy: rp,
+	}
 	for k, v := range cfg.DriverOpts {
 		switch {
 		case k == "network":
@@ -82,6 +92,11 @@ func (f *factory) New(ctx context.Context, cfg driver.InitConfig) (driver.Driver
 			d.cpusetMems = v
 		case k == "cgroup-parent":
 			d.cgroupParent = v
+		case k == "restart-policy":
+			d.restartPolicy, err = dockeropts.ParseRestartPolicy(v)
+			if err != nil {
+				return nil, err
+			}
 		case strings.HasPrefix(k, "env."):
 			envName := strings.TrimPrefix(k, "env.")
 			if envName == "" {

--- a/tests/create.go
+++ b/tests/create.go
@@ -17,6 +17,7 @@ func createCmd(sb integration.Sandbox, opts ...cmdOpt) (string, error) {
 
 var createTests = []func(t *testing.T, sb integration.Sandbox){
 	testCreateMemoryLimit,
+	testCreateRestartAlways,
 }
 
 func testCreateMemoryLimit(t *testing.T, sb integration.Sandbox) {
@@ -34,6 +35,25 @@ func testCreateMemoryLimit(t *testing.T, sb integration.Sandbox) {
 	})
 
 	out, err := createCmd(sb, withArgs("--driver", "docker-container", "--driver-opt", "network=host", "--driver-opt", "memory=1g"))
+	require.NoError(t, err, out)
+	builderName = strings.TrimSpace(out)
+}
+
+func testCreateRestartAlways(t *testing.T, sb integration.Sandbox) {
+	if sb.Name() != "docker-container" {
+		t.Skip("only testing for docker-container driver")
+	}
+
+	var builderName string
+	t.Cleanup(func() {
+		if builderName == "" {
+			return
+		}
+		out, err := rmCmd(sb, withArgs(builderName))
+		require.NoError(t, err, out)
+	})
+
+	out, err := createCmd(sb, withArgs("--driver", "docker-container", "--driver-opt", "restart-policy=always"))
 	require.NoError(t, err, out)
 	builderName = strings.TrimSpace(out)
 }


### PR DESCRIPTION
Currently we can't set the restart policy for buildkit containers created with `docker-container` driver. In my use case I have restarted some machines but as the default restart policy is `no`, the containers were not running. Even if we ensure nodes are booted before building I think it's still useful to have this driver opt.

Current behavior (`unless-stopped`) is kept.

Needs docs update in follow-up (cc @dvdksn): https://docs.docker.com/build/drivers/docker-container/#synopsis

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>