### PR TITLE
SOURCE_DATE_EPOCH build arg injection fixes

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -140,19 +140,6 @@ func ReadTargets(ctx context.Context, files []File, targets, overrides []string,
 		}
 	}
 
-	// Propagate SOURCE_DATE_EPOCH from the client env.
-	// The logic is purposely duplicated from `build/build`.go for keeping this visible in `bake --print`.
-	if v := os.Getenv("SOURCE_DATE_EPOCH"); v != "" {
-		for _, f := range m {
-			if f.Args == nil {
-				f.Args = make(map[string]*string)
-			}
-			if _, ok := f.Args["SOURCE_DATE_EPOCH"]; !ok {
-				f.Args["SOURCE_DATE_EPOCH"] = &v
-			}
-		}
-	}
-
 	return m, n, nil
 }
 

--- a/build/build.go
+++ b/build/build.go
@@ -604,13 +604,6 @@ func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt Op
 		}
 	}
 
-	// Propagate SOURCE_DATE_EPOCH from the client env
-	if v := os.Getenv("SOURCE_DATE_EPOCH"); v != "" {
-		if _, ok := so.FrontendAttrs["build-arg:SOURCE_DATE_EPOCH"]; !ok {
-			so.FrontendAttrs["build-arg:SOURCE_DATE_EPOCH"] = v
-		}
-	}
-
 	// set platforms
 	if len(opt.Platforms) != 0 {
 		pp := make([]string, len(opt.Platforms))

--- a/commands/bake.go
+++ b/commands/bake.go
@@ -149,6 +149,19 @@ func runBake(dockerCli command.Cli, targets []string, in bakeOptions, cFlags com
 		return err
 	}
 
+	if v := os.Getenv("SOURCE_DATE_EPOCH"); v != "" {
+		// TODO: extract env var parsing to a method easily usable by library consumers
+		for _, t := range tgts {
+			if _, ok := t.Args["SOURCE_DATE_EPOCH"]; ok {
+				continue
+			}
+			if t.Args == nil {
+				t.Args = map[string]*string{}
+			}
+			t.Args["SOURCE_DATE_EPOCH"] = &v
+		}
+	}
+
 	// this function can update target context string from the input so call before printOnly check
 	bo, err := bake.TargetsToBuildOpt(tgts, inp)
 	if err != nil {

--- a/commands/build.go
+++ b/commands/build.go
@@ -100,6 +100,13 @@ func (o *buildOptions) toControllerOptions() (controllerapi.BuildOptions, error)
 		Opts:           &o.CommonOptions,
 	}
 
+	// TODO: extract env var parsing to a method easily usable by library consumers
+	if v := os.Getenv("SOURCE_DATE_EPOCH"); v != "" {
+		if _, ok := opts.BuildArgs["SOURCE_DATE_EPOCH"]; !ok {
+			opts.BuildArgs["SOURCE_DATE_EPOCH"] = v
+		}
+	}
+
 	inAttests := append([]string{}, o.attests...)
 	if o.provenance != "" {
 		inAttests = append(inAttests, buildflags.CanonicalizeAttest("provenance", o.provenance))


### PR DESCRIPTION
This PR pushes all `SOURCE_DATE_EPOCH` parsing into the command layer. This fixes two issues (in separate commits):
- For the `build` command, we pull out `SOURCE_DATE_EPOCH` early, and set it in the build-args - then in the case of the remote controller (which connects to a buildx server), we can still set `SOURCE_DATE_EPOCH` correctly.
- For the `bake` command, we pull out `SOURCE_DATE_EPOCH` early, and set it as an override - this fixes https://github.com/NixOS/nixpkgs/pull/221023#discussion_r1134601194, where if `SOURCE_DATE_EPOCH` is set in the test environment (I think this is standard on Nix, though I'm not familiar) we generate additional build args. By splitting into a separate override in the bake command, tests don't end up accidentally reading the contents of the environment.

