### PR TITLE
controller: use os.Executable() for getting the exceutable path

### DIFF
--- a/controller/remote/controller.go
+++ b/controller/remote/controller.go
@@ -297,7 +297,7 @@ func (c *buildxController) Kill(ctx context.Context) error {
 
 func launch(ctx context.Context, logFile string, args ...string) (func() error, error) {
 	// set absolute path of binary, since we set the working directory to the root
-	pathname, err := filepath.Abs(os.Args[0])
+	pathname, err := os.Executable()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We should use`os.Executable()` to get the absolute path of the executing binary. https://pkg.go.dev/os#Executable

Otherwise we get the error like:
```
ERROR: failed to use buildx server; use --detach=false: fork/exec /tmp/ctx/buildx: no such file or directory
```

that unexpectedly joins the command name with the current working directory.