### PR TITLE
bake: add completion to list targets

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -84,6 +84,21 @@ func ReadLocalFiles(names []string) ([]File, error) {
 	return out, nil
 }
 
+func ListTargets(files []File) ([]string, error) {
+	c, err := ParseFiles(files, nil)
+	if err != nil {
+		return nil, err
+	}
+	var targets []string
+	for _, g := range c.Groups {
+		targets = append(targets, g.Name)
+	}
+	for _, t := range c.Targets {
+		targets = append(targets, t.Name)
+	}
+	return dedupSlice(targets), nil
+}
+
 func ReadTargets(ctx context.Context, files []File, targets, overrides []string, defaults map[string]string) (map[string]*Target, map[string]*Group, error) {
 	c, err := ParseFiles(files, defaults)
 	if err != nil {

--- a/commands/bake.go
+++ b/commands/bake.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/buildx/builder"
 	controllerapi "github.com/docker/buildx/controller/pb"
 	"github.com/docker/buildx/util/buildflags"
+	"github.com/docker/buildx/util/cobrautil"
 	"github.com/docker/buildx/util/confutil"
 	"github.com/docker/buildx/util/dockerutil"
 	"github.com/docker/buildx/util/progress"
@@ -214,6 +215,7 @@ func bakeCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 			// Other common flags (noCache, pull and progress) are processed in runBake function.
 			return runBake(dockerCli, args, options, cFlags)
 		},
+		ValidArgsFunction: cobrautil.CompleteBakeTargets(options.files),
 	}
 
 	flags := cmd.Flags()

--- a/commands/build.go
+++ b/commands/build.go
@@ -22,6 +22,7 @@ import (
 	"github.com/docker/buildx/store"
 	"github.com/docker/buildx/store/storeutil"
 	"github.com/docker/buildx/util/buildflags"
+	"github.com/docker/buildx/util/cobrautil"
 	"github.com/docker/buildx/util/ioset"
 	"github.com/docker/buildx/util/progress"
 	"github.com/docker/buildx/util/tracing"
@@ -235,6 +236,7 @@ func buildCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 			}
 			return runBuild(dockerCli, options)
 		},
+		ValidArgsFunction: cobrautil.NoCompletion,
 	}
 
 	var platformsDefault []string

--- a/commands/build.go
+++ b/commands/build.go
@@ -22,7 +22,6 @@ import (
 	"github.com/docker/buildx/store"
 	"github.com/docker/buildx/store/storeutil"
 	"github.com/docker/buildx/util/buildflags"
-	"github.com/docker/buildx/util/cobrautil"
 	"github.com/docker/buildx/util/ioset"
 	"github.com/docker/buildx/util/progress"
 	"github.com/docker/buildx/util/tracing"
@@ -236,7 +235,9 @@ func buildCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 			}
 			return runBuild(dockerCli, options)
 		},
-		ValidArgsFunction: cobrautil.NoCompletion,
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return nil, cobra.ShellCompDirectiveFilterDirs
+		},
 	}
 
 	var platformsDefault []string

--- a/commands/create.go
+++ b/commands/create.go
@@ -309,6 +309,7 @@ func createCmd(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCreate(dockerCli, options, args)
 		},
+		ValidArgsFunction: cobrautil.NoCompletion,
 	}
 
 	flags := cmd.Flags()

--- a/commands/diskusage.go
+++ b/commands/diskusage.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/docker/buildx/builder"
+	"github.com/docker/buildx/util/cobrautil"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/opts"
@@ -115,6 +116,7 @@ func duCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 			options.builder = rootOpts.builder
 			return runDiskUsage(dockerCli, options)
 		},
+		ValidArgsFunction: cobrautil.NoCompletion,
 	}
 
 	flags := cmd.Flags()

--- a/commands/imagetools/create.go
+++ b/commands/imagetools/create.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/docker/buildx/builder"
+	"github.com/docker/buildx/util/cobrautil"
 	"github.com/docker/buildx/util/imagetools"
 	"github.com/docker/buildx/util/progress"
 	"github.com/docker/cli/cli/command"
@@ -273,6 +274,7 @@ func createCmd(dockerCli command.Cli, opts RootOptions) *cobra.Command {
 			options.builder = *opts.Builder
 			return runCreate(dockerCli, options, args)
 		},
+		ValidArgsFunction: cobrautil.NoCompletion,
 	}
 
 	flags := cmd.Flags()

--- a/commands/imagetools/inspect.go
+++ b/commands/imagetools/inspect.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"github.com/docker/buildx/builder"
+	"github.com/docker/buildx/util/cobrautil"
 	"github.com/docker/buildx/util/imagetools"
 	"github.com/docker/cli-docs-tool/annotation"
 	"github.com/docker/cli/cli"
@@ -52,6 +53,7 @@ func inspectCmd(dockerCli command.Cli, rootOpts RootOptions) *cobra.Command {
 			options.builder = *rootOpts.Builder
 			return runInspect(dockerCli, options, args[0])
 		},
+		ValidArgsFunction: cobrautil.NoCompletion,
 	}
 
 	flags := cmd.Flags()

--- a/commands/imagetools/root.go
+++ b/commands/imagetools/root.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"github.com/docker/buildx/util/cobrautil"
 	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
 )
@@ -11,8 +12,9 @@ type RootOptions struct {
 
 func RootCmd(dockerCli command.Cli, opts RootOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "imagetools",
-		Short: "Commands to work on images in registry",
+		Use:               "imagetools",
+		Short:             "Commands to work on images in registry",
+		ValidArgsFunction: cobrautil.NoCompletion,
 	}
 
 	cmd.AddCommand(

--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/docker/buildx/builder"
+	"github.com/docker/buildx/util/cobrautil"
 	"github.com/docker/buildx/util/platformutil"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
@@ -112,6 +113,7 @@ func inspectCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 			}
 			return runInspect(dockerCli, options)
 		},
+		ValidArgsFunction: cobrautil.NoCompletion,
 	}
 
 	flags := cmd.Flags()

--- a/commands/install.go
+++ b/commands/install.go
@@ -46,7 +46,8 @@ func installCmd(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runInstall(dockerCli, options)
 		},
-		Hidden: true,
+		Hidden:            true,
+		ValidArgsFunction: cobrautil.NoCompletion,
 	}
 
 	// hide builder persistent flag for this command

--- a/commands/ls.go
+++ b/commands/ls.go
@@ -126,6 +126,7 @@ func lsCmd(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runLs(dockerCli, options)
 		},
+		ValidArgsFunction: cobrautil.NoCompletion,
 	}
 
 	// hide builder persistent flag for this command

--- a/commands/prune.go
+++ b/commands/prune.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/docker/buildx/builder"
+	"github.com/docker/buildx/util/cobrautil"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/opts"
@@ -139,6 +140,7 @@ func pruneCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 			options.builder = rootOpts.builder
 			return runPrune(dockerCli, options)
 		},
+		ValidArgsFunction: cobrautil.NoCompletion,
 	}
 
 	flags := cmd.Flags()

--- a/commands/rm.go
+++ b/commands/rm.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/buildx/builder"
 	"github.com/docker/buildx/store"
 	"github.com/docker/buildx/store/storeutil"
+	"github.com/docker/buildx/util/cobrautil"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/moby/buildkit/util/appcontext"
@@ -92,6 +93,7 @@ func rmCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 			}
 			return runRm(dockerCli, options)
 		},
+		ValidArgsFunction: cobrautil.NoCompletion,
 	}
 
 	flags := cmd.Flags()

--- a/commands/root.go
+++ b/commands/root.go
@@ -23,6 +23,9 @@ func NewRootCmd(name string, isPlugin bool, dockerCli command.Cli) *cobra.Comman
 		Annotations: map[string]string{
 			annotation.CodeDelimiter: `"`,
 		},
+		CompletionOptions: cobra.CompletionOptions{
+			HiddenDefaultCmd: true,
+		},
 	}
 	if isPlugin {
 		cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {

--- a/commands/stop.go
+++ b/commands/stop.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/docker/buildx/builder"
+	"github.com/docker/buildx/util/cobrautil"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/moby/buildkit/util/appcontext"
@@ -46,6 +47,7 @@ func stopCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 			}
 			return runStop(dockerCli, options)
 		},
+		ValidArgsFunction: cobrautil.NoCompletion,
 	}
 
 	return cmd

--- a/commands/uninstall.go
+++ b/commands/uninstall.go
@@ -52,7 +52,8 @@ func uninstallCmd(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runUninstall(dockerCli, options)
 		},
-		Hidden: true,
+		Hidden:            true,
+		ValidArgsFunction: cobrautil.NoCompletion,
 	}
 
 	// hide builder persistent flag for this command

--- a/commands/use.go
+++ b/commands/use.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/docker/buildx/store/storeutil"
+	"github.com/docker/buildx/util/cobrautil"
 	"github.com/docker/buildx/util/dockerutil"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
@@ -78,6 +79,7 @@ func useCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 			}
 			return runUse(dockerCli, options)
 		},
+		ValidArgsFunction: cobrautil.NoCompletion,
 	}
 
 	flags := cmd.Flags()

--- a/commands/version.go
+++ b/commands/version.go
@@ -23,6 +23,7 @@ func versionCmd(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runVersion(dockerCli)
 		},
+		ValidArgsFunction: cobrautil.NoCompletion,
 	}
 
 	// hide builder persistent flag for this command

--- a/util/cobrautil/completion.go
+++ b/util/cobrautil/completion.go
@@ -1,0 +1,38 @@
+package cobrautil
+
+import (
+	"strings"
+
+	"github.com/docker/buildx/bake"
+	"github.com/spf13/cobra"
+)
+
+// ValidArgsFn defines a completion func to be returned to fetch completion options
+type ValidArgsFn func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)
+
+func NoCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return nil, cobra.ShellCompDirectiveNoFileComp
+}
+
+func CompleteBakeTargets(files []string) ValidArgsFn {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		f, err := bake.ReadLocalFiles(files)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+		tgts, err := bake.ListTargets(f)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+		var filtered []string
+		if toComplete == "" {
+			return tgts, cobra.ShellCompDirectiveNoFileComp
+		}
+		for _, tgt := range tgts {
+			if strings.HasPrefix(tgt, toComplete) {
+				filtered = append(filtered, tgt)
+			}
+		}
+		return filtered, cobra.ShellCompDirectiveNoFileComp
+	}
+}


### PR DESCRIPTION
partially solves https://github.com/docker/buildx/issues/1072
~needs https://github.com/docker/cli/pull/4089~

Add completion to list bake targets and also folders (context) for build command.

Can be tested within this repo:

```
$ docker __completeNoDesc buildx ""
bake    Build from a file
build   Start a build
create  Create a new builder instance
du      Disk usage
imagetools      Commands to work on images in registry
inspect Inspect current builder instance
ls      List builder instances
prune   Remove build cache
rm      Remove a builder instance
stop    Stop builder instance
use     Set the current builder instance
version Show buildx version information
:4
Completion ended with directive: ShellCompDirectiveNoFileComp
```

```
$ docker __completeNoDesc buildx bake ""
default
validate
meta-helper
_common
lint
validate-vendor
validate-docs
validate-authors
validate-generated-files
update-vendor
update-docs
update-authors
update-generated-files
mod-outdated
test
binaries
binaries-cross
release
image
image-cross
image-local
:4
Completion ended with directive: ShellCompDirectiveNoFileComp
```

```
$ docker __completeNoDesc buildx bake "v"
validate
validate-vendor
validate-docs
validate-authors
validate-generated-files
:4
Completion ended with directive: ShellCompDirectiveNoFileComp
```