### PR TITLE
bake: recursively resolve groups

### DIFF
--- a/commands/bake.go
+++ b/commands/bake.go
@@ -120,17 +120,11 @@ func runBake(dockerCli command.Cli, targets []string, in bakeOptions) (err error
 	}
 
 	if in.printOnly {
-		var defg map[string]*bake.Group
-		if len(grps) == 1 {
-			defg = map[string]*bake.Group{
-				"default": grps[0],
-			}
-		}
 		dt, err := json.MarshalIndent(struct {
 			Group  map[string]*bake.Group  `json:"group,omitempty"`
 			Target map[string]*bake.Target `json:"target"`
 		}{
-			defg,
+			grps,
 			tgts,
 		}, "", "  ")
 		if err != nil {


### PR DESCRIPTION
Fixes https://github.com/docker/buildx/issues/1058.

Groups that contained other groups were not recursively resolved by `ReadTargets`, which prevented output from `--print` from being useable as a self-contained bake file. e.g.

```hcl
group "default" {
    targets = ["other-group"]
}

group "other-group" {
    targets = ["app"]
}

target "app" {
    dockerfile = "Dockerfile"
    tags = ["docker.io/username/app"]
}
```
is used as 
```bash
$ buildx bake --print -f docker-bake.hcl
[+] Building 0.0s (0/0)                                                                                                    
{
  "group": {
    "default": {
      "targets": [
        "other-group"
      ]
    },
    "other-group": {
      "targets": [
        "app"
      ]
    }
  },
  "target": {
    "app": {
      "context": ".",
      "dockerfile": "Dockerfile",
      "tags": [
        "docker.io/username/app"
      ]
    }
  }
}

```

This patch ensures that all groups that are referenced inside the bake file are actually defined under the groups field. This has required a substantial refactor, as previously only a single group was returned from `ReadTargets`, notably, returning a map of groups, instead of a slice.

This does introduce a small behavior change to the behavior of `--print` - while previously, passing a group name to bake would return all the targets of that group back as the default group, now only the name of that group will be inserted into the default group, keeping the original group intact. The impact of this can be observed in some of the changes to the `bake_test.go` file.

e.g. previously with buildx's docker-bake.hcl:
```
$ docker buildx bake --print validate
[+] Building 0.0s (0/0)                                                                                                    
{
  "group": {
    "default": {
      "targets": [
        "lint",
        "validate-vendor",
        "validate-docs"
      ]
    }
  },
```
vs now:
```
$ buildx bake --print validate
[+] Building 0.0s (0/0)                                                                                                    
{
  "group": {
    "default": {
      "targets": [
        "validate"
      ]
    },
    "validate": {
      "targets": [
        "lint",
        "validate-vendor",
        "validate-docs"
      ]
    }
  },
```