### PR TITLE
progress: add prefix to vertex progress group

### DIFF
--- a/util/progress/multiwriter.go
+++ b/util/progress/multiwriter.go
@@ -24,6 +24,9 @@ func (p *prefixed) Write(v *client.SolveStatus) {
 	if p.force {
 		for _, v := range v.Vertexes {
 			v.Name = addPrefix(p.pfx, v.Name)
+			if v.ProgressGroup != nil {
+				v.ProgressGroup.Name = addPrefix(p.pfx, v.ProgressGroup.Name)
+			}
 		}
 	}
 	p.Writer.Write(v)


### PR DESCRIPTION
Fixes #1195. CC @ciaranmcnulty.

As buildkit now uses progress groups for the COPY --link instruction we need to ensure that we additionally prefix the progress group name, or the target name will be left off in bake commands with more than one target.