### PR TITLE
set default timeout for git context

### DIFF
--- a/build/git.go
+++ b/build/git.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/docker/buildx/util/gitutil"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -15,6 +16,9 @@ import (
 const DockerfileLabel = "com.docker.image.source.entrypoint"
 
 func getGitAttributes(ctx context.Context, contextPath string, dockerfilePath string) (res map[string]string) {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
 	res = make(map[string]string)
 	if contextPath == "" {
 		return

--- a/util/gitutil/gitutil.go
+++ b/util/gitutil/gitutil.go
@@ -98,7 +98,7 @@ func (c *Git) run(args ...string) (string, error) {
 	}
 
 	args = append(extraArgs, args...)
-	cmd := exec.Command("git", args...)
+	cmd := exec.CommandContext(c.ctx, "git", args...)
 	if c.wd != "" {
 		cmd.Dir = c.wd
 	}


### PR DESCRIPTION
There are some cases where Git operations can be slow. For example checking dirty state can take more than 1 minute on WSL2 for fs operations on NTFS folders before the build even starts: https://github.com/microsoft/WSL/issues/4197

```console
$ cd /mnt/c/github.com/moby/moby
$ time git -c log.showSignature=false status --porcelain --ignored >/dev/null
real    1m5.620s
user    0m0.387s
sys     0m59.010s
```

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>