### PR TITLE
docs: fix link in driver guide

### DIFF
--- a/docs/guides/drivers/docker-container.md
+++ b/docs/guides/drivers/docker-container.md
@@ -71,5 +71,3 @@ REPOSITORY                       TAG               IMAGE ID       CREATED       
 ## Further reading
 
 For more information on the docker-container driver, see the [buildx reference](https://docs.docker.com/engine/reference/commandline/buildx_create/#driver).
-
-<!--- FIXME: for 0.9, make reference link relative --->

--- a/docs/guides/drivers/docker.md
+++ b/docs/guides/drivers/docker.md
@@ -34,7 +34,7 @@ the available [Docker Contexts](https://docs.docker.com/engine/context/working-w
 When you add new contexts using `docker context create`, these will appear in
 your list of buildx builders.
 
-Unlike the [other drivers](../index.md), builders using the docker driver
+Unlike the [other drivers](./index.md), builders using the docker driver
 cannot be manually created, and can only be automatically created from the
 docker context. Additionally, they cannot be configured to a specific BuildKit
 version, and cannot take any extra parameters, as these are both preset by the
@@ -46,5 +46,3 @@ overhead, then see the help page for the [docker-container driver](./docker-cont
 ## Further reading
 
 For more information on the docker driver, see the [buildx reference](https://docs.docker.com/engine/reference/commandline/buildx_create/#driver).
-
-<!--- FIXME: for 0.9, make reference link relative --->

--- a/docs/guides/drivers/index.md
+++ b/docs/guides/drivers/index.md
@@ -2,24 +2,22 @@
 
 The buildx client connects out to the BuildKit backend to execute builds -
 Buildx drivers allow fine-grained control over management of the backend, and
-supports several different options for where and how BuildKit should run.
+supports several options for where and how BuildKit should run.
 
 Currently, we support the following drivers:
 
 - The `docker` driver, that uses the BuildKit library bundled into the Docker
   daemon.
-  ([guide](./docker.md), [reference](https://docs.docker.com/engine/reference/commandline/buildx_create/#driver))
+  ([guide](./docker.md), [reference](https://docs.docker.com/engine/reference/commandline/buildx_create/#docker-driver-1))
 - The `docker-container` driver, that launches a dedicated BuildKit container
   using Docker, for access to advanced features.
-  ([guide](./docker-container.md), [reference](https://docs.docker.com/engine/reference/commandline/buildx_create/#driver))
+  ([guide](./docker-container.md), [reference](https://docs.docker.com/engine/reference/commandline/buildx_create/#docker-container-driver-1))
 - The `kubernetes` driver, that launches dedicated BuildKit pods in a
   remote Kubernetes cluster, for scalable builds.
-  ([guide](./kubernetes.md), [reference](https://docs.docker.com/engine/reference/commandline/buildx_create/#driver))
+  ([guide](./kubernetes.md), [reference](https://docs.docker.com/engine/reference/commandline/buildx_create/#kubernetes-driver-1))
 - The `remote` driver, that allows directly connecting to a manually managed
   BuildKit daemon, for more custom setups.
-  ([guide](./remote.md))
-
-<!--- FIXME: for 0.9, make links relative, and add reference link for remote --->
+  ([guide](./remote.md), [reference](https://docs.docker.com/engine/reference/commandline/buildx_create/#remote-driver-1))
 
 To create a new builder that uses one of the above drivers, you can use the
 [`docker buildx create`](https://docs.docker.com/engine/reference/commandline/buildx_create/) command:

--- a/docs/guides/drivers/kubernetes.md
+++ b/docs/guides/drivers/kubernetes.md
@@ -234,5 +234,3 @@ This will create your pods without `securityContext.privileged`.
 ## Further reading
 
 For more information on the kubernetes driver, see the [buildx reference](https://docs.docker.com/engine/reference/commandline/buildx_create/#driver).
-
-<!--- FIXME: for 0.9, make reference link relative --->

--- a/docs/guides/drivers/remote.md
+++ b/docs/guides/drivers/remote.md
@@ -174,5 +174,3 @@ $ docker buildx create \
   --driver remote \
   kube-pod://buildkitd-XXXXXXXXXX-xxxxx
 ```
-
-<!--- FIXME: for 0.9, add further reading section with link to reference --->


### PR DESCRIPTION
While working on merging buildx overview page in main overview one, I found out a link was broken in the drivers guide:

```
#16 0.099 - ./_site/build/buildx/drivers/docker/index.html
#16 0.099   *  internally linking to ../index.md, which does not exist (line 147)
#16 0.099      <a href="../index.md">other drivers</a>
```

Looks like we linked _others drivers_ to the buildx overview page which is also broken on GitHub: https://github.com/docker/buildx/blob/master/docs/guides/index.md.

@jedevc I guess you wanted to link to the drivers guide index page.

Also update links to driver reference. About left `FIXME` I don't think we should use relative links actually as we could easily break pages when moving them between sections in docs repo. Also with the `fix_url` jekyll plugin on docs repo we are safe to use absolute urls.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>