### PR TITLE
ci: do not publish docs on prerelease

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -2,11 +2,13 @@ name: docs-release
 
 on:
   release:
-    types: [ released ]
+    types:
+      - releases
 
 jobs:
   open-pr:
     runs-on: ubuntu-latest
+    if: "!github.event.release.prerelease"
     steps:
       -
         name: Checkout docs repo


### PR DESCRIPTION
follow-up https://github.com/docker/docs/pull/16339

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>