### PR TITLE
Better attestations default parameters using new exporter `attestation` options

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -594,10 +594,10 @@ func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt Op
 			if v == nil {
 				continue
 			}
-			so.FrontendAttrs[k] = *v
+			so.FrontendAttrs["attest:"+k] = *v
 		}
 	}
-	if _, ok := opt.Attests["attest:provenance"]; !ok {
+	if _, ok := opt.Attests["provenance"]; !ok {
 		so.FrontendAttrs["attest:provenance"] = "mode=min,inline-only=true"
 	}
 

--- a/util/buildflags/attests.go
+++ b/util/buildflags/attests.go
@@ -28,14 +28,13 @@ func ParseAttests(in []string) (map[string]*string, error) {
 			return nil, err
 		}
 
-		k := "attest:" + attestType
-		if _, ok := out[k]; ok {
+		if _, ok := out[attestType]; ok {
 			return nil, errors.Errorf("duplicate attestation field %s", attestType)
 		}
 		if enabled {
-			out[k] = &in
+			out[attestType] = &in
 		} else {
-			out[k] = nil
+			out[attestType] = nil
 		}
 	}
 	return out, nil


### PR DESCRIPTION
:hammer_and_wrench: Fixes https://github.com/moby/buildkit/pull/3380#discussion_r1045462541

This PR refactors the buildx attestations addition to improve the defaults for what attestations are added.

The main part of the patch includes the addition of explicit filtering to all exporters -- if the user has not explicitly enabled an attestation option, then no attestations of that type will be exported, even if they are generated (e.g. a frontend that might unconditionally produce SBOMs).

The exception to the above rule is for the `type=image` exporter: for this case *only*, we additionally ensure that provenance is always generated (with at least `mode=min`) and attach this provenance to the generated image (unless the user explicitly opts out, either by specifying `--provenance=false` or setting the exporter attestation option to not include `provenance`). Because the end destination of the `image` exporter should be a registry (or, I think, a containerd image store?), then it will support the image indexes we use for storing attestations.