### PR TITLE
[0.10] Propagate SOURCE_DATE_EPOCH from the client env

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -140,6 +140,16 @@ func ReadTargets(ctx context.Context, files []File, targets, overrides []string,
 		}
 	}
 
+	// Propagate SOURCE_DATE_EPOCH from the client env.
+	// The logic is purposely duplicated from `build/build`.go for keeping this visible in `bake --print`.
+	if v := os.Getenv("SOURCE_DATE_EPOCH"); v != "" {
+		for _, f := range m {
+			if _, ok := f.Args["SOURCE_DATE_EPOCH"]; !ok {
+				f.Args["SOURCE_DATE_EPOCH"] = &v
+			}
+		}
+	}
+
 	return m, n, nil
 }
 

--- a/build/build.go
+++ b/build/build.go
@@ -579,6 +579,13 @@ func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt Op
 		}
 	}
 
+	// Propagate SOURCE_DATE_EPOCH from the client env
+	if v := os.Getenv("SOURCE_DATE_EPOCH"); v != "" {
+		if _, ok := so.FrontendAttrs["build-arg:SOURCE_DATE_EPOCH"]; !ok {
+			so.FrontendAttrs["build-arg:SOURCE_DATE_EPOCH"] = v
+		}
+	}
+
 	if len(opt.Attests) > 0 {
 		if !bopts.LLBCaps.Contains(apicaps.CapID("exporter.image.attestations")) {
 			return nil, nil, errors.Errorf("attestations are not supported by the current buildkitd")


### PR DESCRIPTION
Cherry-pick (clean)
- https://github.com/docker/buildx/pull/1482