### PR TITLE
[v0.10 backport] build: strip credentials from remote url on collecting Git provenance info

### DIFF
--- a/util/gitutil/gitutil_test.go
+++ b/util/gitutil/gitutil_test.go
@@ -189,3 +189,45 @@ func TestGitRemoteURL(t *testing.T) {
 		})
 	}
 }
+
+func TestStripCredentials(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "non-blank Password",
+			url:  "https://user:password@host.tld/this:that",
+			want: "https://host.tld/this:that",
+		},
+		{
+			name: "blank Password",
+			url:  "https://user@host.tld/this:that",
+			want: "https://host.tld/this:that",
+		},
+		{
+			name: "blank Username",
+			url:  "https://:password@host.tld/this:that",
+			want: "https://host.tld/this:that",
+		},
+		{
+			name: "blank Username, blank Password",
+			url:  "https://host.tld/this:that",
+			want: "https://host.tld/this:that",
+		},
+		{
+			name: "invalid URL",
+			url:  "1https://foo.com",
+			want: "1https://foo.com",
+		},
+	}
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			if g, w := stripCredentials(tt.url), tt.want; g != w {
+				t.Fatalf("got: %q\nwant: %q", g, w)
+			}
+		})
+	}
+}


### PR DESCRIPTION
* backport of #1663 