### PR TITLE
build: fix preferred platform not taken into account

### DIFF
--- a/builder/node.go
+++ b/builder/node.go
@@ -62,6 +62,7 @@ func (b *Builder) LoadNodes(ctx context.Context, withData bool) (_ []Node, err e
 				node := Node{
 					Node:        n,
 					ProxyConfig: storeutil.GetProxyConfig(b.opts.dockerCli),
+					Platforms:   n.Platforms,
 				}
 				defer func() {
 					b.nodes[i] = node


### PR DESCRIPTION
fixes #1539
fixes #1560

When checking available platforms for current nodes, those are always empty in https://github.com/docker/buildx/blob/a718d07f6414bfe960899050c0107e6baa86dcba/build/build.go#L259

That's because when loading nodes we don't set the preferred platforms from the store. Therefore builds will always run on the very first node available.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>