### PR TITLE
docs: replaced broken relative links

### DIFF
--- a/docs/guides/cache/azblob.md
+++ b/docs/guides/cache/azblob.md
@@ -12,8 +12,8 @@ The `azblob` cache store uploads your resulting build cache to
 >
 > This cache storage backend requires using a different driver than the default
 > `docker` driver - see more information on selecting a driver
-> [here](../drivers/index.md). To create a new driver (which can act as a simple
-> drop-in replacement):
+> [here](https://docs.docker.com/build/building/drivers/). To create a new
+> driver (which can act as a simple drop-in replacement):
 >
 > ```console
 > docker buildx create --use --driver=docker-container
@@ -50,7 +50,7 @@ The environment variables are read from the server, not the Buildx client.
 ## Further reading
 
 For an introduction to caching see
-[Optimizing builds with cache management](https://docs.docker.com/build/building/cache).
+[Optimizing builds with cache](https://docs.docker.com/build/building/cache).
 
 For more information on the `azblob` cache backend, see the
 [BuildKit README](https://github.com/moby/buildkit#azure-blob-storage-cache-experimental).

--- a/docs/guides/cache/gha.md
+++ b/docs/guides/cache/gha.md
@@ -16,8 +16,8 @@ inside your GitHub action pipelines, as long as your use case falls within the
 >
 > This cache storage backend requires using a different driver than the default
 > `docker` driver - see more information on selecting a driver
-> [here](../drivers/index.md). To create a new driver (which can act as a simple
-> drop-in replacement):
+> [here](https://docs.docker.com/build/building/drivers/). To create a new
+> driver (which can act as a simple drop-in replacement):
 >
 > ```console
 > docker buildx create --use --driver=docker-container
@@ -105,7 +105,7 @@ For example:
 ## Further reading
 
 For an introduction to caching see
-[Optimizing builds with cache management](https://docs.docker.com/build/building/cache).
+[Optimizing builds with cache](https://docs.docker.com/build/building/cache).
 
 For more information on the `gha` cache backend, see the
 [BuildKit README](https://github.com/moby/buildkit#github-actions-cache-experimental).

--- a/docs/guides/cache/index.md
+++ b/docs/guides/cache/index.md
@@ -43,12 +43,14 @@ Buildx supports the following cache storage backends:
 ## Command syntax
 
 To use any of the cache backends, you first need to specify it on build with the
-[`--cache-to` option](https://docs.docker.com/engine/reference/commandline/buildx_build/#cache-to) to export the cache to your storage backend of choice. Then,
-use the [`--cache-from` option](https://docs.docker.com/engine/reference/commandline/buildx_build/#cache-from) to import the cache from the storage backend into
-the current build. Unlike the local BuildKit cache (which is always enabled),
-all of the cache storage backends must be explicitly exported to, and explicitly
-imported from. All cache exporters except for the `inline` cache requires that
-you [select an alternative Buildx driver](../drivers/index.md).
+[`--cache-to` option](https://docs.docker.com/engine/reference/commandline/buildx_build/#cache-to)
+to export the cache to your storage backend of choice. Then, use the
+[`--cache-from` option](https://docs.docker.com/engine/reference/commandline/buildx_build/#cache-from)
+to import the cache from the storage backend into the current build. Unlike the
+local BuildKit cache (which is always enabled), all of the cache storage
+backends must be explicitly exported to, and explicitly imported from. All cache
+exporters except for the `inline` cache requires that you
+[select an alternative Buildx driver](https://docs.docker.com/build/building/drivers/).
 
 Example `buildx` command using the `registry` backend, using import and export
 cache:

--- a/docs/guides/cache/inline.md
+++ b/docs/guides/cache/inline.md
@@ -41,7 +41,7 @@ $ docker buildx build . --push -t <registry>/<image> --cache-from type=registry,
 ## Further reading
 
 For an introduction to caching see
-[Optimizing builds with cache management](https://docs.docker.com/build/building/cache).
+[Optimizing builds with cache](https://docs.docker.com/build/building/cache).
 
 For more information on the `inline` cache backend, see the
 [BuildKit README](https://github.com/moby/buildkit#inline-push-image-and-cache-together).

--- a/docs/guides/cache/local.md
+++ b/docs/guides/cache/local.md
@@ -11,8 +11,8 @@ solution.
 >
 > This cache storage backend requires using a different driver than the default
 > `docker` driver - see more information on selecting a driver
-> [here](../drivers/index.md). To create a new driver (which can act as a simple
-> drop-in replacement):
+> [here](https://docs.docker.com/build/building/drivers/). To create a new
+> driver (which can act as a simple drop-in replacement):
 >
 > ```console
 > docker buildx create --use --driver=docker-container
@@ -96,7 +96,7 @@ $ docker buildx build . --push -t <registry>/<image> \
 ## Further reading
 
 For an introduction to caching see
-[Optimizing builds with cache management](https://docs.docker.com/build/building/cache).
+[Optimizing builds with cache](https://docs.docker.com/build/building/cache).
 
 For more information on the `local` cache backend, see the
 [BuildKit README](https://github.com/moby/buildkit#local-directory-1).

--- a/docs/guides/cache/registry.md
+++ b/docs/guides/cache/registry.md
@@ -16,8 +16,8 @@ everything that the inline cache can do, and more:
 >
 > This cache storage backend requires using a different driver than the default
 > `docker` driver - see more information on selecting a driver
-> [here](../drivers/index.md). To create a new driver (which can act as a simple
-> drop-in replacement):
+> [here](https://docs.docker.com/build/building/drivers/). To create a new
+> driver (which can act as a simple drop-in replacement):
 >
 > ```console
 > docker buildx create --use --driver=docker-container
@@ -64,7 +64,7 @@ fail, but the build will continue.
 ## Further reading
 
 For an introduction to caching see
-[Optimizing builds with cache management](https://docs.docker.com/build/building/cache).
+[Optimizing builds with cache](https://docs.docker.com/build/building/cache).
 
 For more information on the `registry` cache backend, see the
 [BuildKit README](https://github.com/moby/buildkit#registry-push-image-and-cache-separately).

--- a/docs/guides/cache/s3.md
+++ b/docs/guides/cache/s3.md
@@ -13,8 +13,8 @@ bucket.
 >
 > This cache storage backend requires using a different driver than the default
 > `docker` driver - see more information on selecting a driver
-> [here](../drivers/index.md). To create a new driver (which can act as a simple
-> drop-in replacement):
+> [here](https://docs.docker.com/build/building/drivers/). To create a new
+> driver (which can act as a simple drop-in replacement):
 >
 > ```console
 > docker buildx create --use --driver=docker-container
@@ -57,7 +57,7 @@ The environment variables are read from the server, not the Buildx client.
 ## Further reading
 
 For an introduction to caching see
-[Optimizing builds with cache management](https://docs.docker.com/build/building/cache).
+[Optimizing builds with cache](https://docs.docker.com/build/building/cache).
 
 For more information on the `s3` cache backend, see the
 [BuildKit README](https://github.com/moby/buildkit#s3-cache-experimental).

--- a/docs/guides/drivers/docker-container.md
+++ b/docs/guides/drivers/docker-container.md
@@ -36,9 +36,9 @@ pass to `--driver-opt`:
 ## Usage
 
 When you run a build, Buildx pulls the specified `image` (by default,
-[`moby/buildkit`](https://hub.docker.com/r/moby/buildkit))
-[Docker Hub](https://hub.docker.com/u/moby/buildkit). When the container has
-started, Buildx submits the build submitted to the containerized build server.
+[`moby/buildkit`](https://hub.docker.com/r/moby/buildkit)). When the container
+has started, Buildx submits the build submitted to the containerized build
+server.
 
 ```console
 $ docker buildx build -t <image> --builder=container .


### PR DESCRIPTION
Replaced more (broken) relative links with absolute ones

Signed-off-by: David Karlsson <david.karlsson@docker.com>
