### PR TITLE
build: skip "host-gateway" validation with moby driver

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -615,7 +615,7 @@ func toSolveOpt(ctx context.Context, di DriverInfo, multiDriver bool, opt Option
 	}
 
 	// setup extrahosts
-	extraHosts, err := toBuildkitExtraHosts(opt.ExtraHosts)
+	extraHosts, err := toBuildkitExtraHosts(opt.ExtraHosts, d.IsMobyDriver())
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
follow-up https://github.com/moby/moby/pull/44537

When parsing extra hosts, skip "host-gateway" IP address validation with moby driver.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>