### PR TITLE
docs: fix typo in cache docs

### DIFF
--- a/docs/guides/cache/index.md
+++ b/docs/guides/cache/index.md
@@ -20,7 +20,7 @@ important to keep the runtime of image builds as low as possible.
 
 Buildx supports the following cache storage backends:
 
-- `inline-cache`: embeds the build cache into the image.
+- `inline`: embeds the build cache into the image.
 
   The inline cache gets pushed to the same location as the main output result.
   Note that this only works for the `image` exporter.


### PR DESCRIPTION
We should keep consistency with the rest of the list, and call it "inline" instead of "inline-cache".