### PR TITLE
Synchronise access to the map when printing.

### DIFF
--- a/util/imagetools/printers.go
+++ b/util/imagetools/printers.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 	"text/tabwriter"
 	"text/template"
 
@@ -113,6 +114,7 @@ func (p *Printer) Print(raw bool, out io.Writer) error {
 
 	imageconfigs := make(map[string]*ocispecs.Image)
 	buildinfos := make(map[string]*binfotypes.BuildInfo)
+	mutex := &sync.RWMutex{}
 
 	eg, _ := errgroup.WithContext(p.ctx)
 	for _, platform := range p.platforms {
@@ -122,12 +124,16 @@ func (p *Printer) Print(raw bool, out io.Writer) error {
 				if err != nil {
 					return err
 				} else if img != nil {
+					mutex.Lock()
 					imageconfigs[platforms.Format(platform)] = img
+					mutex.Unlock()
 				}
 				if bi, err := imageutil.BuildInfo(dtic); err != nil {
 					return err
 				} else if bi != nil {
+					mutex.Lock()
 					buildinfos[platforms.Format(platform)] = bi
+					mutex.Unlock()
 				}
 				return nil
 			})

--- a/util/imagetools/printers.go
+++ b/util/imagetools/printers.go
@@ -113,8 +113,9 @@ func (p *Printer) Print(raw bool, out io.Writer) error {
 	}
 
 	imageconfigs := make(map[string]*ocispecs.Image)
+	imageconfigsMutex := sync.Mutex{}
 	buildinfos := make(map[string]*binfotypes.BuildInfo)
-	mutex := &sync.RWMutex{}
+	buildinfosMutex := sync.Mutex{}
 
 	eg, _ := errgroup.WithContext(p.ctx)
 	for _, platform := range p.platforms {
@@ -124,16 +125,16 @@ func (p *Printer) Print(raw bool, out io.Writer) error {
 				if err != nil {
 					return err
 				} else if img != nil {
-					mutex.Lock()
+					imageconfigsMutex.Lock()
 					imageconfigs[platforms.Format(platform)] = img
-					mutex.Unlock()
+					imageconfigsMutex.Unlock()
 				}
 				if bi, err := imageutil.BuildInfo(dtic); err != nil {
 					return err
 				} else if bi != nil {
-					mutex.Lock()
+					buildinfosMutex.Lock()
 					buildinfos[platforms.Format(platform)] = bi
-					mutex.Unlock()
+					buildinfosMutex.Unlock()
 				}
 				return nil
 			})


### PR DESCRIPTION
If you happen to run:

    docker buildx imagetools inspect --format '{{. | json}}' imageRef

Where `imageRef` points to a manifest list with multiple platforms.

You can sometimes run into `concurrent map write` errors as there are multiple goroutines trying to write to the `imageInfo` and `buildInfo` maps.

NB: I'm not a Go developer, if there is a nicer way to do this, happy to make edits.