### PR TITLE
ci: don't trigger build and e2e workflows on docs-only pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,9 @@ on:
     branches:
       - 'master'
       - 'v[0-9]*'
+    paths-ignore:
+      - 'README.md'
+      - 'docs/**'
 
 env:
   REPO_SLUG: "docker/buildx-bin"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,6 +14,9 @@ on:
     branches:
       - 'master'
       - 'v[0-9]*'
+    paths-ignore:
+      - 'README.md'
+      - 'docs/**'
 
 jobs:
   build:


### PR DESCRIPTION
PRs like https://github.com/docker/buildx/pull/1316 which don't modify any code or ci tooling still run all the long build and e2e workflows.

This patch skips those workflows if the changes affect only "docs" files, currently set to be the entire contents of the `docs/` directory and `README.md`.