### PR TITLE
build: don't set add-hosts option if empty

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -607,7 +607,9 @@ func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt Op
 	if err != nil {
 		return nil, nil, err
 	}
-	so.FrontendAttrs["add-hosts"] = extraHosts
+	if len(extraHosts) > 0 {
+		so.FrontendAttrs["add-hosts"] = extraHosts
+	}
 
 	// setup shm size
 	if opt.ShmSize.Value() > 0 {


### PR DESCRIPTION
This looks like an oversight, all of the other options have similar checks. This can interfere with generated provenance where "add-hosts" will be marked as an argument to the build, even though it's not actually being utilized.