### PR TITLE
ci: fix pr branch name in releases-json workflow

### DIFF
--- a/.github/workflows/releases-json.yml
+++ b/.github/workflows/releases-json.yml
@@ -46,7 +46,7 @@ jobs:
         uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04
         with:
           base: master
-          branch: releases-json/${{ github.event.release.name }}
+          branch: bot/releases-json
           commit-message: "github: update .github/releases.json"
           signoff: true
           delete-branch: true


### PR DESCRIPTION
```
  /usr/bin/git checkout --progress -B releases-json/ 9f0b2a21-fceb-4f3a-832c-19ad87af7a3f --
  fatal: 'releases-json/' is not a valid branch name
  Error: The process '/usr/bin/git' failed with exit code 128
```

Well, on `workflow_dispatch` there is no release name. Let's just put a fixed branch name.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>