### PR TITLE
go.mod: bump to Go 1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/docker/buildx
 
-go 1.17
+go 1.19
 
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.15.5

--- a/hack/dockerfiles/vendor.Dockerfile
+++ b/hack/dockerfiles/vendor.Dockerfile
@@ -13,7 +13,7 @@ RUN --mount=target=/context \
   --mount=target=/go/pkg/mod,type=cache <<EOT
 set -e
 rsync -a /context/. .
-go mod tidy -compat=1.17
+go mod tidy
 go mod vendor
 mkdir /out
 cp -r go.mod go.sum vendor /out


### PR DESCRIPTION
Go 1.20 will be there soon, I think it's time to move our go.mod to latest stable. We can then remove the compat in our vendor.Dockerfile

Downstream projects like compose or github.com/linuxkit/linuxkit should not be affected.

cc @rumpl 

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>