### PR TITLE
Docs consistency fixes

### DIFF
--- a/docs/manuals/drivers/docker-container.md
+++ b/docs/manuals/drivers/docker-container.md
@@ -27,7 +27,7 @@ container
 The following table describes the available driver-specific options that you can
 pass to `--driver-opt`:
 
-| Parameter       | Value  | Default          | Description                                                                                |
+| Parameter       | Type   | Default          | Description                                                                                |
 | --------------- | ------ | ---------------- | ------------------------------------------------------------------------------------------ |
 | `image`         | String |                  | Sets the image to use for running BuildKit.                                                |
 | `network`       | String |                  | Sets the network mode for running the BuildKit container.                                  |

--- a/docs/manuals/drivers/docker-container.md
+++ b/docs/manuals/drivers/docker-container.md
@@ -32,6 +32,7 @@ pass to `--driver-opt`:
 | `image`         | String |                  | Sets the image to use for running BuildKit.                                                |
 | `network`       | String |                  | Sets the network mode for running the BuildKit container.                                  |
 | `cgroup-parent` | String | `/docker/buildx` | Sets the cgroup parent of the BuildKit container if Docker is using the `cgroupfs` driver. |
+| `env.<key>`     | String |                  | Sets the environment variable `key` to the specified `value` in the BuildKit container.    |
 
 ## Usage
 

--- a/docs/manuals/drivers/kubernetes.md
+++ b/docs/manuals/drivers/kubernetes.md
@@ -20,7 +20,7 @@ $ docker buildx create \
 The following table describes the available driver-specific options that you can
 pass to `--driver-opt`:
 
-| Parameter         | Value             | Default                                 | Description                                                                                                                          |
+| Parameter         | Type              | Default                                 | Description                                                                                                                          |
 | ----------------- | ----------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | `image`           | String            |                                         | Sets the image to use for running BuildKit.                                                                                          |
 | `namespace`       | String            | Namespace in current Kubernetes context | Sets the Kubernetes namespace.                                                                                                       |

--- a/docs/manuals/drivers/remote.md
+++ b/docs/manuals/drivers/remote.md
@@ -17,7 +17,7 @@ $ docker buildx create \
 The following table describes the available driver-specific options that you can
 pass to `--driver-opt`:
 
-| Parameter    | Value  | Default            | Description                                                |
+| Parameter    | Type   | Default            | Description                                                |
 | ------------ | ------ | ------------------ | ---------------------------------------------------------- |
 | `key`        | String |                    | Sets the TLS client key.                                   |
 | `cert`       | String |                    | Sets the TLS client certificate to present to `buildkitd`. |

--- a/docs/manuals/exporters/image-registry.md
+++ b/docs/manuals/exporters/image-registry.md
@@ -19,7 +19,7 @@ $ docker buildx build --output type=registry[,parameters] .
 The following table describes the available parameters that you can pass to
 `--output` for `type=image`:
 
-| Parameter              | Value                                  | Default | Description                                                                                                                                                                                                                         |
+| Parameter              | Type                                   | Default | Description                                                                                                                                                                                                                         |
 | ---------------------- | -------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `name`                 | String                                 |         | Specify image name(s)                                                                                                                                                                                                               |
 | `push`                 | `true`,`false`                         | `false` | Push after creating the image.                                                                                                                                                                                                      |

--- a/docs/manuals/exporters/local-tar.md
+++ b/docs/manuals/exporters/local-tar.md
@@ -21,7 +21,7 @@ $ docker buildx build --output type=tar[,parameters] .
 
 The following table describes the available parameters:
 
-| Parameter | Value  | Default | Description           |
+| Parameter | Type   | Default | Description           |
 | --------- | ------ | ------- | --------------------- |
 | `dest`    | String |         | Path to copy files to |
 

--- a/docs/manuals/exporters/oci-docker.md
+++ b/docs/manuals/exporters/oci-docker.md
@@ -23,7 +23,7 @@ $ docker buildx build --output type=docker[,parameters] .
 
 The following table describes the available parameters:
 
-| Parameter           | Value                                  | Default | Description                                                                                                                           |
+| Parameter           | Type                                   | Default | Description                                                                                                                           |
 | ------------------- | -------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | `name`              | String                                 |         | Specify image name(s)                                                                                                                 |
 | `dest`              | String                                 |         | Path                                                                                                                                  |


### PR DESCRIPTION
:hammer_and_wrench: Fixes https://github.com/docker/setup-buildx-action/issues/179#issuecomment-1309977562
:hammer_and_wrench: Also ensures we use consistent parameter table headers with "Type" instead of "Value", to be inline with GitHub actions (e.g. [build-push-action](https://github.com/docker/build-push-action#inputs))