### PR TITLE
Consistent experimental help

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -479,7 +479,7 @@ func buildCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 	flags.StringArrayVar(&options.platforms, "platform", platformsDefault, "Set target platform for build")
 
 	if isExperimental() {
-		flags.StringVar(&options.printFunc, "print", "", "Print result of information request (outline, targets)")
+		flags.StringVar(&options.printFunc, "print", "", "Print result of information request (e.g., outline, targets) [experimental]")
 	}
 
 	flags.BoolVar(&options.exportPush, "push", false, `Shorthand for "--output=type=registry"`)
@@ -501,7 +501,7 @@ func buildCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 	flags.Var(options.ulimits, "ulimit", "Ulimit options")
 
 	if isExperimental() {
-		flags.StringVar(&options.invoke, "invoke", "", "Invoke a command after the build. BUILDX_EXPERIMENTAL=1 is required.")
+		flags.StringVar(&options.invoke, "invoke", "", "Invoke a command after the build [experimental]")
 	}
 
 	// hidden flags

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -20,6 +20,7 @@ target "_common" {
   args = {
     GO_VERSION = GO_VERSION
     BUILDKIT_CONTEXT_KEEP_GIT_DIR = 1
+    BUILDX_EXPERIMENTAL = 1
   }
 }
 

--- a/docs/reference/buildx_build.md
+++ b/docs/reference/buildx_build.md
@@ -25,6 +25,7 @@ Start a build
 | [`--cgroup-parent`](https://docs.docker.com/engine/reference/commandline/build/#use-a-custom-parent-cgroup---cgroup-parent) | `string` |  | Optional parent cgroup for the container |
 | [`-f`](https://docs.docker.com/engine/reference/commandline/build/#specify-a-dockerfile--f), [`--file`](https://docs.docker.com/engine/reference/commandline/build/#specify-a-dockerfile--f) | `string` |  | Name of the Dockerfile (default: `PATH/Dockerfile`) |
 | `--iidfile` | `string` |  | Write the image ID to the file |
+| `--invoke` | `string` |  | Invoke a command after the build [experimental] |
 | `--label` | `stringArray` |  | Set metadata for an image |
 | [`--load`](#load) |  |  | Shorthand for `--output=type=docker` |
 | [`--metadata-file`](#metadata-file) | `string` |  | Write build result metadata to the file |
@@ -33,6 +34,7 @@ Start a build
 | `--no-cache-filter` | `stringArray` |  | Do not cache specified stages |
 | [`-o`](#output), [`--output`](#output) | `stringArray` |  | Output destination (format: `type=local,dest=path`) |
 | [`--platform`](#platform) | `stringArray` |  | Set target platform for build |
+| `--print` | `string` |  | Print result of information request (e.g., outline, targets) [experimental] |
 | [`--progress`](#progress) | `string` | `auto` | Set type of progress output (`auto`, `plain`, `tty`). Use plain to show container output |
 | `--pull` |  |  | Always attempt to pull all referenced images |
 | [`--push`](#push) |  |  | Shorthand for `--output=type=registry` |
@@ -46,6 +48,9 @@ Start a build
 
 
 <!---MARKER_GEN_END-->
+
+Flags marked with `[experimental]` need to be explicitly enabled by setting the
+`BUILDX_EXPERIMENTAL=1` environment variable.
 
 ## Description
 

--- a/hack/dockerfiles/docs.Dockerfile
+++ b/hack/dockerfiles/docs.Dockerfile
@@ -14,6 +14,7 @@ RUN apk add --no-cache rsync git
 WORKDIR /src
 COPY --from=docsgen /out/docsgen /usr/bin
 ARG FORMATS
+ARG BUILDX_EXPERIMENTAL
 RUN --mount=target=/context \
   --mount=target=.,type=tmpfs <<EOT
 set -e


### PR DESCRIPTION
Follow-up to https://github.com/docker/buildx/pull/1267

This patch ensures that we have consistent help messages between the two experimental options, and additionally adds the experimental options to the command reference along with information on how to enable them.