### PR TITLE
bake: ensure ReadTargets returns the original group

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -84,7 +84,7 @@ func ReadLocalFiles(names []string) ([]File, error) {
 	return out, nil
 }
 
-func ReadTargets(ctx context.Context, files []File, targets, overrides []string, defaults map[string]string) (map[string]*Target, []*Group, error) {
+func ReadTargets(ctx context.Context, files []File, targets, overrides []string, defaults map[string]string) (map[string]*Target, map[string]*Group, error) {
 	c, err := ParseFiles(files, defaults)
 	if err != nil {
 		return nil, nil, err
@@ -111,30 +111,23 @@ func ReadTargets(ctx context.Context, files []File, targets, overrides []string,
 		}
 	}
 
-	var g []*Group
+	gs := map[string]*Group{}
 	if len(targets) == 0 || (len(targets) == 1 && targets[0] == "default") {
 		for _, group := range c.Groups {
 			if group.Name != "default" {
 				continue
 			}
-			g = []*Group{{Targets: group.Targets}}
+			gs[group.Name] = group
 		}
 	} else {
-		var gt []string
 		for _, target := range targets {
-			isGroup := false
 			for _, group := range c.Groups {
 				if target == group.Name {
-					gt = append(gt, group.Targets...)
-					isGroup = true
+					gs[group.Name] = group
 					break
 				}
 			}
-			if !isGroup {
-				gt = append(gt, target)
-			}
 		}
-		g = []*Group{{Targets: dedupSlice(gt)}}
 	}
 
 	for name, t := range m {
@@ -143,7 +136,7 @@ func ReadTargets(ctx context.Context, files []File, targets, overrides []string,
 		}
 	}
 
-	return m, g, nil
+	return m, gs, nil
 }
 
 func dedupSlice(s []string) []string {

--- a/commands/bake.go
+++ b/commands/bake.go
@@ -120,17 +120,11 @@ func runBake(dockerCli command.Cli, targets []string, in bakeOptions) (err error
 	}
 
 	if in.printOnly {
-		var defg map[string]*bake.Group
-		if len(grps) == 1 {
-			defg = map[string]*bake.Group{
-				"default": grps[0],
-			}
-		}
 		dt, err := json.MarshalIndent(struct {
 			Group  map[string]*bake.Group  `json:"group,omitempty"`
 			Target map[string]*bake.Target `json:"target"`
 		}{
-			defg,
+			grps,
 			tgts,
 		}, "", "  ")
 		if err != nil {


### PR DESCRIPTION
This implements the first option from #1058 - it's also left open to now be possible to implement recursive group resolution, though that hasn't been added yet. Since we already resolve targets recursively, I think we probably should resolve all the groups recursively as well, but that's something to consider in a different PR.

With this patch, there's a couple of implications. With the file:

```hcl
group "default" {
    targets = ["other-group"]
}

group "other-group" {
    targets = ["app"]
}

target "app" {
    dockerfile = "Dockerfile"
    tags = ["docker.io/username/app"]
}
```

We get the following different behavior:
```bash
$ docker buildx bake --print other-group
{
  "group": {
    "other-group": { <-- this is other-group, not default
      "targets": [
        "app"
      ]
    }
  },
  "target": {
    "app": {
      "context": ".",
      "dockerfile": "Dockerfile",
      "tags": [
        "docker.io/username/app"
      ]
    }
  }
}

$ docker buildx bake --print app
{  <-- app is not part of the default group, so don't print a group here
  "target": {
    "app": {
      "context": ".",
      "dockerfile": "Dockerfile",
      "tags": [
        "docker.io/username/app"
      ]
    }
  }
}
```

In the latter, `app` is not part of a selected group, so the field is left empty.