### PR TITLE
ci: fix docs-upstream workflow

### DIFF
--- a/.github/workflows/docs-upstream.yml
+++ b/.github/workflows/docs-upstream.yml
@@ -19,8 +19,6 @@ on:
     paths:
       - '.github/workflows/docs-upstream.yml'
       - 'docs/**'
-    paths-ignore:
-      - '.github/releases.json'
 
 jobs:
   docs-yaml:


### PR DESCRIPTION
Didn't catch this one as GitHub doesn't give any check failure when a workflow is invalid :persevere:

https://github.com/docker/buildx/actions/runs/4047616608

![image](https://user-images.githubusercontent.com/1951866/215582579-71db09db-e47a-427c-a8a3-827d7a4cbe30.png)

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>