### PR TITLE
add system proxy config support for cli requests

### DIFF
--- a/cmd/buildx/main.go
+++ b/cmd/buildx/main.go
@@ -56,6 +56,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err := configureProxy(cmd); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
 	if plugin.RunningStandalone() {
 		err = runStandalone(cmd)
 	} else {

--- a/cmd/buildx/proxy.go
+++ b/cmd/buildx/proxy.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/docker/buildx/util/confutil"
+	"github.com/docker/cli/cli/command"
+	"github.com/pkg/errors"
+)
+
+func configureProxy(cmd *command.DockerCli) error {
+	fp := filepath.Join(confutil.ConfigDir(cmd), "proxy.json")
+	dt, err := os.ReadFile(fp)
+	if err != nil {
+		if os.IsNotExist(err) || os.IsPermission(err) {
+			return nil
+		}
+		return err
+	}
+	env := map[string]string{}
+	if err := json.Unmarshal(dt, &env); err != nil {
+		return errors.Wrapf(err, "failed to parse proxy config %s", fp)
+	}
+	permitted := map[string]struct{}{
+		"HTTP_PROXY":  {},
+		"HTTPS_PROXY": {},
+		"NO_PROXY":    {},
+		"FTP_PROXY":   {},
+		"ALL_PROXY":   {},
+	}
+	for k := range permitted {
+		if _, ok := os.LookupEnv(k); ok {
+			continue
+		}
+		if val, ok := env[k]; ok {
+			os.Setenv(k, val)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This adds support for system HTTP_PROXY config for the requests that are made directly by the CLI. When previously user needed to call `HTTPS_PROXY=x docker buildx build` then now they can define these variables in `~/.docker/buildx/proxy.json` where they are loaded automatically.

Note that this is different from the proxy config in the Docker CLI config that buildx also loads. That config is per host and forwarded to the VM side, so it can be a completely different configuration.

@djs55 @thaJeztah 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>