### PR TITLE
Add env var to disable default attestations

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -462,8 +462,19 @@ func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt Op
 			so.FrontendAttrs[k] = v
 		}
 	}
+
 	if _, ok := opt.Attests["attest:provenance"]; !ok && supportsAttestations {
-		so.FrontendAttrs["attest:provenance"] = "mode=min,inline-only=true"
+		const noAttestEnv = "BUILDX_NO_DEFAULT_ATTESTATIONS"
+		var noProv bool
+		if v, ok := os.LookupEnv(noAttestEnv); ok {
+			noProv, err = strconv.ParseBool(v)
+			if err != nil {
+				return nil, nil, errors.Wrap(err, "invalid "+noAttestEnv)
+			}
+		}
+		if !noProv {
+			so.FrontendAttrs["attest:provenance"] = "mode=min,inline-only=true"
+		}
 	}
 
 	switch len(opt.Exports) {


### PR DESCRIPTION
For certain cases we need to build with `--provenance=false`. However not all build envs (especially in the OSS ethos) have the latest buildx so just blanket setting `--provenance=false` will fail in these cases.

Having an env var allows people to set the value without having to worry about if the buildx version has the `--provenance` flag.
