### PR TITLE
[v0.10] Bump Buildx and BuildKit versions in GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ on:
       - 'docs/**'
 
 env:
-  BUILDX_VERSION: "v0.10.0-rc3"
+  BUILDX_VERSION: "v0.10.0"
   BUILDKIT_IMAGE: "moby/buildkit:v0.11.0"
   REPO_SLUG: "docker/buildx-bin"
   DESTDIR: "./bin"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ on:
 
 env:
   BUILDX_VERSION: "v0.10.0"
-  BUILDKIT_IMAGE: "moby/buildkit:v0.11.0"
+  BUILDKIT_IMAGE: "moby/buildkit:v0.11.1"
   REPO_SLUG: "docker/buildx-bin"
   DESTDIR: "./bin"
 


### PR DESCRIPTION
:cherries: Cherry-picks of https://github.com/docker/buildx/pull/1525 and https://github.com/docker/buildx/pull/1543.