### PR TITLE
ci(docs-upstream): fix ref on pull request event

### DIFF
--- a/.github/workflows/docs-upstream.yml
+++ b/.github/workflows/docs-upstream.yml
@@ -52,67 +52,10 @@ jobs:
           retention-days: 1
 
   validate:
-    runs-on: ubuntu-latest
+    uses: docker/docs/.github/workflows/validate-upstream.yml@main
     needs:
       - docs-yaml
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v3
-        with:
-          repository: docker/docker.github.io
-      -
-        name: Install js-yaml
-        run: npm install js-yaml
-      -
-        # use the actual buildx ref that triggers this workflow, so we make
-        # sure pages fetched by docs repo are still valid
-        # https://github.com/docker/docker.github.io/blob/98c7c9535063ae4cd2cd0a31478a21d16d2f07a3/_config.yml#L164-L173
-        name: Set correct ref to fetch remote resources
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const fs = require('fs');
-            const yaml = require('js-yaml');
-
-            const configFile = '_config.yml'
-            const config = yaml.load(fs.readFileSync(configFile, 'utf8'));
-            for (const remote of config['fetch-remote']) {
-              if (remote['repo'] != 'https://github.com/docker/buildx') {
-                continue;
-              }
-              remote['ref'] = "${{ github.ref }}";
-            }
-
-            try {
-              fs.writeFileSync(configFile, yaml.dump(config), 'utf8')
-            } catch (err) {
-              console.error(err.message)
-              process.exit(1)
-            }
-      -
-        name: Prepare
-        run: |
-          # print docs jekyll config updated in previous step
-          yq _config.yml
-          # cleanup reference yaml docs and js-yaml module
-          rm -rf ./_data/buildx/* ./node_modules
-      -
-        name: Download built reference YAML docs
-        uses: actions/download-artifact@v3
-        with:
-          name: docs-yaml
-          path: ./_data/buildx/
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          version: latest
-      -
-        name: Validate
-        uses: docker/bake-action@v2
-        with:
-          targets: validate
-          set: |
-            *.cache-from=type=gha,scope=docs-upstream
-            *.cache-to=type=gha,scope=docs-upstream,mode=max
+    with:
+      repo: https://github.com/${{ github.repository }}
+      data-files-id: docs-yaml
+      data-files-folder: buildx


### PR DESCRIPTION
related to https://github.com/docker/buildx/pull/1385

Now that docs fetches remote resources using Git, we need to use the right head repo and ref on pull request event, otherwise: https://github.com/docker/buildx/actions/runs/3369331654/jobs/5588889013#step:8:563

```
#20 6.832   Repo https://github.com/docker/buildx
#20 6.832     Cloning repository into /tmp/docker-docs-clone/docker/buildx
#20 7.140                     ------------------------------------------------
#20 7.140       Jekyll 4.2.2   Please append `--trace` to the `build` command 
#20 7.141                      for any additional information or backtrace. 
#20 7.141                     ------------------------------------------------
#20 7.142 /usr/local/bundle/gems/git-1.12.0/lib/git/lib.rb:1125:in `command': git '-c' 'core.quotePath=true' '-c' 'color.ui=false' clone '--branch' 'refs/pull/1385/merge' '--depth' '1' '--' 'https://github.com/docker/buildx.git' '/tmp/docker-docs-clone/docker/buildx'  2>&1:Cloning into '/tmp/docker-docs-clone/docker/buildx'... (Git::GitExecuteError)
#20 7.145 warning: Could not find remote branch refs/pull/1385/merge to clone.
#20 7.145 fatal: Remote branch refs/pull/1385/merge not found in upstream origin
```

Switch to reusable workflow from docs repo that fixes this issue. See https://github.com/docker/docs/pull/16042

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>