### PR TITLE
ci: add workflow_dispatch in releases-json workflow

### DIFF
--- a/.github/workflows/releases-json.yml
+++ b/.github/workflows/releases-json.yml
@@ -5,6 +5,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  workflow_dispatch:
   release:
     types:
       - released
@@ -23,7 +24,7 @@ jobs:
 
   open-pr:
     runs-on: ubuntu-22.04
-    if: github.event_name == 'release'
+    if: github.event_name != 'pull_request'
     needs:
       - generate
     steps:


### PR DESCRIPTION
Looks like the `releases-json` workflow [has not been triggered with release v0.10.2](https://github.com/docker/buildx/actions?query=branch%3Av0.10.2) from yesterday.

~I think this is related to the event not being dispatched correctly when using a `release` and `pull_request` event within the same workflow. I have tested this behavior on another repo and looks good without `pull_request`.~

Ok after investigation with @jedevc it looks like the event has not been propagated at all for this workflow. So let's just add a `workflow_dispatch` event to be able to trigger this workflow manually in case it happens again.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>