### PR TITLE
store: skip DockerContext field from being saved

### DIFF
--- a/store/nodegroup.go
+++ b/store/nodegroup.go
@@ -12,11 +12,13 @@ import (
 )
 
 type NodeGroup struct {
-	Name          string
-	Driver        string
-	Nodes         []Node
-	Dynamic       bool
-	DockerContext bool
+	Name    string
+	Driver  string
+	Nodes   []Node
+	Dynamic bool
+
+	// skip the following fields from being saved in the store
+	DockerContext bool `json:"-"`
 }
 
 type Node struct {


### PR DESCRIPTION
related to #1454

Forgot to skip `DockerContext` field from being saved. Otherwise when a new builder is created, it will be added to the store:

```json
{
  "Name": "hardcore_wu",
  "Driver": "docker-container",
  "Nodes": [
    {
      "Name": "hardcore_wu0",
      "Endpoint": "unix:///var/run/docker.sock",
      "Platforms": null,
      "Flags": null,
      "DriverOpts": null,
      "Files": null
    }
  ],
  "Dynamic": false,
  "DockerContext": false
}
```

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>