### PR TITLE
[1340] Disable git labels if `BUILDX_GIT_LABELS` is not `1` or `full`

### DIFF
--- a/build/git.go
+++ b/build/git.go
@@ -15,8 +15,8 @@ import (
 const DockerfileLabel = "com.docker.image.source.entrypoint"
 
 func addGitProvenance(ctx context.Context, contextPath string, dockerfilePath string) (map[string]string, error) {
-	v, ok := os.LookupEnv("BUILDX_GIT_LABELS")
-	if !ok || contextPath == "" {
+	v := os.Getenv("BUILDX_GIT_LABELS")
+	if (v != "1" && v != "full") || contextPath == "" {
 		return nil, nil
 	}
 	labels := make(map[string]string, 0)

--- a/build/git_test.go
+++ b/build/git_test.go
@@ -64,6 +64,14 @@ func TestAddGitProvenanceDataWithoutEnv(t *testing.T) {
 	assert.Nilf(t, labels, "No labels expected")
 }
 
+func TestAddGitProvenanceDataWitEmptyEnv(t *testing.T) {
+	defer setupTest(t)(t)
+	os.Setenv("BUILDX_GIT_LABELS", "")
+	labels, err := addGitProvenance(context.Background(), repoDir, filepath.Join(repoDir, "Dockerfile"))
+	assert.Nilf(t, err, "No error expected")
+	assert.Nilf(t, labels, "No labels expected")
+}
+
 func TestAddGitProvenanceDataWithoutLabels(t *testing.T) {
 	defer setupTest(t)(t)
 	os.Setenv("BUILDX_GIT_LABELS", "full")


### PR DESCRIPTION
This is to make sure that `BUILDX_GIT_LABELS= docker buildx build ...` will not set the git labels.

Fixes https://github.com/docker/buildx/issues/1340

Signed-off-by: David Gageot <david.gageot@docker.com>