### PR TITLE
Improvements for remote controller code

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -392,10 +392,6 @@ func launchControllerAndRunBuild(dockerCli command.Cli, options buildOptions) er
 		if err := c.Disconnect(ctx, ref); err != nil {
 			logrus.Warnf("disconnect error: %v", err)
 		}
-		// If "invoke" isn't specified, further inspection ins't provided. Finish the buildx server.
-		if err := c.Kill(ctx); err != nil {
-			return err
-		}
 	}
 	return nil
 }

--- a/controller/remote/client.go
+++ b/controller/remote/client.go
@@ -20,20 +20,21 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-func NewClient(addr string) (*Client, error) {
+func NewClient(ctx context.Context, addr string) (*Client, error) {
 	backoffConfig := backoff.DefaultConfig
 	backoffConfig.MaxDelay = 3 * time.Second
 	connParams := grpc.ConnectParams{
 		Backoff: backoffConfig,
 	}
 	gopts := []grpc.DialOption{
+		grpc.WithBlock(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithConnectParams(connParams),
 		grpc.WithContextDialer(dialer.ContextDialer),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(defaults.DefaultMaxRecvMsgSize)),
 		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(defaults.DefaultMaxSendMsgSize)),
 	}
-	conn, err := grpc.Dial(dialer.DialAddress(addr), gopts...)
+	conn, err := grpc.DialContext(ctx, dialer.DialAddress(addr), gopts...)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/remote/controller.go
+++ b/controller/remote/controller.go
@@ -154,7 +154,8 @@ func serveCmd(dockerCli command.Cli) *cobra.Command {
 
 			var s os.Signal
 			sigCh := make(chan os.Signal, 1)
-			signal.Notify(sigCh, os.Interrupt)
+			signal.Notify(sigCh, syscall.SIGINT)
+			signal.Notify(sigCh, syscall.SIGTERM)
 			select {
 			case err := <-errCh:
 				logrus.Errorf("got error %s, exiting", err)

--- a/controller/remote/controller.go
+++ b/controller/remote/controller.go
@@ -296,7 +296,12 @@ func (c *buildxController) Kill(ctx context.Context) error {
 }
 
 func launch(ctx context.Context, logFile string, args ...string) (func() error, error) {
-	bCmd := exec.CommandContext(ctx, os.Args[0], args...)
+	// set absolute path of binary, since we set the working directory to the root
+	pathname, err := filepath.Abs(os.Args[0])
+	if err != nil {
+		return nil, err
+	}
+	bCmd := exec.CommandContext(ctx, pathname, args...)
 	if logFile != "" {
 		f, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {

--- a/controller/remote/controller.go
+++ b/controller/remote/controller.go
@@ -151,18 +151,21 @@ func serveCmd(dockerCli command.Cli) *cobra.Command {
 					errCh <- errors.Wrapf(err, "error on serving via socket %q", addr)
 				}
 			}()
+
 			var s os.Signal
 			sigCh := make(chan os.Signal, 1)
 			signal.Notify(sigCh, os.Interrupt)
 			select {
-			case s = <-sigCh:
-				logrus.Debugf("got signal %v", s)
 			case err := <-errCh:
+				logrus.Errorf("got error %s, exiting", err)
 				return err
+			case s = <-sigCh:
+				logrus.Infof("got signal %s, exiting", s)
+				return nil
 			case <-doneCh:
+				logrus.Infof("rpc server done, exiting")
+				return nil
 			}
-			return nil
-
 		},
 	}
 


### PR DESCRIPTION
A few commits with various improvements for the remote controller code.

- Don't kill the remote controller immediately after build. We should keep the server alive, since the client can't know exactly what's running on the controller - also we want the behavior for debugging or not to remain relatively similar. At some point in the future, we could introduce logic to the server where it can shut itself down, if no builds are currently being run, however, the server should dictate this, instead of each individual client.
- Add more informative server exit messages, so that the reasons for exit are always available in a log.
- Add signal handling for SIGTERM (in addition to the existing SIGINT). SIGKILL can be caused by pkill and similar programs, which is useful for debugging, etc.
- Switch to using `context.Context` for timeout handling with GRPC instead of a custom loop - this simplifies the code, makes it more configurable, and gives us better performance.
- Use unique files for each buildx version. Instead of only having a single controller server, we allow for having multiple, one for each version of buildx, so we should never have any version clashes, meaning user interaction is less necessary. This means we can dramatically change the protocol between buildx versions, without needing to worry about any form of compatibility.
  - We also should keep separate log files for each server - but I'm not quite sure how that should interact with a `log_file` specified in `config.toml`. Ideas for this welcome :smile: