### PR TITLE
ci: switch to ghaction-github-release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,7 +185,7 @@ jobs:
       -
         name: GitHub Release
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
+        uses: crazy-max/ghaction-github-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
`softprops/action-gh-release` does not look maintain anymore https://github.com/softprops/action-gh-release/issues/249#issuecomment-1307491834 and still using deprecated Node 12 runtime:

![image](https://user-images.githubusercontent.com/1951866/203016083-11ebab8f-049f-4296-be6b-1992a644e659.png)

Forked this action and update dependencies and Node runtime.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>