### PR TITLE
Lazily load attestation data in `imagetools inspect`

### DIFF
--- a/util/imagetools/printers.go
+++ b/util/imagetools/printers.go
@@ -213,7 +213,10 @@ type tplInput struct {
 }
 
 func (inp tplInput) SBOM() (sbomStub, error) {
-	sbom := inp.result.SBOM()
+	sbom, err := inp.result.SBOM()
+	if err != nil {
+		return sbomStub{}, nil
+	}
 	for _, v := range sbom {
 		return v, nil
 	}
@@ -221,7 +224,10 @@ func (inp tplInput) SBOM() (sbomStub, error) {
 }
 
 func (inp tplInput) Provenance() (provenanceStub, error) {
-	provenance := inp.result.Provenance()
+	provenance, err := inp.result.Provenance()
+	if err != nil {
+		return provenanceStub{}, nil
+	}
 	for _, v := range provenance {
 		return v, nil
 	}
@@ -237,9 +243,9 @@ type tplInputs struct {
 }
 
 func (inp tplInputs) SBOM() (map[string]sbomStub, error) {
-	return inp.result.SBOM(), nil
+	return inp.result.SBOM()
 }
 
 func (inp tplInputs) Provenance() (map[string]provenanceStub, error) {
-	return inp.result.Provenance(), nil
+	return inp.result.Provenance()
 }


### PR DESCRIPTION
:arrow_up: Follow-up to #1498

This PR improves performance for the standard case of doing a simple `imagetools inspect` command. In v0.10.0 we see a performance regression when inspecting images that have [attached attestations](https://github.com/moby/buildkit/blob/master/docs/attestations/attestation-storage.md) using simple format strings like `{{ json . }}`. We can resolve this performance issue by lazily loading attestation data, only when requested to by the format template.

This is split into two patches:
- Split out the template input struct definitions. This allows us to define methods on the struct, so that we can make the `.SBOM` and `.Provenance` attributes into methods instead of properties on the struct. These can be accessed *identically* to the previous attributes for all valid format inputs (though we get a slightly different error message in some cases, if we attempt to pass arguments to these methods, but these are invalid inputs anyways).
- Defer fetching SBOM and Provenance data during load - we can defer the results of these computations until access from the template, and then cache them to avoid multiple requests for the same data.

Because this data is now loaded lazily, it no longer makes sense to include it in the output of commands such as `{{ json . }}`, so no field for `SBOM` or `Provenance` is included for those.

I think we can cherry-pick this to the v0.10 branch, and release it in v0.10.1? Users who were relying on the SBOM and Provenance data appearing in the output of `{{ json . }}` and similar would be affected, but this is a relatively minor change. 

Note: we could simplify some of this code with a `Deferred` type in the future, which would encapsulate some of the logic for computing a function and caching the result, however, we'd want to use generics for that, which would require a bump to buildx 1.18 - which we shouldn't do a minor release.