### PR TITLE
disable buildx experimental in pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![GitHub release](https://img.shields.io/github/release/docker/buildx.svg?style=flat-square)](https://github.com/docker/buildx/releases/latest)
 [![PkgGoDev](https://img.shields.io/badge/go.dev-docs-007d9c?style=flat-square&logo=go&logoColor=white)](https://pkg.go.dev/github.com/docker/buildx)
-[![Build Status](https://img.shields.io/github/workflow/status/docker/buildx/build?label=build&logo=github&style=flat-square)](https://github.com/docker/buildx/actions?query=workflow%3Abuild)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/docker/buildx/build.yml?branch=master&label=build&logo=github&style=flat-square)](https://github.com/docker/buildx/actions?query=workflow%3Abuild)
 [![Go Report Card](https://goreportcard.com/badge/github.com/docker/buildx?style=flat-square)](https://goreportcard.com/report/github.com/docker/buildx)
 [![codecov](https://img.shields.io/codecov/c/github/docker/buildx?logo=codecov&style=flat-square)](https://codecov.io/gh/docker/buildx)
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -17,7 +17,6 @@ target "_common" {
   args = {
     GO_VERSION = GO_VERSION
     BUILDKIT_CONTEXT_KEEP_GIT_DIR = 1
-    BUILDX_EXPERIMENTAL = 1
   }
 }
 
@@ -46,6 +45,7 @@ target "validate-docs" {
   inherits = ["_common"]
   args = {
     FORMATS = DOCS_FORMATS
+    BUILDX_EXPERIMENTAL = 1 // enables experimental cmds/flags for docs generation
   }
   dockerfile = "./hack/dockerfiles/docs.Dockerfile"
   target = "validate"
@@ -70,6 +70,7 @@ target "update-docs" {
   inherits = ["_common"]
   args = {
     FORMATS = DOCS_FORMATS
+    BUILDX_EXPERIMENTAL = 1 // enables experimental cmds/flags for docs generation
   }
   dockerfile = "./hack/dockerfiles/docs.Dockerfile"
   target = "update"


### PR DESCRIPTION
As discussed with @tonistiigi, we should not set `BUILDX_EXPERIMENTAL` when releasing binaries or bin-image.

Also adds extra commit related to https://github.com/badges/shields/issues/8671 to fix badge in the readme:

![image](https://user-images.githubusercontent.com/1951866/208148908-0b9ced4f-76e5-4cac-9e59-5692136472b2.png)

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>