### PR TITLE
bake(compose): fix unskipped services without build context

### DIFF
--- a/bake/bake_test.go
+++ b/bake/bake_test.go
@@ -530,7 +530,8 @@ func TestReadEmptyTargets(t *testing.T) {
 		Name: "docker-compose.yml",
 		Data: []byte(`
 services:
-  app2: {}
+  app2:
+    build: {}
 `),
 	}
 

--- a/bake/bake_test.go
+++ b/bake/bake_test.go
@@ -1227,3 +1227,35 @@ target "f" {
 		})
 	}
 }
+
+func TestUnknownExt(t *testing.T) {
+	dt := []byte(`
+		target "app" {
+			context = "dir"
+			args = {
+				v1 = "foo"
+			}
+		}
+		`)
+	dt2 := []byte(`
+services:
+  app:
+    build:
+      dockerfile: Dockerfile-alternate
+      args:
+        v2: "bar"
+`)
+
+	c, err := ParseFiles([]File{
+		{Data: dt, Name: "c1.foo"},
+		{Data: dt2, Name: "c2.bar"},
+	}, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(c.Targets))
+	require.Equal(t, "app", c.Targets[0].Name)
+	require.Equal(t, "foo", c.Targets[0].Args["v1"])
+	require.Equal(t, "bar", c.Targets[0].Args["v2"])
+	require.Equal(t, "dir", *c.Targets[0].Context)
+	require.Equal(t, "Dockerfile-alternate", *c.Targets[0].Dockerfile)
+}

--- a/bake/compose_test.go
+++ b/bake/compose_test.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"testing"
 
+	compose "github.com/compose-spec/compose-go/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -38,7 +39,7 @@ secrets:
     file: /root/.aws/credentials
 `)
 
-	c, err := ParseCompose(dt, nil)
+	c, err := ParseCompose([]compose.ConfigFile{{Content: dt}}, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(c.Groups))
@@ -76,9 +77,10 @@ services:
     webapp:
         build: ./db
 `)
-	c, err := ParseCompose(dt, nil)
+	c, err := ParseCompose([]compose.ConfigFile{{Content: dt}}, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(c.Groups))
+	require.Equal(t, 1, len(c.Targets))
 }
 
 func TestParseComposeTarget(t *testing.T) {
@@ -94,7 +96,7 @@ services:
       target: webapp
 `)
 
-	c, err := ParseCompose(dt, nil)
+	c, err := ParseCompose([]compose.ConfigFile{{Content: dt}}, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, 2, len(c.Targets))
@@ -119,7 +121,7 @@ services:
       target: webapp
 `)
 
-	c, err := ParseCompose(dt, nil)
+	c, err := ParseCompose([]compose.ConfigFile{{Content: dt}}, nil)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(c.Targets))
 	sort.Slice(c.Targets, func(i, j int) bool {
@@ -153,7 +155,7 @@ services:
 	os.Setenv("ZZZ_BAR", "zzz_foo")
 	defer os.Unsetenv("ZZZ_BAR")
 
-	c, err := ParseCompose(dt, sliceToMap(os.Environ()))
+	c, err := ParseCompose([]compose.ConfigFile{{Content: dt}}, sliceToMap(os.Environ()))
 	require.NoError(t, err)
 	require.Equal(t, "bar", c.Targets[0].Args["FOO"])
 	require.Equal(t, "zzz_foo", c.Targets[0].Args["BAR"])
@@ -167,8 +169,8 @@ services:
     entrypoint: echo 1
 `)
 
-	_, err := ParseCompose(dt, nil)
-	require.NoError(t, err)
+	_, err := ParseCompose([]compose.ConfigFile{{Content: dt}}, nil)
+	require.Error(t, err)
 }
 
 func TestAdvancedNetwork(t *testing.T) {
@@ -192,7 +194,7 @@ networks:
           gateway: 10.5.0.254
 `)
 
-	_, err := ParseCompose(dt, nil)
+	_, err := ParseCompose([]compose.ConfigFile{{Content: dt}}, nil)
 	require.NoError(t, err)
 }
 
@@ -209,7 +211,7 @@ services:
         - bar
 `)
 
-	c, err := ParseCompose(dt, nil)
+	c, err := ParseCompose([]compose.ConfigFile{{Content: dt}}, nil)
 	require.NoError(t, err)
 	require.Equal(t, []string{"foo", "bar"}, c.Targets[0].Tags)
 }
@@ -246,7 +248,7 @@ networks:
     name: test-net
 `)
 
-	_, err := ParseCompose(dt, nil)
+	_, err := ParseCompose([]compose.ConfigFile{{Content: dt}}, nil)
 	require.NoError(t, err)
 }
 
@@ -299,7 +301,7 @@ services:
         no-cache: true
 `)
 
-	c, err := ParseCompose(dt, nil)
+	c, err := ParseCompose([]compose.ConfigFile{{Content: dt}}, nil)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(c.Targets))
 	sort.Slice(c.Targets, func(i, j int) bool {
@@ -343,7 +345,7 @@ services:
           - type=local,dest=path/to/cache
 `)
 
-	c, err := ParseCompose(dt, nil)
+	c, err := ParseCompose([]compose.ConfigFile{{Content: dt}}, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(c.Targets))
 	require.Equal(t, []string{"ct-addon:foo", "ct-addon:baz"}, c.Targets[0].Tags)
@@ -376,7 +378,7 @@ services:
       - ` + envf.Name() + `
 `)
 
-	c, err := ParseCompose(dt, nil)
+	c, err := ParseCompose([]compose.ConfigFile{{Content: dt}}, nil)
 	require.NoError(t, err)
 	require.Equal(t, map[string]string{"CT_ECR": "foo", "FOO": "bsdf -csdf", "NODE_ENV": "test"}, c.Targets[0].Args)
 }
@@ -397,7 +399,10 @@ services:
 `)
 
 	chdir(t, tmpdir)
-	c, _, err := ParseComposeFile(dt, "docker-compose.yml")
+	c, err := ParseComposeFiles([]File{{
+		Name: "docker-compose.yml",
+		Data: dt,
+	}})
 	require.NoError(t, err)
 	require.Equal(t, map[string]string{"FOO": "bar"}, c.Targets[0].Args)
 }
@@ -419,7 +424,7 @@ services:
         published: "3306"
         protocol: tcp
 `)
-	_, err := ParseCompose(dt, nil)
+	_, err := ParseCompose([]compose.ConfigFile{{Content: dt}}, nil)
 	require.NoError(t, err)
 }
 
@@ -465,12 +470,12 @@ func TestServiceName(t *testing.T) {
 	for _, tt := range cases {
 		tt := tt
 		t.Run(tt.svc, func(t *testing.T) {
-			_, err := ParseCompose([]byte(`
+			_, err := ParseCompose([]compose.ConfigFile{{Content: []byte(`
 services:
-  `+tt.svc+`:
+  ` + tt.svc + `:
     build:
       context: .
-`), nil)
+`)}}, nil)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
@@ -536,7 +541,7 @@ services:
 	for _, tt := range cases {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := ParseCompose(tt.dt, nil)
+			_, err := ParseCompose([]compose.ConfigFile{{Content: tt.dt}}, nil)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {


### PR DESCRIPTION
fixes #1276 

while fixing compose consistency check in https://github.com/docker/buildx/pull/1181 a regression was introduced where services without build context were taken into account.

it was not detected because our test `TestNoBuildOutOfTreeService` was not checking the targets length: https://github.com/docker/buildx/blob/611329fc7f1365556789bff4747f608d40cdc8a9/bake/compose_test.go#L71-L82

by fixing this issue we now remove the ability to merge compose files without a build context https://github.com/docker/buildx/issues/1172. To fix this we now parse compose files all together so the compose-go library can handle a proper sanity check on its side.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>