### PR TITLE
docs: small tweak to opentelemetry

### DIFF
--- a/docs/guides/opentelemetry.md
+++ b/docs/guides/opentelemetry.md
@@ -6,7 +6,7 @@ To capture the trace to [Jaeger](https://github.com/jaegertracing/jaeger), set
 First create a Jaeger container:
 
 ```console
-$ docker run -d --name jaeger -p "6831:6831/udp" -p "16686:16686" jaegertracing/all-in-one
+$ docker run -d --name jaeger -p "6831:6831/udp" -p "16686:16686" --restart unless-stopped jaegertracing/all-in-one
 ```
 
 Then [create a `docker-container` builder](https://docs.docker.com/engine/reference/commandline/buildx_create/)


### PR DESCRIPTION
The buildx builder persists across Desktop restarts. So when we start up Jaeger, we should recommend that people configure it to persist across restarts as well.

Signed-off-by: Nick Santos <nick.santos@docker.com>