### PR TITLE
hack: mutualize build opts in Makefile and Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,56 +4,77 @@ else ifneq (, $(shell docker buildx version))
 	export BUILDX_CMD = docker buildx
 else ifneq (, $(shell which buildx))
 	export BUILDX_CMD = $(which buildx)
-else
-	$(error "Buildx is required: https://github.com/docker/buildx#installing")
 endif
 
+export BUILDX_CMD ?= docker buildx
+
+.PHONY: all
+all: binaries
+
+.PHONY: build
+build:
+	./hack/build
+
+.PHONY: shell
 shell:
 	./hack/shell
 
+.PHONY: binaries
 binaries:
 	$(BUILDX_CMD) bake binaries
 
+.PHONY: binaries-cross
 binaries-cross:
 	$(BUILDX_CMD) bake binaries-cross
 
+.PHONY: install
 install: binaries
 	mkdir -p ~/.docker/cli-plugins
 	install bin/build/buildx ~/.docker/cli-plugins/docker-buildx
 
+.PHONY: release
 release:
 	./hack/release
 
+.PHONY: validate-all
 validate-all: lint test validate-vendor validate-docs
 
+.PHONY: lint
 lint:
 	$(BUILDX_CMD) bake lint
 
+.PHONY: test
 test:
 	$(BUILDX_CMD) bake test
 
+.PHONY: validate-vendor
 validate-vendor:
 	$(BUILDX_CMD) bake validate-vendor
 
+.PHONY: validate-docs
 validate-docs:
 	$(BUILDX_CMD) bake validate-docs
 
+.PHONY: validate-authors
 validate-authors:
 	$(BUILDX_CMD) bake validate-authors
 
+.PHONY: test-driver
 test-driver:
 	./hack/test-driver
 
+.PHONY: vendor
 vendor:
 	./hack/update-vendor
 
+.PHONY: docs
 docs:
 	./hack/update-docs
 
+.PHONY: authors
 authors:
 	$(BUILDX_CMD) bake update-authors
 
+.PHONY: mod-outdated
 mod-outdated:
 	$(BUILDX_CMD) bake mod-outdated
-
-.PHONY: shell binaries binaries-cross install release validate-all lint validate-vendor validate-docs validate-authors vendor docs authors

--- a/hack/build
+++ b/hack/build
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+set -e
+
+: "${DESTDIR=./bin/build}"
+: "${PACKAGE=github.com/docker/buildx}"
+: "${VERSION=$(./hack/git-meta version)}"
+: "${REVISION=$(./hack/git-meta revision)}"
+
+: "${CGO_ENABLED=0}"
+: "${GO_PKG=github.com/docker/buildx}"
+: "${GO_LDFLAGS=-X ${GO_PKG}/version.Version=${VERSION} -X ${GO_PKG}/version.Revision=${REVISION} -X ${GO_PKG}/version.Package=${PACKAGE}}"
+: "${GO_EXTRA_LDFLAGS=}"
+
+set -x
+CGO_ENABLED=$CGO_ENABLED go build -mod vendor -trimpath -ldflags "${GO_LDFLAGS} ${GO_EXTRA_LDFLAGS}" -o "${DESTDIR}/docker-buildx" ./cmd/buildx

--- a/hack/git-meta
+++ b/hack/git-meta
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+set -e
+
+case $1 in
+  "version")
+    git describe --match 'v[0-9]*' --dirty='.m' --always --tags
+    ;;
+  "revision")
+    echo "$(git rev-parse HEAD)$(if ! git diff --no-ext-diff --quiet --exit-code; then echo .m; fi)"
+    ;;
+  *)
+    echo "usage: ./hack/git-meta <version|revision>"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
follow-up https://github.com/docker/buildx/pull/1268#issuecomment-1288488791

Mutualize build opts in Makefile and Dockerfile so we avoid drifting with packaging releases https://github.com/docker/docker-ce-packaging/blob/43635c4329d15c3639d6b8693b653b7ea9818487/deb/common/rules#L22:

We can then change:

```
CGO_ENABLED=0 GO111MODULE=on go build -mod=vendor -o /usr/libexec/docker/cli-plugins/docker-buildx -ldflags "-X github.com/docker/buildx/version.Version=$(BUILDX_VERSION) -X github.com/docker/buildx/version.Revision=$(git rev-parse HEAD) -X github.com/docker/buildx/version.Package=github.com/docker/buildx" ./cmd/buildx
```

with:

```
DESTDIR=/usr/libexec/docker/cli-plugins VERSION=$(BUILDX_VERSION) REVISION=$(BUILDX_GITCOMMIT) make build
```

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>