### PR TITLE
store: set nodegroup last activity

### DIFF
--- a/commands/bake.go
+++ b/commands/bake.go
@@ -111,6 +111,9 @@ func runBake(dockerCli command.Cli, targets []string, in bakeOptions) (err error
 		if err != nil {
 			return err
 		}
+		if err = updateLastActivity(dockerCli, b.NodeGroup); err != nil {
+			return errors.Wrapf(err, "failed to update builder last activity time")
+		}
 		nodes, err = b.LoadNodes(ctx, false)
 		if err != nil {
 			return err

--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -50,6 +50,9 @@ func runInspect(dockerCli command.Cli, in inspectOptions) error {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
 	fmt.Fprintf(w, "Name:\t%s\n", b.Name)
 	fmt.Fprintf(w, "Driver:\t%s\n", b.Driver)
+	if !b.NodeGroup.LastActivity.IsZero() {
+		fmt.Fprintf(w, "Last Activity:\t%v\n", b.NodeGroup.LastActivity)
+	}
 
 	if err != nil {
 		fmt.Fprintf(w, "Error:\t%s\n", err.Error())

--- a/store/nodegroup.go
+++ b/store/nodegroup.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/containerd/containerd/platforms"
 	"github.com/docker/buildx/util/confutil"
@@ -18,7 +19,8 @@ type NodeGroup struct {
 	Dynamic bool
 
 	// skip the following fields from being saved in the store
-	DockerContext bool `json:"-"`
+	DockerContext bool      `json:"-"`
+	LastActivity  time.Time `json:"-"`
 }
 
 type Node struct {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -92,6 +92,7 @@ func TestNodeManagement(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "mybuild", ng.Name)
 	require.Equal(t, "mydriver", ng.Driver)
+	require.True(t, !ng.LastActivity.IsZero())
 
 	_, err = txn.NodeGroupByName("mybuild2")
 	require.Error(t, err)

--- a/store/storeutil/storeutil.go
+++ b/store/storeutil/storeutil.go
@@ -85,7 +85,7 @@ func GetNodeGroup(txn *store.Txn, dockerCli command.Cli, name string) (*store.No
 	}
 	for _, l := range list {
 		if l.Name == name {
-			return &store.NodeGroup{
+			ng = &store.NodeGroup{
 				Name: name,
 				Nodes: []store.Node{
 					{
@@ -93,8 +93,11 @@ func GetNodeGroup(txn *store.Txn, dockerCli command.Cli, name string) (*store.No
 						Endpoint: name,
 					},
 				},
-				DockerContext: true,
-			}, nil
+			}
+			if ng.LastActivity, err = txn.GetLastActivity(ng); err != nil {
+				return nil, err
+			}
+			return ng, nil
 		}
 	}
 


### PR DESCRIPTION
adds last activity property that will be updated on build or when a node is updated.

```console
$ docker buildx inspect
Name:          builder2
Driver:        docker-container
Last Activity: 2022-11-30 13:56:51 +0100 CET

Nodes:
Name:           builder20
Endpoint:       unix:///var/run/docker.sock
Driver Options: env.BUILDKIT_STEP_LOG_MAX_SPEED="10485760" env.JAEGER_TRACE="localhost:6831" image="moby/buildkit:master" network="host" env.BUILDKIT_STEP_LOG_MAX_SIZE="10485760"
Status:         running
Flags:          --debug --allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host
Buildkit:       7615120
Platforms:      linux/amd64, linux/amd64/v2, linux/amd64/v3, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/mips64le, linux/mips64, linux/arm/v7, linux/arm/v6
```