### PR TITLE
[1342] Fix assignment to nil map

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -801,6 +801,9 @@ func BuildWithResultHandler(ctx context.Context, drivers []DriverInfo, opt map[s
 		}
 		for n, v := range gitLabels {
 			if _, ok := opt.Labels[n]; !ok {
+				if opt.Labels == nil {
+					opt.Labels = map[string]string{}
+				}
 				opt.Labels[n] = v
 			}
 		}


### PR DESCRIPTION
Make sure the labels map is not empty before setting values

Fixes https://github.com/docker/buildx/issues/1342

Signed-off-by: David Gageot <david.gageot@docker.com>