### PR TITLE
cli: update help message for --push

### DIFF
--- a/commands/bake.go
+++ b/commands/bake.go
@@ -188,7 +188,7 @@ func bakeCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 	flags.StringArrayVarP(&options.files, "file", "f", []string{}, "Build definition file")
 	flags.BoolVar(&options.exportLoad, "load", false, `Shorthand for "--set=*.output=type=docker"`)
 	flags.BoolVar(&options.printOnly, "print", false, "Print the options without building")
-	flags.BoolVar(&options.exportPush, "push", false, `Shorthand for "--set=*.output=type=registry"`)
+	flags.BoolVar(&options.exportPush, "push", false, `Shorthand for "--set=*.output=type=image,push=true"`)
 	flags.StringArrayVar(&options.overrides, "set", nil, `Override target value (e.g., "targetpattern.key=value")`)
 
 	commonBuildFlags(&options.commonOptions, flags)

--- a/commands/build.go
+++ b/commands/build.go
@@ -482,7 +482,7 @@ func buildCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 		flags.StringVar(&options.printFunc, "print", "", "Print result of information request (e.g., outline, targets) [experimental]")
 	}
 
-	flags.BoolVar(&options.exportPush, "push", false, `Shorthand for "--output=type=registry"`)
+	flags.BoolVar(&options.exportPush, "push", false, `Shorthand for "--output=type=image,push=true"`)
 
 	flags.BoolVarP(&options.quiet, "quiet", "q", false, "Suppress the build output and print image ID on success")
 

--- a/docs/reference/buildx_bake.md
+++ b/docs/reference/buildx_bake.md
@@ -23,7 +23,7 @@ Build from a file
 | [`--print`](#print) |  |  | Print the options without building |
 | [`--progress`](#progress) | `string` | `auto` | Set type of progress output (`auto`, `plain`, `tty`). Use plain to show container output |
 | [`--pull`](#pull) |  |  | Always attempt to pull all referenced images |
-| `--push` |  |  | Shorthand for `--set=*.output=type=registry` |
+| `--push` |  |  | Shorthand for `--set=*.output=type=image,push=true` |
 | [`--set`](#set) | `stringArray` |  | Override target value (e.g., `targetpattern.key=value`) |
 
 

--- a/docs/reference/buildx_build.md
+++ b/docs/reference/buildx_build.md
@@ -37,7 +37,7 @@ Start a build
 | `--print` | `string` |  | Print result of information request (e.g., outline, targets) [experimental] |
 | [`--progress`](#progress) | `string` | `auto` | Set type of progress output (`auto`, `plain`, `tty`). Use plain to show container output |
 | `--pull` |  |  | Always attempt to pull all referenced images |
-| [`--push`](#push) |  |  | Shorthand for `--output=type=registry` |
+| [`--push`](#push) |  |  | Shorthand for `--output=type=image,push=true` |
 | `-q`, `--quiet` |  |  | Suppress the build output and print image ID on success |
 | [`--secret`](#secret) | `stringArray` |  | Secret to expose to the build (format: `id=mysecret[,src=/local/secret]`) |
 | [`--shm-size`](#shm-size) | `bytes` | `0` | Size of `/dev/shm` |
@@ -314,7 +314,7 @@ $ docker buildx build -o outdir .
 $ docker buildx build -o - - > out.tar
 $ docker buildx build -o type=docker .
 $ docker buildx build -o type=docker,dest=- . > myimage.tar
-$ docker buildx build -t tonistiigi/foo -o type=registry
+$ docker buildx build -t tonistiigi/foo -o type=image,push=true
 ```
 
 Supported exported types are:


### PR DESCRIPTION
The default behavior of `--push` has changed from `--output type=registry` to `--output type=image,push=true`, with `type=registry` now otherwise undocumented.

As a cleanup for docs, we should update the flag inline with the true behavior.