### PR TITLE
bake: do not fail printing definition if instance unavailable

### DIFF
--- a/commands/bake.go
+++ b/commands/bake.go
@@ -86,13 +86,17 @@ func runBake(dockerCli command.Cli, targets []string, in bakeOptions) (err error
 		}
 	}()
 
-	dis, err := getInstanceOrDefault(ctx, dockerCli, in.builder, contextPathHash)
-	if err != nil {
-		return err
-	}
-
+	var dis []build.DriverInfo
 	var files []bake.File
 	var inp *bake.Input
+
+	// instance only needed for reading remote bake files or building
+	if url != "" || !in.printOnly {
+		dis, err = getInstanceOrDefault(ctx, dockerCli, in.builder, contextPathHash)
+		if err != nil {
+			return err
+		}
+	}
 
 	if url != "" {
 		files, inp, err = bake.ReadRemoteFiles(ctx, dis, url, in.files, printer)


### PR DESCRIPTION
fixes #1344 

Since 0.9 we are checking the context builder endpoint to make sure it's reachable before returning the instance: https://github.com/docker/buildx/pull/1129#issuecomment-1195542481. By doing so we are not soft-failing as before when loading `driversForNodeGroup` and therefore `bake --print` now fails if no instance is available.

This PR will not return an error if we are printing local bake files. An instance is still required when building or loading remote bake files.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>