### PR TITLE
[0.10 backport] update anchor-links and cli-docs-tool v0.5.1

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -470,7 +470,7 @@ func buildCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 	flags := cmd.Flags()
 
 	flags.StringSliceVar(&options.extraHosts, "add-host", []string{}, `Add a custom host-to-IP mapping (format: "host:ip")`)
-	flags.SetAnnotation("add-host", annotation.ExternalURL, []string{"https://docs.docker.com/engine/reference/commandline/build/#add-entries-to-container-hosts-file---add-host"})
+	flags.SetAnnotation("add-host", annotation.ExternalURL, []string{"https://docs.docker.com/engine/reference/commandline/build/#add-host"})
 
 	flags.StringSliceVar(&options.allow, "allow", []string{}, `Allow extra privileged entitlement (e.g., "network.host", "security.insecure")`)
 
@@ -481,12 +481,12 @@ func buildCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 	flags.StringArrayVar(&options.cacheTo, "cache-to", []string{}, `Cache export destinations (e.g., "user/app:cache", "type=local,dest=path/to/dir")`)
 
 	flags.StringVar(&options.cgroupParent, "cgroup-parent", "", "Optional parent cgroup for the container")
-	flags.SetAnnotation("cgroup-parent", annotation.ExternalURL, []string{"https://docs.docker.com/engine/reference/commandline/build/#use-a-custom-parent-cgroup---cgroup-parent"})
+	flags.SetAnnotation("cgroup-parent", annotation.ExternalURL, []string{"https://docs.docker.com/engine/reference/commandline/build/#cgroup-parent"})
 
 	flags.StringArrayVar(&options.contexts, "build-context", []string{}, "Additional build contexts (e.g., name=path)")
 
 	flags.StringVarP(&options.dockerfileName, "file", "f", "", `Name of the Dockerfile (default: "PATH/Dockerfile")`)
-	flags.SetAnnotation("file", annotation.ExternalURL, []string{"https://docs.docker.com/engine/reference/commandline/build/#specify-a-dockerfile--f"})
+	flags.SetAnnotation("file", annotation.ExternalURL, []string{"https://docs.docker.com/engine/reference/commandline/build/#file"})
 
 	flags.StringVar(&options.imageIDFile, "iidfile", "", "Write the image ID to the file")
 
@@ -517,10 +517,10 @@ func buildCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 	flags.StringArrayVar(&options.ssh, "ssh", []string{}, `SSH agent socket or keys to expose to the build (format: "default|<id>[=<socket>|<key>[,<key>]]")`)
 
 	flags.StringArrayVarP(&options.tags, "tag", "t", []string{}, `Name and optionally a tag (format: "name:tag")`)
-	flags.SetAnnotation("tag", annotation.ExternalURL, []string{"https://docs.docker.com/engine/reference/commandline/build/#tag-an-image--t"})
+	flags.SetAnnotation("tag", annotation.ExternalURL, []string{"https://docs.docker.com/engine/reference/commandline/build/#tag"})
 
 	flags.StringVar(&options.target, "target", "", "Set the target build stage to build")
-	flags.SetAnnotation("target", annotation.ExternalURL, []string{"https://docs.docker.com/engine/reference/commandline/build/#specifying-target-build-stage---target"})
+	flags.SetAnnotation("target", annotation.ExternalURL, []string{"https://docs.docker.com/engine/reference/commandline/build/#target"})
 
 	flags.Var(options.ulimits, "ulimit", "Ulimit options")
 

--- a/docs/reference/buildx.md
+++ b/docs/reference/buildx.md
@@ -9,29 +9,29 @@ Extended build capabilities with BuildKit
 
 ### Subcommands
 
-| Name | Description |
-| --- | --- |
-| [`bake`](buildx_bake.md) | Build from a file |
-| [`build`](buildx_build.md) | Start a build |
-| [`create`](buildx_create.md) | Create a new builder instance |
-| [`du`](buildx_du.md) | Disk usage |
-| [`imagetools`](buildx_imagetools.md) | Commands to work on images in registry |
-| [`inspect`](buildx_inspect.md) | Inspect current builder instance |
-| [`install`](buildx_install.md) | Install buildx as a 'docker builder' alias |
-| [`ls`](buildx_ls.md) | List builder instances |
-| [`prune`](buildx_prune.md) | Remove build cache |
-| [`rm`](buildx_rm.md) | Remove a builder instance |
-| [`stop`](buildx_stop.md) | Stop builder instance |
-| [`uninstall`](buildx_uninstall.md) | Uninstall the 'docker builder' alias |
-| [`use`](buildx_use.md) | Set the current builder instance |
-| [`version`](buildx_version.md) | Show buildx version information |
+| Name                                 | Description                                |
+|:-------------------------------------|:-------------------------------------------|
+| [`bake`](buildx_bake.md)             | Build from a file                          |
+| [`build`](buildx_build.md)           | Start a build                              |
+| [`create`](buildx_create.md)         | Create a new builder instance              |
+| [`du`](buildx_du.md)                 | Disk usage                                 |
+| [`imagetools`](buildx_imagetools.md) | Commands to work on images in registry     |
+| [`inspect`](buildx_inspect.md)       | Inspect current builder instance           |
+| [`install`](buildx_install.md)       | Install buildx as a 'docker builder' alias |
+| [`ls`](buildx_ls.md)                 | List builder instances                     |
+| [`prune`](buildx_prune.md)           | Remove build cache                         |
+| [`rm`](buildx_rm.md)                 | Remove a builder instance                  |
+| [`stop`](buildx_stop.md)             | Stop builder instance                      |
+| [`uninstall`](buildx_uninstall.md)   | Uninstall the 'docker builder' alias       |
+| [`use`](buildx_use.md)               | Set the current builder instance           |
+| [`version`](buildx_version.md)       | Show buildx version information            |
 
 
 ### Options
 
-| Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| [`--builder`](#builder) | `string` |  | Override the configured builder instance |
+| Name                    | Type     | Default | Description                              |
+|:------------------------|:---------|:--------|:-----------------------------------------|
+| [`--builder`](#builder) | `string` |         | Override the configured builder instance |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_bake.md
+++ b/docs/reference/buildx_bake.md
@@ -13,20 +13,20 @@ Build from a file
 
 ### Options
 
-| Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| [`--builder`](#builder) | `string` |  | Override the configured builder instance |
-| [`-f`](#file), [`--file`](#file) | `stringArray` |  | Build definition file |
-| `--load` |  |  | Shorthand for `--set=*.output=type=docker` |
-| `--metadata-file` | `string` |  | Write build result metadata to the file |
-| [`--no-cache`](#no-cache) |  |  | Do not use cache when building the image |
-| [`--print`](#print) |  |  | Print the options without building |
-| [`--progress`](#progress) | `string` | `auto` | Set type of progress output (`auto`, `plain`, `tty`). Use plain to show container output |
-| `--provenance` | `string` |  | Shorthand for `--set=*.attest=type=provenance` |
-| [`--pull`](#pull) |  |  | Always attempt to pull all referenced images |
-| `--push` |  |  | Shorthand for `--set=*.output=type=registry` |
-| `--sbom` | `string` |  | Shorthand for `--set=*.attest=type=sbom` |
-| [`--set`](#set) | `stringArray` |  | Override target value (e.g., `targetpattern.key=value`) |
+| Name                             | Type          | Default | Description                                                                              |
+|:---------------------------------|:--------------|:--------|:-----------------------------------------------------------------------------------------|
+| [`--builder`](#builder)          | `string`      |         | Override the configured builder instance                                                 |
+| [`-f`](#file), [`--file`](#file) | `stringArray` |         | Build definition file                                                                    |
+| `--load`                         |               |         | Shorthand for `--set=*.output=type=docker`                                               |
+| `--metadata-file`                | `string`      |         | Write build result metadata to the file                                                  |
+| [`--no-cache`](#no-cache)        |               |         | Do not use cache when building the image                                                 |
+| [`--print`](#print)              |               |         | Print the options without building                                                       |
+| [`--progress`](#progress)        | `string`      | `auto`  | Set type of progress output (`auto`, `plain`, `tty`). Use plain to show container output |
+| `--provenance`                   | `string`      |         | Shorthand for `--set=*.attest=type=provenance`                                           |
+| [`--pull`](#pull)                |               |         | Always attempt to pull all referenced images                                             |
+| `--push`                         |               |         | Shorthand for `--set=*.output=type=registry`                                             |
+| `--sbom`                         | `string`      |         | Shorthand for `--set=*.attest=type=sbom`                                                 |
+| [`--set`](#set)                  | `stringArray` |         | Override target value (e.g., `targetpattern.key=value`)                                  |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_build.md
+++ b/docs/reference/buildx_build.md
@@ -13,41 +13,41 @@ Start a build
 
 ### Options
 
-| Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| [`--add-host`](https://docs.docker.com/engine/reference/commandline/build/#add-host) | `stringSlice` |  | Add a custom host-to-IP mapping (format: `host:ip`) |
-| [`--allow`](#allow) | `stringSlice` |  | Allow extra privileged entitlement (e.g., `network.host`, `security.insecure`) |
-| `--attest` | `stringArray` |  | Attestation parameters (format: `type=sbom,generator=image`) |
-| [`--build-arg`](#build-arg) | `stringArray` |  | Set build-time variables |
-| [`--build-context`](#build-context) | `stringArray` |  | Additional build contexts (e.g., name=path) |
-| [`--builder`](#builder) | `string` |  | Override the configured builder instance |
-| [`--cache-from`](#cache-from) | `stringArray` |  | External cache sources (e.g., `user/app:cache`, `type=local,src=path/to/dir`) |
-| [`--cache-to`](#cache-to) | `stringArray` |  | Cache export destinations (e.g., `user/app:cache`, `type=local,dest=path/to/dir`) |
-| [`--cgroup-parent`](https://docs.docker.com/engine/reference/commandline/build/#cgroup-parent) | `string` |  | Optional parent cgroup for the container |
-| [`-f`](https://docs.docker.com/engine/reference/commandline/build/#file), [`--file`](https://docs.docker.com/engine/reference/commandline/build/#file) | `string` |  | Name of the Dockerfile (default: `PATH/Dockerfile`) |
-| `--iidfile` | `string` |  | Write the image ID to the file |
-| `--invoke` | `string` |  | Invoke a command after the build [experimental] |
-| `--label` | `stringArray` |  | Set metadata for an image |
-| [`--load`](#load) |  |  | Shorthand for `--output=type=docker` |
-| [`--metadata-file`](#metadata-file) | `string` |  | Write build result metadata to the file |
-| `--network` | `string` | `default` | Set the networking mode for the `RUN` instructions during build |
-| `--no-cache` |  |  | Do not use cache when building the image |
-| `--no-cache-filter` | `stringArray` |  | Do not cache specified stages |
-| [`-o`](#output), [`--output`](#output) | `stringArray` |  | Output destination (format: `type=local,dest=path`) |
-| [`--platform`](#platform) | `stringArray` |  | Set target platform for build |
-| `--print` | `string` |  | Print result of information request (e.g., outline, targets) [experimental] |
-| [`--progress`](#progress) | `string` | `auto` | Set type of progress output (`auto`, `plain`, `tty`). Use plain to show container output |
-| `--provenance` | `string` |  | Shortand for `--attest=type=provenance` |
-| `--pull` |  |  | Always attempt to pull all referenced images |
-| [`--push`](#push) |  |  | Shorthand for `--output=type=registry` |
-| `-q`, `--quiet` |  |  | Suppress the build output and print image ID on success |
-| `--sbom` | `string` |  | Shorthand for `--attest=type=sbom` |
-| [`--secret`](#secret) | `stringArray` |  | Secret to expose to the build (format: `id=mysecret[,src=/local/secret]`) |
-| [`--shm-size`](#shm-size) | `bytes` | `0` | Size of `/dev/shm` |
-| [`--ssh`](#ssh) | `stringArray` |  | SSH agent socket or keys to expose to the build (format: `default\|<id>[=<socket>\|<key>[,<key>]]`) |
-| [`-t`](https://docs.docker.com/engine/reference/commandline/build/#tag), [`--tag`](https://docs.docker.com/engine/reference/commandline/build/#tag) | `stringArray` |  | Name and optionally a tag (format: `name:tag`) |
-| [`--target`](https://docs.docker.com/engine/reference/commandline/build/#target) | `string` |  | Set the target build stage to build |
-| [`--ulimit`](#ulimit) | `ulimit` |  | Ulimit options |
+| Name                                                                                                                                                   | Type          | Default   | Description                                                                                         |
+|:-------------------------------------------------------------------------------------------------------------------------------------------------------|:--------------|:----------|:----------------------------------------------------------------------------------------------------|
+| [`--add-host`](https://docs.docker.com/engine/reference/commandline/build/#add-host)                                                                   | `stringSlice` |           | Add a custom host-to-IP mapping (format: `host:ip`)                                                 |
+| [`--allow`](#allow)                                                                                                                                    | `stringSlice` |           | Allow extra privileged entitlement (e.g., `network.host`, `security.insecure`)                      |
+| `--attest`                                                                                                                                             | `stringArray` |           | Attestation parameters (format: `type=sbom,generator=image`)                                        |
+| [`--build-arg`](#build-arg)                                                                                                                            | `stringArray` |           | Set build-time variables                                                                            |
+| [`--build-context`](#build-context)                                                                                                                    | `stringArray` |           | Additional build contexts (e.g., name=path)                                                         |
+| [`--builder`](#builder)                                                                                                                                | `string`      |           | Override the configured builder instance                                                            |
+| [`--cache-from`](#cache-from)                                                                                                                          | `stringArray` |           | External cache sources (e.g., `user/app:cache`, `type=local,src=path/to/dir`)                       |
+| [`--cache-to`](#cache-to)                                                                                                                              | `stringArray` |           | Cache export destinations (e.g., `user/app:cache`, `type=local,dest=path/to/dir`)                   |
+| [`--cgroup-parent`](https://docs.docker.com/engine/reference/commandline/build/#cgroup-parent)                                                         | `string`      |           | Optional parent cgroup for the container                                                            |
+| [`-f`](https://docs.docker.com/engine/reference/commandline/build/#file), [`--file`](https://docs.docker.com/engine/reference/commandline/build/#file) | `string`      |           | Name of the Dockerfile (default: `PATH/Dockerfile`)                                                 |
+| `--iidfile`                                                                                                                                            | `string`      |           | Write the image ID to the file                                                                      |
+| `--invoke`                                                                                                                                             | `string`      |           | Invoke a command after the build [experimental]                                                     |
+| `--label`                                                                                                                                              | `stringArray` |           | Set metadata for an image                                                                           |
+| [`--load`](#load)                                                                                                                                      |               |           | Shorthand for `--output=type=docker`                                                                |
+| [`--metadata-file`](#metadata-file)                                                                                                                    | `string`      |           | Write build result metadata to the file                                                             |
+| `--network`                                                                                                                                            | `string`      | `default` | Set the networking mode for the `RUN` instructions during build                                     |
+| `--no-cache`                                                                                                                                           |               |           | Do not use cache when building the image                                                            |
+| `--no-cache-filter`                                                                                                                                    | `stringArray` |           | Do not cache specified stages                                                                       |
+| [`-o`](#output), [`--output`](#output)                                                                                                                 | `stringArray` |           | Output destination (format: `type=local,dest=path`)                                                 |
+| [`--platform`](#platform)                                                                                                                              | `stringArray` |           | Set target platform for build                                                                       |
+| `--print`                                                                                                                                              | `string`      |           | Print result of information request (e.g., outline, targets) [experimental]                         |
+| [`--progress`](#progress)                                                                                                                              | `string`      | `auto`    | Set type of progress output (`auto`, `plain`, `tty`). Use plain to show container output            |
+| `--provenance`                                                                                                                                         | `string`      |           | Shortand for `--attest=type=provenance`                                                             |
+| `--pull`                                                                                                                                               |               |           | Always attempt to pull all referenced images                                                        |
+| [`--push`](#push)                                                                                                                                      |               |           | Shorthand for `--output=type=registry`                                                              |
+| `-q`, `--quiet`                                                                                                                                        |               |           | Suppress the build output and print image ID on success                                             |
+| `--sbom`                                                                                                                                               | `string`      |           | Shorthand for `--attest=type=sbom`                                                                  |
+| [`--secret`](#secret)                                                                                                                                  | `stringArray` |           | Secret to expose to the build (format: `id=mysecret[,src=/local/secret]`)                           |
+| [`--shm-size`](#shm-size)                                                                                                                              | `bytes`       | `0`       | Size of `/dev/shm`                                                                                  |
+| [`--ssh`](#ssh)                                                                                                                                        | `stringArray` |           | SSH agent socket or keys to expose to the build (format: `default\|<id>[=<socket>\|<key>[,<key>]]`) |
+| [`-t`](https://docs.docker.com/engine/reference/commandline/build/#tag), [`--tag`](https://docs.docker.com/engine/reference/commandline/build/#tag)    | `stringArray` |           | Name and optionally a tag (format: `name:tag`)                                                      |
+| [`--target`](https://docs.docker.com/engine/reference/commandline/build/#target)                                                                       | `string`      |           | Set the target build stage to build                                                                 |
+| [`--ulimit`](#ulimit)                                                                                                                                  | `ulimit`      |           | Ulimit options                                                                                      |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_build.md
+++ b/docs/reference/buildx_build.md
@@ -15,7 +15,7 @@ Start a build
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| [`--add-host`](https://docs.docker.com/engine/reference/commandline/build/#add-entries-to-container-hosts-file---add-host) | `stringSlice` |  | Add a custom host-to-IP mapping (format: `host:ip`) |
+| [`--add-host`](https://docs.docker.com/engine/reference/commandline/build/#add-host) | `stringSlice` |  | Add a custom host-to-IP mapping (format: `host:ip`) |
 | [`--allow`](#allow) | `stringSlice` |  | Allow extra privileged entitlement (e.g., `network.host`, `security.insecure`) |
 | `--attest` | `stringArray` |  | Attestation parameters (format: `type=sbom,generator=image`) |
 | [`--build-arg`](#build-arg) | `stringArray` |  | Set build-time variables |
@@ -23,8 +23,8 @@ Start a build
 | [`--builder`](#builder) | `string` |  | Override the configured builder instance |
 | [`--cache-from`](#cache-from) | `stringArray` |  | External cache sources (e.g., `user/app:cache`, `type=local,src=path/to/dir`) |
 | [`--cache-to`](#cache-to) | `stringArray` |  | Cache export destinations (e.g., `user/app:cache`, `type=local,dest=path/to/dir`) |
-| [`--cgroup-parent`](https://docs.docker.com/engine/reference/commandline/build/#use-a-custom-parent-cgroup---cgroup-parent) | `string` |  | Optional parent cgroup for the container |
-| [`-f`](https://docs.docker.com/engine/reference/commandline/build/#specify-a-dockerfile--f), [`--file`](https://docs.docker.com/engine/reference/commandline/build/#specify-a-dockerfile--f) | `string` |  | Name of the Dockerfile (default: `PATH/Dockerfile`) |
+| [`--cgroup-parent`](https://docs.docker.com/engine/reference/commandline/build/#cgroup-parent) | `string` |  | Optional parent cgroup for the container |
+| [`-f`](https://docs.docker.com/engine/reference/commandline/build/#file), [`--file`](https://docs.docker.com/engine/reference/commandline/build/#file) | `string` |  | Name of the Dockerfile (default: `PATH/Dockerfile`) |
 | `--iidfile` | `string` |  | Write the image ID to the file |
 | `--invoke` | `string` |  | Invoke a command after the build [experimental] |
 | `--label` | `stringArray` |  | Set metadata for an image |
@@ -45,8 +45,8 @@ Start a build
 | [`--secret`](#secret) | `stringArray` |  | Secret to expose to the build (format: `id=mysecret[,src=/local/secret]`) |
 | [`--shm-size`](#shm-size) | `bytes` | `0` | Size of `/dev/shm` |
 | [`--ssh`](#ssh) | `stringArray` |  | SSH agent socket or keys to expose to the build (format: `default\|<id>[=<socket>\|<key>[,<key>]]`) |
-| [`-t`](https://docs.docker.com/engine/reference/commandline/build/#tag-an-image--t), [`--tag`](https://docs.docker.com/engine/reference/commandline/build/#tag-an-image--t) | `stringArray` |  | Name and optionally a tag (format: `name:tag`) |
-| [`--target`](https://docs.docker.com/engine/reference/commandline/build/#specifying-target-build-stage---target) | `string` |  | Set the target build stage to build |
+| [`-t`](https://docs.docker.com/engine/reference/commandline/build/#tag), [`--tag`](https://docs.docker.com/engine/reference/commandline/build/#tag) | `stringArray` |  | Name and optionally a tag (format: `name:tag`) |
+| [`--target`](https://docs.docker.com/engine/reference/commandline/build/#target) | `string` |  | Set the target build stage to build |
 | [`--ulimit`](#ulimit) | `ulimit` |  | Ulimit options |
 
 
@@ -90,7 +90,7 @@ $ docker buildx build --allow security.insecure .
 
 ### <a name="build-arg"></a> Set build-time variables (--build-arg)
 
-Same as [`docker build` command](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg).
+Same as [`docker build` command](https://docs.docker.com/engine/reference/commandline/build/#build-arg).
 
 There are also useful built-in build args like:
 

--- a/docs/reference/buildx_create.md
+++ b/docs/reference/buildx_create.md
@@ -9,19 +9,19 @@ Create a new builder instance
 
 ### Options
 
-| Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| [`--append`](#append) |  |  | Append a node to builder instead of changing it |
-| `--bootstrap` |  |  | Boot builder after creation |
-| [`--buildkitd-flags`](#buildkitd-flags) | `string` |  | Flags for buildkitd daemon |
-| [`--config`](#config) | `string` |  | BuildKit config file |
-| [`--driver`](#driver) | `string` |  | Driver to use (available: `docker-container`, `kubernetes`, `remote`) |
-| [`--driver-opt`](#driver-opt) | `stringArray` |  | Options for the driver |
-| [`--leave`](#leave) |  |  | Remove a node from builder instead of changing it |
-| [`--name`](#name) | `string` |  | Builder instance name |
-| [`--node`](#node) | `string` |  | Create/modify node with given name |
-| [`--platform`](#platform) | `stringArray` |  | Fixed platforms for current node |
-| [`--use`](#use) |  |  | Set the current builder instance |
+| Name                                    | Type          | Default | Description                                                           |
+|:----------------------------------------|:--------------|:--------|:----------------------------------------------------------------------|
+| [`--append`](#append)                   |               |         | Append a node to builder instead of changing it                       |
+| `--bootstrap`                           |               |         | Boot builder after creation                                           |
+| [`--buildkitd-flags`](#buildkitd-flags) | `string`      |         | Flags for buildkitd daemon                                            |
+| [`--config`](#config)                   | `string`      |         | BuildKit config file                                                  |
+| [`--driver`](#driver)                   | `string`      |         | Driver to use (available: `docker-container`, `kubernetes`, `remote`) |
+| [`--driver-opt`](#driver-opt)           | `stringArray` |         | Options for the driver                                                |
+| [`--leave`](#leave)                     |               |         | Remove a node from builder instead of changing it                     |
+| [`--name`](#name)                       | `string`      |         | Builder instance name                                                 |
+| [`--node`](#node)                       | `string`      |         | Create/modify node with given name                                    |
+| [`--platform`](#platform)               | `stringArray` |         | Fixed platforms for current node                                      |
+| [`--use`](#use)                         |               |         | Set the current builder instance                                      |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_du.md
+++ b/docs/reference/buildx_du.md
@@ -9,11 +9,11 @@ Disk usage
 
 ### Options
 
-| Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| [`--builder`](#builder) | `string` |  | Override the configured builder instance |
-| `--filter` | `filter` |  | Provide filter values |
-| `--verbose` |  |  | Provide a more verbose output |
+| Name                    | Type     | Default | Description                              |
+|:------------------------|:---------|:--------|:-----------------------------------------|
+| [`--builder`](#builder) | `string` |         | Override the configured builder instance |
+| `--filter`              | `filter` |         | Provide filter values                    |
+| `--verbose`             |          |         | Provide a more verbose output            |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_imagetools.md
+++ b/docs/reference/buildx_imagetools.md
@@ -9,17 +9,17 @@ Commands to work on images in registry
 
 ### Subcommands
 
-| Name | Description |
-| --- | --- |
-| [`create`](buildx_imagetools_create.md) | Create a new image based on source images |
-| [`inspect`](buildx_imagetools_inspect.md) | Show details of an image in the registry |
+| Name                                      | Description                               |
+|:------------------------------------------|:------------------------------------------|
+| [`create`](buildx_imagetools_create.md)   | Create a new image based on source images |
+| [`inspect`](buildx_imagetools_inspect.md) | Show details of an image in the registry  |
 
 
 ### Options
 
-| Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| [`--builder`](#builder) | `string` |  | Override the configured builder instance |
+| Name                    | Type     | Default | Description                              |
+|:------------------------|:---------|:--------|:-----------------------------------------|
+| [`--builder`](#builder) | `string` |         | Override the configured builder instance |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_imagetools_create.md
+++ b/docs/reference/buildx_imagetools_create.md
@@ -9,14 +9,14 @@ Create a new image based on source images
 
 ### Options
 
-| Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| [`--append`](#append) |  |  | Append to existing manifest |
-| [`--builder`](#builder) | `string` |  | Override the configured builder instance |
-| [`--dry-run`](#dry-run) |  |  | Show final image instead of pushing |
-| [`-f`](#file), [`--file`](#file) | `stringArray` |  | Read source descriptor from file |
-| `--progress` | `string` | `auto` | Set type of progress output (`auto`, `plain`, `tty`). Use plain to show container output |
-| [`-t`](#tag), [`--tag`](#tag) | `stringArray` |  | Set reference for new image |
+| Name                             | Type          | Default | Description                                                                              |
+|:---------------------------------|:--------------|:--------|:-----------------------------------------------------------------------------------------|
+| [`--append`](#append)            |               |         | Append to existing manifest                                                              |
+| [`--builder`](#builder)          | `string`      |         | Override the configured builder instance                                                 |
+| [`--dry-run`](#dry-run)          |               |         | Show final image instead of pushing                                                      |
+| [`-f`](#file), [`--file`](#file) | `stringArray` |         | Read source descriptor from file                                                         |
+| `--progress`                     | `string`      | `auto`  | Set type of progress output (`auto`, `plain`, `tty`). Use plain to show container output |
+| [`-t`](#tag), [`--tag`](#tag)    | `stringArray` |         | Set reference for new image                                                              |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_imagetools_inspect.md
+++ b/docs/reference/buildx_imagetools_inspect.md
@@ -9,11 +9,11 @@ Show details of an image in the registry
 
 ### Options
 
-| Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| [`--builder`](#builder) | `string` |  | Override the configured builder instance |
-| [`--format`](#format) | `string` | `{{.Manifest}}` | Format the output using the given Go template |
-| [`--raw`](#raw) |  |  | Show original, unformatted JSON manifest |
+| Name                    | Type     | Default         | Description                                   |
+|:------------------------|:---------|:----------------|:----------------------------------------------|
+| [`--builder`](#builder) | `string` |                 | Override the configured builder instance      |
+| [`--format`](#format)   | `string` | `{{.Manifest}}` | Format the output using the given Go template |
+| [`--raw`](#raw)         |          |                 | Show original, unformatted JSON manifest      |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_inspect.md
+++ b/docs/reference/buildx_inspect.md
@@ -9,10 +9,10 @@ Inspect current builder instance
 
 ### Options
 
-| Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| [`--bootstrap`](#bootstrap) |  |  | Ensure builder has booted before inspecting |
-| [`--builder`](#builder) | `string` |  | Override the configured builder instance |
+| Name                        | Type     | Default | Description                                 |
+|:----------------------------|:---------|:--------|:--------------------------------------------|
+| [`--bootstrap`](#bootstrap) |          |         | Ensure builder has booted before inspecting |
+| [`--builder`](#builder)     | `string` |         | Override the configured builder instance    |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_prune.md
+++ b/docs/reference/buildx_prune.md
@@ -9,14 +9,14 @@ Remove build cache
 
 ### Options
 
-| Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| `-a`, `--all` |  |  | Include internal/frontend images |
-| [`--builder`](#builder) | `string` |  | Override the configured builder instance |
-| `--filter` | `filter` |  | Provide filter values (e.g., `until=24h`) |
-| `-f`, `--force` |  |  | Do not prompt for confirmation |
-| `--keep-storage` | `bytes` | `0` | Amount of disk space to keep for cache |
-| `--verbose` |  |  | Provide a more verbose output |
+| Name                    | Type     | Default | Description                               |
+|:------------------------|:---------|:--------|:------------------------------------------|
+| `-a`, `--all`           |          |         | Include internal/frontend images          |
+| [`--builder`](#builder) | `string` |         | Override the configured builder instance  |
+| `--filter`              | `filter` |         | Provide filter values (e.g., `until=24h`) |
+| `-f`, `--force`         |          |         | Do not prompt for confirmation            |
+| `--keep-storage`        | `bytes`  | `0`     | Amount of disk space to keep for cache    |
+| `--verbose`             |          |         | Provide a more verbose output             |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_rm.md
+++ b/docs/reference/buildx_rm.md
@@ -9,13 +9,13 @@ Remove a builder instance
 
 ### Options
 
-| Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| [`--all-inactive`](#all-inactive) |  |  | Remove all inactive builders |
-| [`--builder`](#builder) | `string` |  | Override the configured builder instance |
-| [`-f`](#force), [`--force`](#force) |  |  | Do not prompt for confirmation |
-| [`--keep-daemon`](#keep-daemon) |  |  | Keep the buildkitd daemon running |
-| [`--keep-state`](#keep-state) |  |  | Keep BuildKit state |
+| Name                                | Type     | Default | Description                              |
+|:------------------------------------|:---------|:--------|:-----------------------------------------|
+| [`--all-inactive`](#all-inactive)   |          |         | Remove all inactive builders             |
+| [`--builder`](#builder)             | `string` |         | Override the configured builder instance |
+| [`-f`](#force), [`--force`](#force) |          |         | Do not prompt for confirmation           |
+| [`--keep-daemon`](#keep-daemon)     |          |         | Keep the buildkitd daemon running        |
+| [`--keep-state`](#keep-state)       |          |         | Keep BuildKit state                      |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_stop.md
+++ b/docs/reference/buildx_stop.md
@@ -9,9 +9,9 @@ Stop builder instance
 
 ### Options
 
-| Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| [`--builder`](#builder) | `string` |  | Override the configured builder instance |
+| Name                    | Type     | Default | Description                              |
+|:------------------------|:---------|:--------|:-----------------------------------------|
+| [`--builder`](#builder) | `string` |         | Override the configured builder instance |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_use.md
+++ b/docs/reference/buildx_use.md
@@ -9,11 +9,11 @@ Set the current builder instance
 
 ### Options
 
-| Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| [`--builder`](#builder) | `string` |  | Override the configured builder instance |
-| `--default` |  |  | Set builder as default for current context |
-| `--global` |  |  | Builder persists context changes |
+| Name                    | Type     | Default | Description                                |
+|:------------------------|:---------|:--------|:-------------------------------------------|
+| [`--builder`](#builder) | `string` |         | Override the configured builder instance   |
+| `--default`             |          |         | Set builder as default for current context |
+| `--global`              |          |         | Builder persists context changes           |
 
 
 <!---MARKER_GEN_END-->

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/containerd/console v1.0.3
 	github.com/containerd/containerd v1.6.14
 	github.com/docker/cli v23.0.0-rc.1+incompatible
-	github.com/docker/cli-docs-tool v0.5.0
+	github.com/docker/cli-docs-tool v0.5.1
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/docker/docker v23.0.0-rc.1+incompatible
 	github.com/docker/go-units v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/distribution/distribution/v3 v3.0.0-20220725133111-4bf3547399eb h1:oC
 github.com/distribution/distribution/v3 v3.0.0-20220725133111-4bf3547399eb/go.mod h1:28YO/VJk9/64+sTGNuYaBjWxrXTPrj0C0XmgTIOjxX4=
 github.com/docker/cli v23.0.0-rc.1+incompatible h1:Vl3pcUK4/LFAD56Ys3BrqgAtuwpWd/IO3amuSL0ZbP0=
 github.com/docker/cli v23.0.0-rc.1+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
-github.com/docker/cli-docs-tool v0.5.0 h1:EjGwI6EyB7YemHCC7R8mwXszJTbuq0T0pFuDC5bMhcE=
-github.com/docker/cli-docs-tool v0.5.0/go.mod h1:zMjqTFCU361PRh8apiXzeAZ1Q/xupbIwTusYpzCXS/o=
+github.com/docker/cli-docs-tool v0.5.1 h1:jIk/cCZurZERhALPVKhqlNxTQGxn2kcI+56gE57PQXg=
+github.com/docker/cli-docs-tool v0.5.1/go.mod h1:zMjqTFCU361PRh8apiXzeAZ1Q/xupbIwTusYpzCXS/o=
 github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
 github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v23.0.0-rc.1+incompatible h1:Dmn88McWuHc7BSNN1s6RtfhMmt6ZPQAYUEf7FhqpiQI=

--- a/vendor/github.com/docker/cli-docs-tool/README.md
+++ b/vendor/github.com/docker/cli-docs-tool/README.md
@@ -1,5 +1,5 @@
 [![PkgGoDev](https://img.shields.io/badge/go.dev-docs-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/github.com/docker/cli-docs-tool)
-[![Test Status](https://img.shields.io/github/workflow/status/docker/cli-docs-tool/test?label=test&logo=github&style=flat-square)](https://github.com/docker/cli-docs-tool/actions?query=workflow%3Atest)
+[![Test Status](https://img.shields.io/github/actions/workflow/status/docker/cli-docs-tool/test.yml?branch=main&label=test&logo=github&style=flat-square)](https://github.com/docker/cli-docs-tool/actions?query=workflow%3Atest)
 [![Go Report Card](https://goreportcard.com/badge/github.com/docker/cli-docs-tool)](https://goreportcard.com/report/github.com/docker/cli-docs-tool)
 
 ## About

--- a/vendor/github.com/docker/cli-docs-tool/clidocstool_md.go
+++ b/vendor/github.com/docker/cli-docs-tool/clidocstool_md.go
@@ -20,12 +20,19 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
+	"text/tabwriter"
 	"text/template"
 
 	"github.com/docker/cli-docs-tool/annotation"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+)
+
+var (
+	nlRegexp  = regexp.MustCompile(`\r?\n`)
+	adjustSep = regexp.MustCompile(`\|:---(\s+)`)
 )
 
 // GenMarkdownTree will generate a markdown page for this command and all
@@ -144,6 +151,42 @@ func mdMakeLink(txt, link string, f *pflag.Flag, isAnchor bool) string {
 	return "[" + txt + "](" + link + ")"
 }
 
+type mdTable struct {
+	out       *strings.Builder
+	tabWriter *tabwriter.Writer
+}
+
+func newMdTable(headers ...string) *mdTable {
+	w := &strings.Builder{}
+	t := &mdTable{
+		out: w,
+		// Using tabwriter.Debug, which uses "|" as separator instead of tabs,
+		// which is what we want. It's a bit of a hack, but does the job :)
+		tabWriter: tabwriter.NewWriter(w, 5, 5, 1, ' ', tabwriter.Debug),
+	}
+	t.addHeader(headers...)
+	return t
+}
+
+func (t *mdTable) addHeader(cols ...string) {
+	t.AddRow(cols...)
+	_, _ = t.tabWriter.Write([]byte("|" + strings.Repeat(":---\t", len(cols)) + "\n"))
+}
+
+func (t *mdTable) AddRow(cols ...string) {
+	for i := range cols {
+		cols[i] = mdEscapePipe(cols[i])
+	}
+	_, _ = t.tabWriter.Write([]byte("| " + strings.Join(cols, "\t ") + "\t\n"))
+}
+
+func (t *mdTable) String() string {
+	_ = t.tabWriter.Flush()
+	return adjustSep.ReplaceAllStringFunc(t.out.String()+"\n", func(in string) string {
+		return strings.ReplaceAll(in, " ", "-")
+	})
+}
+
 func mdCmdOutput(cmd *cobra.Command, old string) (string, error) {
 	b := &strings.Builder{}
 
@@ -152,46 +195,41 @@ func mdCmdOutput(cmd *cobra.Command, old string) (string, error) {
 		desc = cmd.Long
 	}
 	if desc != "" {
-		fmt.Fprintf(b, "%s\n\n", desc)
+		b.WriteString(desc + "\n\n")
 	}
 
 	if aliases := getAliases(cmd); len(aliases) != 0 {
-		fmt.Fprint(b, "### Aliases\n\n")
-		fmt.Fprint(b, "`"+strings.Join(aliases, "`, `")+"`")
-		fmt.Fprint(b, "\n\n")
+		b.WriteString("### Aliases\n\n")
+		b.WriteString("`" + strings.Join(aliases, "`, `") + "`")
+		b.WriteString("\n\n")
 	}
 
 	if len(cmd.Commands()) != 0 {
-		fmt.Fprint(b, "### Subcommands\n\n")
-		fmt.Fprint(b, "| Name | Description |\n")
-		fmt.Fprint(b, "| --- | --- |\n")
+		b.WriteString("### Subcommands\n\n")
+		table := newMdTable("Name", "Description")
 		for _, c := range cmd.Commands() {
-			fmt.Fprintf(b, "| [`%s`](%s) | %s |\n", c.Name(), mdFilename(c), c.Short)
+			table.AddRow(fmt.Sprintf("[`%s`](%s)", c.Name(), mdFilename(c)), c.Short)
 		}
-		fmt.Fprint(b, "\n\n")
+		b.WriteString(table.String() + "\n")
 	}
 
 	// add inherited flags before checking for flags availability
 	cmd.Flags().AddFlagSet(cmd.InheritedFlags())
 
 	if cmd.Flags().HasAvailableFlags() {
-		fmt.Fprint(b, "### Options\n\n")
-		fmt.Fprint(b, "| Name | Type | Default | Description |\n")
-		fmt.Fprint(b, "| --- | --- | --- | --- |\n")
-
+		b.WriteString("### Options\n\n")
+		table := newMdTable("Name", "Type", "Default", "Description")
 		cmd.Flags().VisitAll(func(f *pflag.Flag) {
 			if f.Hidden {
 				return
 			}
 			isLink := strings.Contains(old, "<a name=\""+f.Name+"\"></a>")
-			fmt.Fprint(b, "| ")
+			var name string
 			if f.Shorthand != "" {
-				name := "`-" + f.Shorthand + "`"
-				name = mdMakeLink(name, f.Name, f, isLink)
-				fmt.Fprintf(b, "%s, ", name)
+				name = mdMakeLink("`-"+f.Shorthand+"`", f.Name, f, isLink)
+				name += ", "
 			}
-			name := "`--" + f.Name + "`"
-			name = mdMakeLink(name, f.Name, f, isLink)
+			name += mdMakeLink("`--"+f.Name+"`", f.Name, f, isLink)
 
 			var ftype string
 			if f.Value.Type() != "bool" {
@@ -216,9 +254,9 @@ func mdCmdOutput(cmd *cobra.Command, old string) (string, error) {
 			} else if cd, ok := cmd.Annotations[annotation.CodeDelimiter]; ok {
 				usage = strings.ReplaceAll(usage, cd, "`")
 			}
-			fmt.Fprintf(b, "%s | %s | %s | %s |\n", mdEscapePipe(name), mdEscapePipe(ftype), mdEscapePipe(defval), mdEscapePipe(usage))
+			table.AddRow(name, ftype, defval, mdReplaceNewline(usage))
 		})
-		fmt.Fprintln(b, "")
+		b.WriteString(table.String())
 	}
 
 	return b.String(), nil
@@ -226,4 +264,8 @@ func mdCmdOutput(cmd *cobra.Command, old string) (string, error) {
 
 func mdEscapePipe(s string) string {
 	return strings.ReplaceAll(s, `|`, `\|`)
+}
+
+func mdReplaceNewline(s string) string {
+	return nlRegexp.ReplaceAllString(s, "<br>")
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -219,7 +219,7 @@ github.com/docker/cli/cli/streams
 github.com/docker/cli/cli/trust
 github.com/docker/cli/cli/version
 github.com/docker/cli/opts
-# github.com/docker/cli-docs-tool v0.5.0
+# github.com/docker/cli-docs-tool v0.5.1
 ## explicit; go 1.18
 github.com/docker/cli-docs-tool
 github.com/docker/cli-docs-tool/annotation


### PR DESCRIPTION
backports:

- https://github.com/docker/buildx/pull/1493
- https://github.com/docker/buildx/pull/1494

relates to:

- https://github.com/docker/docs/pull/16461
- https://github.com/docker/docs/pull/16460