### PR TITLE
ci: fix typo in docs-release workflow

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -3,7 +3,7 @@ name: docs-release
 on:
   release:
     types:
-      - releases
+      - released
 
 jobs:
   open-pr:


### PR DESCRIPTION
When buildx 0.10.0 was released it didn't trigger the docs-release workflow: https://github.com/docker/buildx/actions/workflows/docs-release.yml

Looks like a typo in release filter introduced in https://github.com/docker/buildx/pull/1473

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>