### PR TITLE
lint: remove structcheck

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters:
     - revive
     - staticcheck
     - typecheck
+    - nolintlint
   disable-all: true
 
 linters-settings:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,6 @@ linters:
     - revive
     - staticcheck
     - typecheck
-    - structcheck
   disable-all: true
 
 linters-settings:

--- a/commands/build.go
+++ b/commands/build.go
@@ -81,10 +81,7 @@ type commonOptions struct {
 	progress     string
 	pull         *bool
 
-	// golangci-lint#826
-	// nolint:structcheck
 	exportPush bool
-	// nolint:structcheck
 	exportLoad bool
 }
 


### PR DESCRIPTION
`structcheck` is abandoned, and has been replaced by the `unused` linter. See https://golangci-lint.run/usage/linters/#structcheck for more information.

> The owner seems to have abandoned the linter. Replaced by unused.

See similar in https://github.com/moby/buildkit/pull/3196