### PR TITLE
Attestations from buildx

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -1109,7 +1109,7 @@ func BuildWithResultHandler(ctx context.Context, nodes []builder.Node, opt map[s
 							FrontendInputs: frontendInputs,
 						}
 						so.Frontend = ""
-						so.FrontendAttrs = nil
+						so.FrontendAttrs = attestations.Filter(so.FrontendAttrs)
 						so.FrontendInputs = nil
 
 						ch, done := progress.NewChannel(pw)

--- a/commands/bake.go
+++ b/commands/bake.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/buildx/bake"
 	"github.com/docker/buildx/build"
 	"github.com/docker/buildx/builder"
+	"github.com/docker/buildx/util/buildflags"
 	"github.com/docker/buildx/util/confutil"
 	"github.com/docker/buildx/util/dockerutil"
 	"github.com/docker/buildx/util/progress"
@@ -72,6 +73,12 @@ func runBake(dockerCli command.Cli, targets []string, in bakeOptions) (err error
 	}
 	if in.pull != nil {
 		overrides = append(overrides, fmt.Sprintf("*.pull=%t", *in.pull))
+	}
+	if in.sbom != "" {
+		overrides = append(overrides, fmt.Sprintf("*.attest=%s", buildflags.CanonicalizeAttest("sbom", in.sbom)))
+	}
+	if in.provenance != "" {
+		overrides = append(overrides, fmt.Sprintf("*.attest=%s", buildflags.CanonicalizeAttest("provenance", in.provenance)))
 	}
 	contextPathHash, _ := os.Getwd()
 
@@ -199,6 +206,8 @@ func bakeCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 	flags.BoolVar(&options.exportLoad, "load", false, `Shorthand for "--set=*.output=type=docker"`)
 	flags.BoolVar(&options.printOnly, "print", false, "Print the options without building")
 	flags.BoolVar(&options.exportPush, "push", false, `Shorthand for "--set=*.output=type=registry"`)
+	flags.StringVar(&options.sbom, "sbom", "", `Shorthand for "--set=*.attest=type=sbom"`)
+	flags.StringVar(&options.provenance, "provenance", "", `Shorthand for "--set=*.attest=type=provenance"`)
 	flags.StringArrayVar(&options.overrides, "set", nil, `Override target value (e.g., "targetpattern.key=value")`)
 
 	commonBuildFlags(&options.commonOptions, flags)

--- a/commands/build.go
+++ b/commands/build.go
@@ -60,6 +60,7 @@ type buildOptions struct {
 	contexts      []string
 	extraHosts    []string
 	imageIDFile   string
+	invoke        string
 	labels        []string
 	networkMode   string
 	noCacheFilter []string
@@ -72,7 +73,6 @@ type buildOptions struct {
 	tags          []string
 	target        string
 	ulimits       *dockeropts.UlimitOpt
-	invoke        string
 	commonOptions
 }
 

--- a/docs/reference/buildx_bake.md
+++ b/docs/reference/buildx_bake.md
@@ -22,8 +22,10 @@ Build from a file
 | [`--no-cache`](#no-cache) |  |  | Do not use cache when building the image |
 | [`--print`](#print) |  |  | Print the options without building |
 | [`--progress`](#progress) | `string` | `auto` | Set type of progress output (`auto`, `plain`, `tty`). Use plain to show container output |
+| `--provenance` | `string` |  | Shorthand for `--set=*.attest=type=provenance` |
 | [`--pull`](#pull) |  |  | Always attempt to pull all referenced images |
 | `--push` |  |  | Shorthand for `--set=*.output=type=registry` |
+| `--sbom` | `string` |  | Shorthand for `--set=*.attest=type=sbom` |
 | [`--set`](#set) | `stringArray` |  | Override target value (e.g., `targetpattern.key=value`) |
 
 

--- a/docs/reference/buildx_build.md
+++ b/docs/reference/buildx_build.md
@@ -17,6 +17,7 @@ Start a build
 | --- | --- | --- | --- |
 | [`--add-host`](https://docs.docker.com/engine/reference/commandline/build/#add-entries-to-container-hosts-file---add-host) | `stringSlice` |  | Add a custom host-to-IP mapping (format: `host:ip`) |
 | [`--allow`](#allow) | `stringSlice` |  | Allow extra privileged entitlement (e.g., `network.host`, `security.insecure`) |
+| `--attest` | `stringArray` |  | Attestation parameters (format: `type=sbom,generator=image`) |
 | [`--build-arg`](#build-arg) | `stringArray` |  | Set build-time variables |
 | [`--build-context`](#build-context) | `stringArray` |  | Additional build contexts (e.g., name=path) |
 | [`--builder`](#builder) | `string` |  | Override the configured builder instance |
@@ -36,9 +37,11 @@ Start a build
 | [`--platform`](#platform) | `stringArray` |  | Set target platform for build |
 | `--print` | `string` |  | Print result of information request (e.g., outline, targets) [experimental] |
 | [`--progress`](#progress) | `string` | `auto` | Set type of progress output (`auto`, `plain`, `tty`). Use plain to show container output |
+| `--provenance` | `string` |  | Shortand for `--attest=type=provenance` |
 | `--pull` |  |  | Always attempt to pull all referenced images |
 | [`--push`](#push) |  |  | Shorthand for `--output=type=registry` |
 | `-q`, `--quiet` |  |  | Suppress the build output and print image ID on success |
+| `--sbom` | `string` |  | Shorthand for `--attest=type=sbom` |
 | [`--secret`](#secret) | `stringArray` |  | Secret to expose to the build (format: `id=mysecret[,src=/local/secret]`) |
 | [`--shm-size`](#shm-size) | `bytes` | `0` | Size of `/dev/shm` |
 | [`--ssh`](#ssh) | `stringArray` |  | SSH agent socket or keys to expose to the build (format: `default\|<id>[=<socket>\|<key>[,<key>]]`) |

--- a/util/buildflags/attests.go
+++ b/util/buildflags/attests.go
@@ -1,0 +1,76 @@
+package buildflags
+
+import (
+	"encoding/csv"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+func CanonicalizeAttest(attestType string, in string) string {
+	if in == "" {
+		return ""
+	}
+	if b, err := strconv.ParseBool(in); err == nil {
+		return fmt.Sprintf("type=%s,enabled=%t", attestType, b)
+	}
+	return fmt.Sprintf("type=%s,%s", attestType, in)
+}
+
+func ParseAttests(in []string) (map[string]*string, error) {
+	out := map[string]*string{}
+	for _, in := range in {
+		in := in
+		attestType, enabled, err := parseAttest(in)
+		if err != nil {
+			return nil, err
+		}
+
+		k := "attest:" + attestType
+		if enabled {
+			out[k] = &in
+		} else {
+			out[k] = nil
+		}
+	}
+	return out, nil
+}
+
+func parseAttest(in string) (string, bool, error) {
+	if in == "" {
+		return "", false, nil
+	}
+
+	csvReader := csv.NewReader(strings.NewReader(in))
+	fields, err := csvReader.Read()
+	if err != nil {
+		return "", false, err
+	}
+
+	attestType := ""
+	enabled := true
+	for _, field := range fields {
+		key, value, ok := strings.Cut(field, "=")
+		if !ok {
+			return "", false, errors.Errorf("invalid value %s", field)
+		}
+		key = strings.TrimSpace(strings.ToLower(key))
+
+		switch key {
+		case "type":
+			attestType = value
+		case "enabled":
+			enabled, err = strconv.ParseBool(value)
+			if err != nil {
+				return "", false, err
+			}
+		}
+	}
+	if attestType == "" {
+		return "", false, errors.Errorf("attestation type not specified")
+	}
+
+	return attestType, enabled, nil
+}


### PR DESCRIPTION
Adds an `--attest` flag to the build command, to add SBOM and provenance attestations. Example usage:

```bash
# basic invocation
$ docker buildx build . -t foo --attest type=sbom --attest type=provenance

# invocation with parameters
$ docker buildx build . -t foo --attest type=sbom,generator="<registry>/<image>" --attest type=provenance,mode="<mode>"
```

Also adds an `attest` field to bake. Example usage:

```hcl
target "myimage" {
  attest = [
    "type=sbom"
  ]
}
```

The attestation parameters are forwarded to buildkit, which should then include them in the build.