### PR TITLE
create: improve interface when attempting to create docker driver

### DIFF
--- a/commands/create.go
+++ b/commands/create.go
@@ -135,8 +135,8 @@ func runCreate(dockerCli command.Cli, in createOptions, args []string) error {
 		}
 	}
 
-	if driver.GetFactory(driverName, true) == nil {
-		return errors.Errorf("failed to find driver %q", driverName)
+	if _, err := driver.GetFactory(driverName, true); err != nil {
+		return err
 	}
 
 	ngOriginal := ng
@@ -282,7 +282,7 @@ func createCmd(dockerCli command.Cli) *cobra.Command {
 	var options createOptions
 
 	var drivers bytes.Buffer
-	for _, d := range driver.GetFactories() {
+	for _, d := range driver.GetFactories(true) {
 		if len(drivers.String()) > 0 {
 			drivers.WriteString(", ")
 		}

--- a/commands/util.go
+++ b/commands/util.go
@@ -60,8 +60,9 @@ func driversForNodeGroup(ctx context.Context, dockerCli command.Cli, ng *store.N
 
 	var f driver.Factory
 	if ng.Driver != "" {
-		f = driver.GetFactory(ng.Driver, true)
-		if f == nil {
+		var err error
+		f, err = driver.GetFactory(ng.Driver, true)
+		if err != nil {
 			return nil, errors.Errorf("failed to find driver %q", f)
 		}
 	} else {

--- a/docs/reference/buildx_create.md
+++ b/docs/reference/buildx_create.md
@@ -15,7 +15,7 @@ Create a new builder instance
 | `--bootstrap` |  |  | Boot builder after creation |
 | [`--buildkitd-flags`](#buildkitd-flags) | `string` |  | Flags for buildkitd daemon |
 | [`--config`](#config) | `string` |  | BuildKit config file |
-| [`--driver`](#driver) | `string` |  | Driver to use (available: `docker`, `docker-container`, `kubernetes`, `remote`) |
+| [`--driver`](#driver) | `string` |  | Driver to use (available: `docker-container`, `kubernetes`, `remote`) |
 | [`--driver-opt`](#driver-opt) | `stringArray` |  | Options for the driver |
 | [`--leave`](#leave) |  |  | Remove a node from builder instead of changing it |
 | [`--name`](#name) | `string` |  | Builder instance name |


### PR DESCRIPTION
Fix https://github.com/docker/buildx/issues/1269.

Previously, the help information for buildx indicated that users could create a new instance of the docker driver - which is explicitly
something we don't support, driver of this form are automatically derived from the available list of docker contexts.

This patch ensures that don't have AllowsInstance set will not appear in the help text, and additionally provide a new more specific error message instead of the generic "failed to find driver". This should help point users in the correct direction.