### PR TITLE
bake: avoid early-exit for resolution failures

### DIFF
--- a/bake/hcl_test.go
+++ b/bake/hcl_test.go
@@ -670,6 +670,24 @@ func TestJSONFunctions(t *testing.T) {
 	require.Equal(t, ptrstr("pre-<FOO-abc>"), c.Targets[0].Args["v1"])
 }
 
+func TestJSONInvalidFunctions(t *testing.T) {
+	dt := []byte(`{
+	"target": {
+		"app": {
+			"args": {
+				"v1": "myfunc(\"foo\")"
+			}
+		}
+	}}`)
+
+	c, err := ParseFile(dt, "docker-bake.json")
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(c.Targets))
+	require.Equal(t, c.Targets[0].Name, "app")
+	require.Equal(t, ptrstr(`myfunc("foo")`), c.Targets[0].Args["v1"])
+}
+
 func TestHCLFunctionInAttr(t *testing.T) {
 	dt := []byte(`
 	function "brace" {


### PR DESCRIPTION
:bug: Fixes https://github.com/docker/buildx/issues/1586 (however, it looks like there are still some underlying issues with `funcCall` erroneously detecting contents of those JSON objects as function calls).

With changes made to allow lazy evaluation, we were early exiting if an undefined name was detected, either for a variable or a function.

This had two key implications:

1. The error messages changed, and became significantly less informative.

   For example, we went from:

   > Unknown variable; There is no variable named "FO". Did you mean "FOO"?, and 1 other diagnostic(s)

   To

   > Invalid expression; undefined variable "FO"

2. Any issues in our function detection from funcCalls which cause JSON functions to be erroneously detected cause invalid functions to be resolved, which causes new name resolution errors.

To avoid the above problems, we can defer the error from an undefined name until HCL evaluation - which produces the more informative errors, and does not suffer from incorrectly detecting JSON functions.