### PR TITLE
docs: add note about minimum docker version

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,13 @@ Key features:
 
 # Installing
 
-Using `buildx` as a docker CLI plugin requires using Docker 19.03 or newer.
-A limited set of functionality works with older versions of Docker when
-invoking the binary directly.
+Using `buildx` with Docker requires Docker engine 19.03 or newer.
+
+> **Warning**
+>
+> Using an incompatible version of Docker may result in unexpected behavior,
+> and will likely cause issues, especially when using Buildx builders with more
+> recent versions of BuildKit.
 
 ## Windows and macOS
 


### PR DESCRIPTION
https://github.com/moby/buildkit/issues/3490 seems to have been caused by an old docker version - we should add a note to the Buildx README about minimum version requirements (we now need OCI support in the docker daemon now that moby/buildkit uses an OCI image), as well as adding a warning for what users can expect if they go ahead.