### PR TITLE
inspect: add buildkit version information to command output

### DIFF
--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -115,6 +115,9 @@ func runInspect(dockerCli command.Cli, in inspectOptions) error {
 				if len(n.Flags) > 0 {
 					fmt.Fprintf(w, "Flags:\t%s\n", strings.Join(n.Flags, " "))
 				}
+				if ngi.drivers[i].version != "" {
+					fmt.Fprintf(w, "Buildkit:\t%s\n", ngi.drivers[i].version)
+				}
 				fmt.Fprintf(w, "Platforms:\t%s\n", strings.Join(platformutil.FormatInGroups(n.Platforms, ngi.drivers[i].platforms), ", "))
 			}
 		}

--- a/docs/reference/buildx_inspect.md
+++ b/docs/reference/buildx_inspect.md
@@ -44,7 +44,7 @@ The following example shows information about a builder instance named
 `elated_tesla`:
 
 > **Note**
-> 
+>
 > Asterisk `*` next to node build platform(s) indicate they had been set manually during `buildx create`. Otherwise, it had been autodetected.
 
 ```console
@@ -57,10 +57,12 @@ Nodes:
 Name:      elated_tesla0
 Endpoint:  unix:///var/run/docker.sock
 Status:    running
+Buildkit:  v0.10.3
 Platforms: linux/amd64
 
 Name:      elated_tesla1
 Endpoint:  ssh://ubuntu@1.2.3.4
 Status:    running
+Buildkit:  v0.10.3
 Platforms: linux/arm64*, linux/arm/v7, linux/arm/v6
 ```


### PR DESCRIPTION
Follow-up to #998 - this adds the buildkit version information to the `buildx inspect` command if it's available.