### PR TITLE
builder: add worker gc policies and labels

### DIFF
--- a/builder/node.go
+++ b/builder/node.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/buildx/util/dockerutil"
 	"github.com/docker/buildx/util/imagetools"
 	"github.com/docker/buildx/util/platformutil"
+	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/util/grpcerrors"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -23,6 +24,8 @@ type Node struct {
 	Driver      driver.Driver
 	DriverInfo  *driver.Info
 	Platforms   []ocispecs.Platform
+	GCPolicy    []client.PruneInfo
+	Labels      map[string]string
 	ImageOpt    imagetools.Opt
 	ProxyConfig map[string]string
 	Version     string
@@ -182,8 +185,12 @@ func (n *Node) loadData(ctx context.Context) error {
 		if err != nil {
 			return errors.Wrap(err, "listing workers")
 		}
-		for _, w := range workers {
+		for idx, w := range workers {
 			n.Platforms = append(n.Platforms, w.Platforms...)
+			if idx == 0 {
+				n.GCPolicy = w.GCPolicy
+				n.Labels = w.Labels
+			}
 		}
 		n.Platforms = platformutil.Dedupe(n.Platforms)
 		inf, err := driverClient.Info(ctx)

--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"github.com/docker/buildx/util/platformutil"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/go-units"
 	"github.com/moby/buildkit/util/appcontext"
 	"github.com/spf13/cobra"
 )
@@ -89,6 +91,26 @@ func runInspect(dockerCli command.Cli, in inspectOptions) error {
 					fmt.Fprintf(w, "Buildkit:\t%s\n", nodes[i].Version)
 				}
 				fmt.Fprintf(w, "Platforms:\t%s\n", strings.Join(platformutil.FormatInGroups(n.Node.Platforms, n.Platforms), ", "))
+				if len(nodes[i].Labels) > 0 {
+					fmt.Fprintf(w, "Labels:\n")
+					for _, k := range sortedKeys(nodes[i].Labels) {
+						v := nodes[i].Labels[k]
+						fmt.Fprintf(w, "\t%s:\t%s\n", k, v)
+					}
+				}
+				for ri, rule := range nodes[i].GCPolicy {
+					fmt.Fprintf(w, "GC Policy rule#%d:\n", ri)
+					fmt.Fprintf(w, "\tAll:\t%v\n", rule.All)
+					if len(rule.Filter) > 0 {
+						fmt.Fprintf(w, "\tFilters:\t%s\n", strings.Join(rule.Filter, " "))
+					}
+					if rule.KeepDuration > 0 {
+						fmt.Fprintf(w, "\tKeep Duration:\t%v\n", rule.KeepDuration.String())
+					}
+					if rule.KeepBytes > 0 {
+						fmt.Fprintf(w, "\tKeep Bytes:\t%s\n", units.BytesSize(float64(rule.KeepBytes)))
+					}
+				}
 			}
 		}
 	}
@@ -118,4 +140,15 @@ func inspectCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 	flags.BoolVar(&options.bootstrap, "bootstrap", false, "Ensure builder has booted before inspecting")
 
 	return cmd
+}
+
+func sortedKeys(m map[string]string) []string {
+	s := make([]string, len(m))
+	i := 0
+	for k := range m {
+		s[i] = k
+		i++
+	}
+	sort.Strings(s)
+	return s
 }

--- a/docs/reference/buildx_inspect.md
+++ b/docs/reference/buildx_inspect.md
@@ -49,20 +49,38 @@ The following example shows information about a builder instance named
 
 ```console
 $ docker buildx inspect elated_tesla
-
-Name:   elated_tesla
-Driver: docker-container
+Name:          elated_tesla
+Driver:        docker-container
+Last Activity: 2022-11-30 12:42:47 +0100 CET
 
 Nodes:
-Name:      elated_tesla0
-Endpoint:  unix:///var/run/docker.sock
-Status:    running
-Buildkit:  v0.10.3
-Platforms: linux/amd64
-
-Name:      elated_tesla1
-Endpoint:  ssh://ubuntu@1.2.3.4
-Status:    running
-Buildkit:  v0.10.3
-Platforms: linux/arm64*, linux/arm/v7, linux/arm/v6
+Name:           elated_tesla0
+Endpoint:       unix:///var/run/docker.sock
+Driver Options: env.BUILDKIT_STEP_LOG_MAX_SPEED="10485760" env.JAEGER_TRACE="localhost:6831" image="moby/buildkit:latest" network="host" env.BUILDKIT_STEP_LOG_MAX_SIZE="10485760"
+Status:         running
+Flags:          --debug --allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host
+BuildKit:       v0.10.6
+Platforms:      linux/arm64*, linux/arm/v7, linux/arm/v6
+Labels:
+ org.mobyproject.buildkit.worker.executor:         oci
+ org.mobyproject.buildkit.worker.hostname:         docker-desktop
+ org.mobyproject.buildkit.worker.network:          host
+ org.mobyproject.buildkit.worker.oci.process-mode: sandbox
+ org.mobyproject.buildkit.worker.selinux.enabled:  false
+ org.mobyproject.buildkit.worker.snapshotter:      overlayfs
+GC Policy rule#0:
+ All:           false
+ Filters:       type==source.local,type==exec.cachemount,type==source.git.checkout
+ Keep Duration: 48h0m0s
+ Keep Bytes:    488.3MiB
+GC Policy rule#1:
+ All:           false
+ Keep Duration: 1440h0m0s
+ Keep Bytes:    24.21GiB
+GC Policy rule#2:
+ All:        false
+ Keep Bytes: 24.21GiB
+GC Policy rule#3:
+ All:        true
+ Keep Bytes: 24.21GiB
 ```


### PR DESCRIPTION
~needs #1430~

Adds builder GC Policies with worker labels. Will be displayed when using `inspect` command:

```console
$ docker buildx inspect
Name:          builder2
Driver:        docker-container
Last Activity: 2022-11-30 12:42:47 +0100 CET

Nodes:
Name:           builder20
Endpoint:       unix:///var/run/docker.sock
Driver Options: env.BUILDKIT_STEP_LOG_MAX_SPEED="10485760" env.JAEGER_TRACE="localhost:6831" image="moby/buildkit:latest" network="host" env.BUILDKIT_STEP_LOG_MAX_SIZE="10485760"
Status:         running
Flags:          --debug --allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host
BuildKit:       v0.10.6
Platforms:      linux/amd64, linux/amd64/v2, linux/amd64/v3, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/mips64le, linux/mips64, linux/arm/v7, linux/arm/v6
Labels:
 org.mobyproject.buildkit.worker.executor:         oci
 org.mobyproject.buildkit.worker.hostname:         docker-desktop
 org.mobyproject.buildkit.worker.network:          host
 org.mobyproject.buildkit.worker.oci.process-mode: sandbox
 org.mobyproject.buildkit.worker.selinux.enabled:  false
 org.mobyproject.buildkit.worker.snapshotter:      overlayfs
GC Policy rule#0:
 All:           false
 Filters:       type==source.local,type==exec.cachemount,type==source.git.checkout
 Keep Duration: 48h0m0s
 Keep Bytes:    488.3MiB
GC Policy rule#1:
 All:           false
 Keep Duration: 1440h0m0s
 Keep Bytes:    24.21GiB
GC Policy rule#2:
 All:        false
 Keep Bytes: 24.21GiB
GC Policy rule#3:
 All:        true
 Keep Bytes: 24.21GiB
```