### PR TITLE
builder: fix docker context not validated

### DIFF
--- a/store/storeutil/storeutil.go
+++ b/store/storeutil/storeutil.go
@@ -93,6 +93,7 @@ func GetNodeGroup(txn *store.Txn, dockerCli command.Cli, name string) (*store.No
 						Endpoint: name,
 					},
 				},
+				DockerContext: true,
 			}
 			if ng.LastActivity, err = txn.GetLastActivity(ng); err != nil {
 				return nil, err


### PR DESCRIPTION
Fixes a regression introduced by https://github.com/docker/buildx/pull/1439 (https://github.com/docker/buildx/pull/1439/commits/8c472771418cc676e69fd7744396b7b9a07b7849) (probably bad rebase :disappointed:) where `DockerContext` is not being set anymore and therefore validation is always skipped in: https://github.com/docker/buildx/blob/d2fa4a57244df2d1aae9efc9dfe6f563f72bafc3/builder/builder.go#L111

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>