### PR TITLE
return di.Err when it's not nil

### DIFF
--- a/commands/diskusage.go
+++ b/commands/diskusage.go
@@ -40,7 +40,7 @@ func runDiskUsage(dockerCli command.Cli, opts duOptions) error {
 
 	for _, di := range dis {
 		if di.Err != nil {
-			return err
+			return di.Err
 		}
 	}
 

--- a/commands/prune.go
+++ b/commands/prune.go
@@ -61,7 +61,7 @@ func runPrune(dockerCli command.Cli, opts pruneOptions) error {
 
 	for _, di := range dis {
 		if di.Err != nil {
-			return err
+			return di.Err
 		}
 	}
 


### PR DESCRIPTION
Fix driver error being omitted