### PR TITLE
build: refactor reference parsing for oci image layouts

### DIFF
--- a/docs/reference/buildx_build.md
+++ b/docs/reference/buildx_build.md
@@ -136,10 +136,12 @@ COPY --from=project myfile /
 
 #### <a name="source-oci-layout"></a> Source image from OCI layout directory
 
-Source an image from a local [OCI layout compliant directory](https://github.com/opencontainers/image-spec/blob/main/image-layout.md):
+Source an image from a local [OCI layout compliant directory](https://github.com/opencontainers/image-spec/blob/main/image-layout.md),
+either by tag, or by digest:
 
 ```console
-$ docker buildx build --build-context foo=oci-layout:///path/to/local/layout@sha256:abcd12345 .
+$ docker buildx build --build-context foo=oci-layout:///path/to/local/layout:<tag>
+$ docker buildx build --build-context foo=oci-layout:///path/to/local/layout@sha256:<digest>
 ```
 
 ```dockerfile
@@ -151,14 +153,8 @@ COPY --from=foo myfile /
 FROM foo
 ```
 
-The OCI layout directory must be compliant with the [OCI layout specification](https://github.com/opencontainers/image-spec/blob/main/image-layout.md). It looks _solely_ for hashes. It does not
-do any form of `image:tag` resolution to find the hash of the manifest; that is up to you.
-
-The format of the `--build-context` must be: `<context>=oci-layout://<path-to-local-layout>@sha256:<hash-of-manifest>`, where:
-
-* `context` is the name of the build context as used in the `Dockerfile`.
-* `path-to-local-layout` is the path on the local machine, where you are running `docker build`, to the spec-compliant OCI layout.
-* `hash-of-manifest` is the hash of the manifest for the image. It can be a single-architecture manifest or a multi-architecture index.
+The OCI layout directory must be compliant with the [OCI layout specification](https://github.com/opencontainers/image-spec/blob/main/image-layout.md).
+You can reference an image in the layout using either tags, or the exact digest.
 
 ### <a name="builder"></a> Override the configured builder instance (--builder)
 


### PR DESCRIPTION
:arrow_up: Follow up to #1173.

We allow any valid image reference format for the oci-layout, not just limiting to name@digest, we additionally allow images of the form name:tag@digest now.

The name of the reference is used to find the local directory to lookup the store in, while the tag and digest are attached to a random identity to generate the dummy reference sent to the oci-layout context.

This separation of the target to replace and the value to replace it with ensures that any tag or digest set in the client is properly sent across to the server. The tag, while not relevant now, may become relevant at some point in the future for the server, so we can should send it across for now.