### PR TITLE
build: mark capabilities request as internal

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -228,7 +228,9 @@ func resolveDrivers(ctx context.Context, nodes []builder.Node, opt map[string]Op
 
 		func(i int, c *client.Client) {
 			eg.Go(func() error {
-				clients[i].Build(ctx, client.SolveOpt{}, "buildx", func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
+				clients[i].Build(ctx, client.SolveOpt{
+					Internal: true,
+				}, "buildx", func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
 					bopts[i] = c.BuildOpts()
 					return nil, nil
 				}, nil)


### PR DESCRIPTION
So it doesn't show up in the History API.

Ideally, we could somehow detect this automatically in the BuildKit side in the future, but don't have good ideas atm.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>