### PR TITLE
driver: don't create tracer delegate opt if tracer is nil

### DIFF
--- a/driver/docker-container/driver.go
+++ b/driver/docker-container/driver.go
@@ -366,11 +366,14 @@ func (d *Driver) Client(ctx context.Context) (*client.Client, error) {
 		return nil, err
 	}
 
-	td, _ := exp.(client.TracerDelegate)
-
-	return client.New(ctx, "", client.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+	var opts []client.ClientOpt
+	opts = append(opts, client.WithContextDialer(func(context.Context, string) (net.Conn, error) {
 		return conn, nil
-	}), client.WithTracerDelegate(td))
+	}))
+	if td, ok := exp.(client.TracerDelegate); ok {
+		opts = append(opts, client.WithTracerDelegate(td))
+	}
+	return client.New(ctx, "", opts...)
 }
 
 func (d *Driver) Factory() driver.Factory {

--- a/driver/kubernetes/driver.go
+++ b/driver/kubernetes/driver.go
@@ -215,11 +215,14 @@ func (d *Driver) Client(ctx context.Context) (*client.Client, error) {
 		return nil, err
 	}
 
-	td, _ := exp.(client.TracerDelegate)
-
-	return client.New(ctx, "", client.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+	var opts []client.ClientOpt
+	opts = append(opts, client.WithContextDialer(func(context.Context, string) (net.Conn, error) {
 		return conn, nil
-	}), client.WithTracerDelegate(td))
+	}))
+	if td, ok := exp.(client.TracerDelegate); ok {
+		opts = append(opts, client.WithTracerDelegate(td))
+	}
+	return client.New(ctx, "", opts...)
 }
 
 func (d *Driver) Factory() driver.Factory {


### PR DESCRIPTION
:hammer_and_wrench: fixes https://github.com/moby/buildkit/issues/3242 

The error handling for the cast to client.TracerDelegate was incorrect, and previously, a client would unconditionally append an opt.

This results in the scenario that while the ClientOpt was not nil, the tracer delegate in the ClientOpt was, which isn't an error case explicitly handled by buildkit.

We might want to follow up in buildkit [here](https://github.com/moby/buildkit/blob/master/client/client.go#L78-L80) and add an explicit `nil` check for `withTracerDelegate.TracerDelegate == nil` as a sanity check.