### PR TITLE
buildflags: error on duplicate attest field

### DIFF
--- a/util/buildflags/attests.go
+++ b/util/buildflags/attests.go
@@ -29,6 +29,9 @@ func ParseAttests(in []string) (map[string]*string, error) {
 		}
 
 		k := "attest:" + attestType
+		if _, ok := out[k]; ok {
+			return nil, errors.Errorf("duplicate attestation field %s", attestType)
+		}
 		if enabled {
 			out[k] = &in
 		} else {


### PR DESCRIPTION
:bug: Bug report from @tianon:

> `--attest type=sbom,generator=...` did work, but I had `--sbom=true` later in my CLI which then overwrote the whole `--attest type=sbom` with one that had no arguments

We now explicitly error if a single field is repeated (I seem to remember we did this at some point previously, but looks like it was removed).