### PR TITLE
kubernetes driver: add serviceaccount opt

### DIFF
--- a/docs/reference/buildx_create.md
+++ b/docs/reference/buildx_create.md
@@ -163,6 +163,7 @@ No driver options.
 - `requests.memory` - Sets the request memory value specified in bytes or with a valid suffix. Example `requests.memory=500Mi`, `requests.memory=4G`
 - `limits.cpu` - Sets the limit CPU value specified in units of Kubernetes CPU. Example `limits.cpu=100m`, `limits.cpu=2`
 - `limits.memory` - Sets the limit memory value specified in bytes or with a valid suffix. Example `limits.memory=500Mi`, `limits.memory=4G`
+- `serviceaccount` - Sets the created pod's service account. Example `serviceaccount=example-sa`
 - `"nodeselector=label1=value1,label2=value2"` - Sets the kv of `Pod` nodeSelector. No Defaults. Example `nodeselector=kubernetes.io/arch=arm64`
 - `"tolerations=key=foo,value=bar;key=foo2,operator=exists;key=foo3,effect=NoSchedule"` - Sets the `Pod` tolerations. Accepts the same values as the kube manifest tolera>tions. Key-value pairs are separated by `,`, tolerations are separated by `;`. No Defaults. Example `tolerations=operator=exists`
 - `rootless=(true|false)` - Run the container as a non-root user without `securityContext.privileged`. Needs Kubernetes 1.19 or later. [Using Ubuntu host kernel is recommended](https://github.com/moby/buildkit/blob/master/docs/rootless.md). Defaults to false.

--- a/driver/kubernetes/factory.go
+++ b/driver/kubernetes/factory.go
@@ -145,6 +145,8 @@ func (f *factory) processDriverOpts(deploymentName string, namespace string, cfg
 			if _, isImage := cfg.DriverOpts["image"]; !isImage {
 				deploymentOpt.Image = bkimage.DefaultRootlessImage
 			}
+		case "serviceaccount":
+			deploymentOpt.ServiceAccountName = v
 		case "nodeselector":
 			kvs := strings.Split(strings.Trim(v, `"`), ",")
 			s := map[string]string{}

--- a/driver/kubernetes/manifest/manifest.go
+++ b/driver/kubernetes/manifest/manifest.go
@@ -14,10 +14,11 @@ import (
 )
 
 type DeploymentOpt struct {
-	Namespace string
-	Name      string
-	Image     string
-	Replicas  int
+	Namespace          string
+	Name               string
+	Image              string
+	Replicas           int
+	ServiceAccountName string
 
 	// Qemu
 	Qemu struct {
@@ -80,6 +81,7 @@ func NewDeployment(opt *DeploymentOpt) (d *appsv1.Deployment, c []*corev1.Config
 					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
+					ServiceAccountName: opt.ServiceAccountName,
 					Containers: []corev1.Container{
 						{
 							Name:  containerName,


### PR DESCRIPTION
Addresses #766

Adds a new (optional) `serviceaccount` opt. When provided, it will be set as the created pod's `serviceAccountName`.

Example usage:

```bash
docker buildx create --name example \
    --driver kubernetes \
    --driver-opt=serviceaccount=example-sa
```