### PR TITLE
version: add "v" prefix to version for tagging convention consistency

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -5,7 +5,7 @@ var (
 	Package = "github.com/docker/buildx"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "0.0.0+unknown"
+	Version = "v0.0.0+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
:arrow_up: Follow-up to https://github.com/docker/buildx/pull/1637#discussion_r1108625166.
:link: Similar to https://github.com/moby/buildkit/pull/3695.

Ensures that `docker buildx version` always begins with a `v` (as in the version tagging convention we use). This will only apply in cases when users build buildx from scratch *without* using the provided build scripts (and just using `go build` directly).