### PR TITLE
bake: support null arg and label value

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -559,24 +559,24 @@ type Target struct {
 	Attest   []string `json:"attest,omitempty" hcl:"attest,optional" cty:"attest"`
 	Inherits []string `json:"inherits,omitempty" hcl:"inherits,optional" cty:"inherits"`
 
-	Context          *string           `json:"context,omitempty" hcl:"context,optional" cty:"context"`
-	Contexts         map[string]string `json:"contexts,omitempty" hcl:"contexts,optional" cty:"contexts"`
-	Dockerfile       *string           `json:"dockerfile,omitempty" hcl:"dockerfile,optional" cty:"dockerfile"`
-	DockerfileInline *string           `json:"dockerfile-inline,omitempty" hcl:"dockerfile-inline,optional" cty:"dockerfile-inline"`
-	Args             map[string]string `json:"args,omitempty" hcl:"args,optional" cty:"args"`
-	Labels           map[string]string `json:"labels,omitempty" hcl:"labels,optional" cty:"labels"`
-	Tags             []string          `json:"tags,omitempty" hcl:"tags,optional" cty:"tags"`
-	CacheFrom        []string          `json:"cache-from,omitempty"  hcl:"cache-from,optional" cty:"cache-from"`
-	CacheTo          []string          `json:"cache-to,omitempty"  hcl:"cache-to,optional" cty:"cache-to"`
-	Target           *string           `json:"target,omitempty" hcl:"target,optional" cty:"target"`
-	Secrets          []string          `json:"secret,omitempty" hcl:"secret,optional" cty:"secret"`
-	SSH              []string          `json:"ssh,omitempty" hcl:"ssh,optional" cty:"ssh"`
-	Platforms        []string          `json:"platforms,omitempty" hcl:"platforms,optional" cty:"platforms"`
-	Outputs          []string          `json:"output,omitempty" hcl:"output,optional" cty:"output"`
-	Pull             *bool             `json:"pull,omitempty" hcl:"pull,optional" cty:"pull"`
-	NoCache          *bool             `json:"no-cache,omitempty" hcl:"no-cache,optional" cty:"no-cache"`
-	NetworkMode      *string           `json:"-" hcl:"-" cty:"-"`
-	NoCacheFilter    []string          `json:"no-cache-filter,omitempty" hcl:"no-cache-filter,optional" cty:"no-cache-filter"`
+	Context          *string            `json:"context,omitempty" hcl:"context,optional" cty:"context"`
+	Contexts         map[string]string  `json:"contexts,omitempty" hcl:"contexts,optional" cty:"contexts"`
+	Dockerfile       *string            `json:"dockerfile,omitempty" hcl:"dockerfile,optional" cty:"dockerfile"`
+	DockerfileInline *string            `json:"dockerfile-inline,omitempty" hcl:"dockerfile-inline,optional" cty:"dockerfile-inline"`
+	Args             map[string]*string `json:"args,omitempty" hcl:"args,optional" cty:"args"`
+	Labels           map[string]string  `json:"labels,omitempty" hcl:"labels,optional" cty:"labels"`
+	Tags             []string           `json:"tags,omitempty" hcl:"tags,optional" cty:"tags"`
+	CacheFrom        []string           `json:"cache-from,omitempty"  hcl:"cache-from,optional" cty:"cache-from"`
+	CacheTo          []string           `json:"cache-to,omitempty"  hcl:"cache-to,optional" cty:"cache-to"`
+	Target           *string            `json:"target,omitempty" hcl:"target,optional" cty:"target"`
+	Secrets          []string           `json:"secret,omitempty" hcl:"secret,optional" cty:"secret"`
+	SSH              []string           `json:"ssh,omitempty" hcl:"ssh,optional" cty:"ssh"`
+	Platforms        []string           `json:"platforms,omitempty" hcl:"platforms,optional" cty:"platforms"`
+	Outputs          []string           `json:"output,omitempty" hcl:"output,optional" cty:"output"`
+	Pull             *bool              `json:"pull,omitempty" hcl:"pull,optional" cty:"pull"`
+	NoCache          *bool              `json:"no-cache,omitempty" hcl:"no-cache,optional" cty:"no-cache"`
+	NetworkMode      *string            `json:"-" hcl:"-" cty:"-"`
+	NoCacheFilter    []string           `json:"no-cache-filter,omitempty" hcl:"no-cache-filter,optional" cty:"no-cache-filter"`
 	// IMPORTANT: if you add more fields here, do not forget to update newOverrides and docs/manuals/bake/file-definition.md.
 
 	// linked is a private field to mark a target used as a linked one
@@ -615,8 +615,11 @@ func (t *Target) Merge(t2 *Target) {
 		t.DockerfileInline = t2.DockerfileInline
 	}
 	for k, v := range t2.Args {
+		if v == nil {
+			continue
+		}
 		if t.Args == nil {
-			t.Args = map[string]string{}
+			t.Args = map[string]*string{}
 		}
 		t.Args[k] = v
 	}
@@ -688,9 +691,9 @@ func (t *Target) AddOverrides(overrides map[string]Override) error {
 				return errors.Errorf("args require name")
 			}
 			if t.Args == nil {
-				t.Args = map[string]string{}
+				t.Args = map[string]*string{}
 			}
-			t.Args[keys[1]] = value
+			t.Args[keys[1]] = &value
 		case "contexts":
 			if len(keys) != 2 {
 				return errors.Errorf("contexts require name")
@@ -882,6 +885,14 @@ func toBuildOpt(t *Target, inp *Input) (*build.Options, error) {
 		dockerfilePath = path.Join(contextPath, dockerfilePath)
 	}
 
+	args := map[string]string{}
+	for k, v := range t.Args {
+		if v == nil {
+			continue
+		}
+		args[k] = *v
+	}
+
 	noCache := false
 	if t.NoCache != nil {
 		noCache = *t.NoCache
@@ -922,7 +933,7 @@ func toBuildOpt(t *Target, inp *Input) (*build.Options, error) {
 	bo := &build.Options{
 		Inputs:        bi,
 		Tags:          t.Tags,
-		BuildArgs:     t.Args,
+		BuildArgs:     args,
 		Labels:        t.Labels,
 		NoCache:       noCache,
 		NoCacheFilter: t.NoCacheFilter,

--- a/bake/bake_test.go
+++ b/bake/bake_test.go
@@ -1296,10 +1296,17 @@ func TestHCLNullVars(t *testing.T) {
 			`variable "FOO" {
 				default = null
 			}
+			variable "BAR" {
+				default = null
+			}
 			target "default" {
 				args = {
 					foo = FOO
 					bar = "baz"
+				}
+				labels = {
+					"com.docker.app.bar" = BAR
+					"com.docker.app.baz" = "foo"
 				}
 			}`),
 	}
@@ -1315,6 +1322,7 @@ func TestHCLNullVars(t *testing.T) {
 	_, err = TargetsToBuildOpt(m, &Input{})
 	require.NoError(t, err)
 	require.Equal(t, map[string]*string{"bar": ptrstr("baz")}, m["default"].Args)
+	require.Equal(t, map[string]*string{"com.docker.app.baz": ptrstr("foo")}, m["default"].Labels)
 }
 
 func TestJSONNullVars(t *testing.T) {

--- a/bake/compose.go
+++ b/bake/compose.go
@@ -75,13 +75,19 @@ func ParseCompose(cfgs []compose.ConfigFile, envs map[string]string) (*Config, e
 				secrets = append(secrets, secret)
 			}
 
+			// compose does not support nil values for labels
+			labels := map[string]*string{}
+			for k, v := range s.Build.Labels {
+				labels[k] = &v
+			}
+
 			g.Targets = append(g.Targets, targetName)
 			t := &Target{
 				Name:       targetName,
 				Context:    contextPathP,
 				Dockerfile: dockerfilePathP,
 				Tags:       s.Build.Tags,
-				Labels:     s.Build.Labels,
+				Labels:     labels,
 				Args: flatten(s.Build.Args.Resolve(func(val string) (string, bool) {
 					if val, ok := s.Environment[val]; ok && val != nil {
 						return *val, true

--- a/bake/compose.go
+++ b/bake/compose.go
@@ -193,16 +193,16 @@ func loadDotEnv(curenv map[string]string, workingDir string) (map[string]string,
 	return curenv, nil
 }
 
-func flatten(in compose.MappingWithEquals) compose.Mapping {
+func flatten(in compose.MappingWithEquals) map[string]*string {
 	if len(in) == 0 {
 		return nil
 	}
-	out := compose.Mapping{}
+	out := map[string]*string{}
 	for k, v := range in {
 		if v == nil {
 			continue
 		}
-		out[k] = *v
+		out[k] = v
 	}
 	return out
 }

--- a/bake/hclparser/expr.go
+++ b/bake/hclparser/expr.go
@@ -83,7 +83,7 @@ func appendJSONFuncCalls(exp hcl.Expression, m map[string]struct{}) error {
 
 	// hcl/v2/json/ast#stringVal
 	val := src.FieldByName("Value")
-	if val.IsZero() {
+	if !val.IsValid() || val.IsZero() {
 		return nil
 	}
 	rng := src.FieldByName("SrcRange")


### PR DESCRIPTION
follow-up https://github.com/docker/buildx/issues/1362#issuecomment-1287397312

```hcl
variable "GO_VERSION" {
  default = ""
}
target "default" {
  args = {
    GO_VERSION = GO_VERSION
  }
}
```

```dockerfile
ARG GO_VERSION="1.18"
FROM golang:${GO_VERSION}
```

```console
$ docker buildx bake --print
{
  "target": {
    "default": {
      "context": ".",
      "dockerfile": "Dockerfile",
      "args": {
        "GO_VERSION": ""
      }
    }
  }
}
```

In this example, `GO_VERSION` arg will always be sent in the request and overwrites the one in the Dockerfile. Therefore build would fail as `GO_VERSION` will be empty.

With this PR, `null` type is now handled and will set the arg only if set:

```hcl
variable "GO_VERSION" {
  default = null
}
target "default" {
  args = {
    GO_VERSION = GO_VERSION
  }
}
```

```console
$ docker buildx bake --print
{
  "target": {
    "default": {
      "context": ".",
      "dockerfile": "Dockerfile"
    }
  }
}
```

```console
$ GO_VERSION=1.19 docker buildx bake --print
{
  "target": {
    "default": {
      "context": ".",
      "dockerfile": "Dockerfile",
      "args": {
        "GO_VERSION": "1.19"
      }
    }
  }
}
```

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>