### PR TITLE
kubernetes: rootless: support Google Container-Optimized OS  (Fix ` Options:[rbind ro]}]: operation not permitted` errors)

### DIFF
--- a/driver/kubernetes/manifest/manifest.go
+++ b/driver/kubernetes/manifest/manifest.go
@@ -213,6 +213,24 @@ func toRootless(d *appsv1.Deployment) error {
 		d.Spec.Template.ObjectMeta.Annotations = make(map[string]string, 1)
 	}
 	d.Spec.Template.ObjectMeta.Annotations["container.apparmor.security.beta.kubernetes.io/"+containerName] = "unconfined"
+
+	// Dockerfile has `VOLUME /home/user/.local/share/buildkit` by default too,
+	// but the default VOLUME does not work with rootless on Google's Container-Optimized OS
+	// as it is mounted with `nosuid,nodev`.
+	// https://github.com/moby/buildkit/issues/879#issuecomment-1240347038
+	// https://github.com/moby/buildkit/pull/3097
+	const emptyDirVolName = "buildkitd"
+	d.Spec.Template.Spec.Containers[0].VolumeMounts = append(d.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
+		Name:      emptyDirVolName,
+		MountPath: "/home/user/.local/share/buildkit",
+	})
+	d.Spec.Template.Spec.Volumes = append(d.Spec.Template.Spec.Volumes, corev1.Volume{
+		Name: emptyDirVolName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	})
+
 	return nil
 }
 


### PR DESCRIPTION
Tested with GKE Autopilot 1.24.3-gke.200 (kernel 5.10.123+, containerd 1.6.6).

ref: moby/buildkit#3097
