### PR TITLE
progress: explicitly fail if tty requested but not available

### DIFF
--- a/commands/bake.go
+++ b/commands/bake.go
@@ -75,7 +75,10 @@ func runBake(dockerCli command.Cli, targets []string, in bakeOptions) (err error
 
 	ctx2, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	printer := progress.NewPrinter(ctx2, os.Stderr, os.Stderr, in.progress)
+	printer, err := progress.NewPrinter(ctx2, os.Stderr, os.Stderr, in.progress)
+	if err != nil {
+		return err
+	}
 
 	defer func() {
 		if printer != nil {

--- a/commands/build.go
+++ b/commands/build.go
@@ -109,7 +109,7 @@ func runBuild(dockerCli command.Cli, in buildOptions) (err error) {
 		return errors.Errorf("--no-cache and --no-cache-filter cannot currently be used together")
 	}
 
-	if in.quiet && in.progress != "auto" && in.progress != "quiet" {
+	if in.quiet && in.progress != progress.PrinterModeAuto && in.progress != progress.PrinterModeQuiet {
 		return errors.Errorf("progress=%s and quiet cannot be used together", in.progress)
 	} else if in.quiet {
 		in.progress = "quiet"
@@ -284,7 +284,10 @@ func buildTargets(ctx context.Context, dockerCli command.Cli, opts map[string]bu
 	ctx2, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 
-	printer := progress.NewPrinter(ctx2, os.Stderr, os.Stderr, progressMode)
+	printer, err := progress.NewPrinter(ctx2, os.Stderr, os.Stderr, progressMode)
+	if err != nil {
+		return "", nil, err
+	}
 
 	var mu sync.Mutex
 	var idx int

--- a/commands/imagetools/create.go
+++ b/commands/imagetools/create.go
@@ -182,7 +182,10 @@ func runCreate(dockerCli command.Cli, in createOptions, args []string) error {
 
 	ctx2, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	printer := progress.NewPrinter(ctx2, os.Stderr, os.Stderr, in.progress)
+	printer, err := progress.NewPrinter(ctx2, os.Stderr, os.Stderr, in.progress)
+	if err != nil {
+		return err
+	}
 
 	eg, _ := errgroup.WithContext(ctx)
 	pw := progress.WithPrefix(printer, "internal", true)

--- a/commands/util.go
+++ b/commands/util.go
@@ -460,7 +460,10 @@ func boot(ctx context.Context, ngi *nginfo) (bool, error) {
 		return false, nil
 	}
 
-	printer := progress.NewPrinter(context.TODO(), os.Stderr, os.Stderr, "auto")
+	printer, err := progress.NewPrinter(context.TODO(), os.Stderr, os.Stderr, progress.PrinterModeAuto)
+	if err != nil {
+		return false, err
+	}
 
 	baseCtx := ctx
 	eg, _ := errgroup.WithContext(ctx)
@@ -477,7 +480,7 @@ func boot(ctx context.Context, ngi *nginfo) (bool, error) {
 		}(idx)
 	}
 
-	err := eg.Wait()
+	err = eg.Wait()
 	err1 := printer.Wait()
 	if err == nil {
 		err = err1


### PR DESCRIPTION
See https://github.com/docker/buildx/issues/1288.

The NewPrinter function is mostly borrowed from buildkit. However, at some point, it seems that the implementations drifted.

This patch updates buildx to be more similar in behavior to it's buildkit counterpart, specifically, it will explicitly fail if a TTY output is requested using "--progress=tty", but the output is not available.

To gracefully fallback to plain progress in this scenario, "--progress=plain" is required.