### PR TITLE
fix the directory of the buildx binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ To remove this alias, run [`docker buildx uninstall`](docs/reference/buildx_unin
 # Buildx 0.6+
 $ docker buildx bake "https://github.com/docker/buildx.git"
 $ mkdir -p ~/.docker/cli-plugins
-$ mv ./bin/buildx ~/.docker/cli-plugins/docker-buildx
+$ mv ./bin/build/buildx ~/.docker/cli-plugins/docker-buildx
 
 # Docker 19.03+
 $ DOCKER_BUILDKIT=1 docker build --platform=local -o . "https://github.com/docker/buildx.git"


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

As I saw in the [docker-bake.hcl](https://github.com/docker/buildx/blob/master/docker-bake.hcl#L104), the binary is outputted into the folder `./bin/build/<binary>,` but in the README, it says `./bin/<binary>,` so, this PR aims to fix this.