### PR TITLE
builder: fix default docker context behavior

### DIFF
--- a/store/nodegroup.go
+++ b/store/nodegroup.go
@@ -12,10 +12,11 @@ import (
 )
 
 type NodeGroup struct {
-	Name    string
-	Driver  string
-	Nodes   []Node
-	Dynamic bool
+	Name          string
+	Driver        string
+	Nodes         []Node
+	Dynamic       bool
+	DockerContext bool
 }
 
 type Node struct {

--- a/store/storeutil/storeutil.go
+++ b/store/storeutil/storeutil.go
@@ -79,10 +79,6 @@ func GetNodeGroup(txn *store.Txn, dockerCli command.Cli, name string) (*store.No
 		return ng, nil
 	}
 
-	if name == "default" {
-		name = dockerCli.CurrentContext()
-	}
-
 	list, err := dockerCli.ContextStore().List()
 	if err != nil {
 		return nil, err
@@ -90,13 +86,14 @@ func GetNodeGroup(txn *store.Txn, dockerCli command.Cli, name string) (*store.No
 	for _, l := range list {
 		if l.Name == name {
 			return &store.NodeGroup{
-				Name: "default",
+				Name: name,
 				Nodes: []store.Node{
 					{
-						Name:     "default",
+						Name:     name,
 						Endpoint: name,
 					},
 				},
+				DockerContext: true,
 			}, nil
 		}
 	}


### PR DESCRIPTION
With changes from https://github.com/docker/buildx/pull/1430 we are now setting the expected builder name and not `default` for `docker` builders: https://github.com/docker/buildx/blob/fe8d5627e0fb9d88febec40baece90b9d23551df/builder/builder.go#L100-L102

When switching to another context other than `default` like `docker context use foo`, build will not work as it still expects `default` to be the active context:

```
$ docker buildx build.
ERROR: use `docker --context=foo buildx` to switch to context "foo"
```

Another issue also linked to this change is that enabled context builder other than `default` (here `docker2010`) appears twice in the list and also docker nodes are always set to `default`:

```
$ docker buildx ls
NAME/NODE         DRIVER/ENDPOINT             STATUS   BUILDKIT PLATFORMS
attest            docker-container
  attest0         unix:///var/run/docker.sock stopped
builder2          docker-container
  builder20       unix:///var/run/docker.sock running  7615120  linux/amd64, linux/amd64/v2, linux/amd64/v3, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/mips64le, linux/mips64, linux/arm/v7, linux/arm/v6
eager_benz        docker-container
  eager_benz0     unix:///var/run/docker.sock running  v0.10.5  linux/amd64, linux/amd64/v2, linux/amd64/v3, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/mips64le, linux/mips64, linux/arm/v7, linux/arm/v6
docker2010        docker
  default         docker2010                  running  20.10.21 linux/amd64, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/arm/v7, linux/arm/v6
desktop-linux     docker
  default         desktop-linux               error
desktop-windows   docker
  default         desktop-windows             error
docker1903        docker
  default         docker1903                  running  19.03.15 linux/amd64, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/arm/v7, linux/arm/v6
docker2010        docker
  default         docker2010                  running  20.10.21 linux/amd64, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/arm/v7, linux/arm/v6
```

And as you can see the `ls` command doesn't show the current builder (with `*`) anymore when switching to another docker context builder. Node name for docker builders is also not correct.

This PR avoids setting the builder name in the new builder client and lets the store doing it. To make a clear distinction with context builders for validation, a new field `DockerContext` has been added. This also avoids unnecessary loading of contexts for validation:

```
$ docker buildx ls
NAME/NODE         DRIVER/ENDPOINT             STATUS   BUILDKIT PLATFORMS
attest            docker-container
  attest0         unix:///var/run/docker.sock stopped
builder2          docker-container
  builder20       unix:///var/run/docker.sock running  7615120  linux/amd64, linux/amd64/v2, linux/amd64/v3, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/mips64le, linux/mips64, linux/arm/v7, linux/arm/v6
eager_benz        docker-container
  eager_benz0     unix:///var/run/docker.sock running  v0.10.5  linux/amd64, linux/amd64/v2, linux/amd64/v3, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/mips64le, linux/mips64, linux/arm/v7, linux/arm/v6
default           docker
  default         default                     running  20.10.21 linux/amd64, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/arm/v7, linux/arm/v6
desktop-linux     docker
  desktop-linux   desktop-linux               error
desktop-windows   docker
  desktop-windows desktop-windows             error
docker1903        docker
  docker1903      docker1903                  running  19.03.15 linux/amd64, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/arm/v7, linux/arm/v6
docker2010 *      docker
  docker2010      docker2010                  running  20.10.21 linux/amd64, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/arm/v7, linux/arm/v6
```

___

Also found out that `buildx inspect` command does not return the correct builder when switching to another context other than `default` in current 0.9.1:

```
$ docker buildx inspect
Name:   default
Driver: docker

Nodes:
Name:      default
Endpoint:  docker2010
Status:    running
Buildkit:  20.10.21
Platforms: linux/amd64, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/arm/v7, linux/arm/v6
```

With this PR:

```
$ docker buildx inspect
Name:   docker2010
Driver: docker

Nodes:
Name:      docker2010
Endpoint:  docker2010
Status:    running
Buildkit:  20.10.21
Platforms: linux/amd64, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/arm/v7, linux/arm/v6
```