### PR TITLE
build: check reachable git commits

### DIFF
--- a/build/git.go
+++ b/build/git.go
@@ -64,7 +64,7 @@ func getGitAttributes(ctx context.Context, contextPath string, dockerfilePath st
 		return res, nil
 	}
 
-	if sha, err := gitc.FullCommit(); err != nil {
+	if sha, err := gitc.FullCommit(); err != nil && !gitutil.IsUnknownRevision(err) {
 		return res, errors.Wrapf(err, "buildx: failed to get git commit")
 	} else if sha != "" {
 		if gitc.IsDirty() {

--- a/util/gitutil/gitutil.go
+++ b/util/gitutil/gitutil.go
@@ -3,6 +3,7 @@ package gitutil
 import (
 	"bytes"
 	"context"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -115,6 +116,9 @@ func (c *Git) run(args ...string) (string, error) {
 	if c.wd != "" {
 		cmd.Dir = c.wd
 	}
+
+	// Override the locale to ensure consistent output
+	cmd.Env = append(os.Environ(), "LC_ALL=C")
 
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}

--- a/util/gitutil/gitutil.go
+++ b/util/gitutil/gitutil.go
@@ -138,3 +138,12 @@ func (c *Git) clean(out string, err error) (string, error) {
 	}
 	return out, err
 }
+
+func IsUnknownRevision(err error) bool {
+	if err == nil {
+		return false
+	}
+	// https://github.com/git/git/blob/a6a323b31e2bcbac2518bddec71ea7ad558870eb/setup.c#L204
+	errMsg := strings.ToLower(err.Error())
+	return strings.Contains(errMsg, "unknown revision or path not in the working tree") || strings.Contains(errMsg, "bad revision")
+}

--- a/util/gitutil/gitutil_test.go
+++ b/util/gitutil/gitutil_test.go
@@ -46,6 +46,18 @@ func TestGitShortCommit(t *testing.T) {
 	require.Equal(t, 7, len(out))
 }
 
+func TestGitFullCommitErr(t *testing.T) {
+	Mktmp(t)
+	c, err := New()
+	require.NoError(t, err)
+
+	GitInit(c, t)
+
+	_, err = c.FullCommit()
+	require.Error(t, err)
+	require.True(t, IsUnknownRevision(err))
+}
+
 func TestGitTagsPointsAt(t *testing.T) {
 	Mktmp(t)
 	c, err := New()


### PR DESCRIPTION
fixes #1587 

We should check if the working tree has git commits before retrieving the git commit so it would not fail. I was also thinking of just silently fail. Let me know what sounds best.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>