### PR TITLE
docs: add user sign for console blocks

### DIFF
--- a/docs/guides/cache/azblob.md
+++ b/docs/guides/cache/azblob.md
@@ -16,7 +16,7 @@ The `azblob` cache store uploads your resulting build cache to
 > driver (which can act as a simple drop-in replacement):
 >
 > ```console
-> docker buildx create --use --driver=docker-container
+> $ docker buildx create --use --driver=docker-container
 > ```
 
 ## Synopsis

--- a/docs/guides/cache/gha.md
+++ b/docs/guides/cache/gha.md
@@ -20,7 +20,7 @@ inside your GitHub action pipelines, as long as your use case falls within the
 > driver (which can act as a simple drop-in replacement):
 >
 > ```console
-> docker buildx create --use --driver=docker-container
+> $ docker buildx create --use --driver=docker-container
 > ```
 
 ## Synopsis

--- a/docs/guides/cache/local.md
+++ b/docs/guides/cache/local.md
@@ -15,7 +15,7 @@ solution.
 > driver (which can act as a simple drop-in replacement):
 >
 > ```console
-> docker buildx create --use --driver=docker-container
+> $ docker buildx create --use --driver=docker-container
 > ```
 
 ## Synopsis

--- a/docs/guides/cache/registry.md
+++ b/docs/guides/cache/registry.md
@@ -20,7 +20,7 @@ everything that the inline cache can do, and more:
 > driver (which can act as a simple drop-in replacement):
 >
 > ```console
-> docker buildx create --use --driver=docker-container
+> $ docker buildx create --use --driver=docker-container
 > ```
 
 ## Synopsis

--- a/docs/guides/cache/s3.md
+++ b/docs/guides/cache/s3.md
@@ -17,7 +17,7 @@ bucket.
 > driver (which can act as a simple drop-in replacement):
 >
 > ```console
-> docker buildx create --use --driver=docker-container
+> $ docker buildx create --use --driver=docker-container
 > ```
 
 ## Synopsis


### PR DESCRIPTION
Signed-off-by: David Karlsson <david.karlsson@docker.com>

Add dollar (`$`) user sign for code blocks of type console
