### PR TITLE
[v0.10 backport] ci: update buildx and buildkit to latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,8 @@ on:
       - 'docs/**'
 
 env:
-  BUILDX_VERSION: "v0.10.0"
-  BUILDKIT_IMAGE: "moby/buildkit:v0.11.1"
+  BUILDX_VERSION: "latest"
+  BUILDKIT_IMAGE: "moby/buildkit:latest"
   REPO_SLUG: "docker/buildx-bin"
   DESTDIR: "./bin"
 


### PR DESCRIPTION
* backport of https://github.com/docker/buildx/pull/1572