### PR TITLE
rm: do not check for context builders when removing inactive

### DIFF
--- a/commands/rm.go
+++ b/commands/rm.go
@@ -141,9 +141,6 @@ func rmAllInactive(ctx context.Context, txn *store.Txn, dockerCli command.Cli, i
 				if err != nil {
 					return errors.Wrapf(err, "cannot load %s", b.Name)
 				}
-				if cb := b.ContextName(); cb != "" {
-					return errors.Errorf("context builder cannot be removed, run `docker context rm %s` to remove this context", cb)
-				}
 				if b.Dynamic {
 					return nil
 				}


### PR DESCRIPTION
fixes #1541

This change has been introduced in e7b5ee7518703fb284fd9ece81abf71e4838f4d9 but we should not check context builders when removing inactive ones.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>