### PR TITLE
imagetools: set default repo ref on creation if nil

### DIFF
--- a/commands/imagetools/create.go
+++ b/commands/imagetools/create.go
@@ -90,21 +90,24 @@ func runCreate(dockerCli command.Cli, in createOptions, args []string) error {
 	}
 
 	for i, s := range srcs {
-		if s.Ref == nil && s.Desc.MediaType == "" && s.Desc.Digest != "" {
+		if s.Ref == nil {
 			if defaultRepo == nil {
 				return errors.Errorf("multiple repositories specified, cannot infer repository for %q", args[i])
 			}
-
 			n, err := reference.ParseNormalizedNamed(*defaultRepo)
 			if err != nil {
 				return err
 			}
-			r, err := reference.WithDigest(n, s.Desc.Digest)
-			if err != nil {
-				return err
+			if s.Desc.MediaType == "" && s.Desc.Digest != "" {
+				r, err := reference.WithDigest(n, s.Desc.Digest)
+				if err != nil {
+					return err
+				}
+				srcs[i].Ref = r
+				sourceRefs = true
+			} else {
+				srcs[i].Ref = reference.TagNameOnly(n)
 			}
-			srcs[i].Ref = r
-			sourceRefs = true
 		}
 	}
 


### PR DESCRIPTION
fixes #1425
related to https://github.com/docker/buildx/pull/1137 (https://github.com/docker/buildx/pull/1137/commits/d3412f1039acd5f13e7891fa2d6b149fc7954d22)

Previously when combining descriptors we were always using the default repo ref for remote resolution. This change brings this logic back and will set the default repo ref for the source if empty.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>