### PR TITLE
Implement matrix for bake targets

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -246,13 +246,28 @@ func ParseFiles(files []File, defaults map[string]string) (_ *Config, err error)
 	}
 
 	if len(hclFiles) > 0 {
-		if err := hclparser.Parse(hcl.MergeFiles(hclFiles), hclparser.Opt{
+		renamed, err := hclparser.Parse(hcl.MergeFiles(hclFiles), hclparser.Opt{
 			LookupVar:     os.LookupEnv,
 			Vars:          defaults,
 			ValidateLabel: validateTargetName,
-		}, &c); err.HasErrors() {
+		}, &c)
+		if err.HasErrors() {
 			return nil, err
 		}
+
+		for _, renamed := range renamed {
+			for oldName, newNames := range renamed {
+				newNames = dedupSlice(newNames)
+				if len(newNames) == 1 && oldName == newNames[0] {
+					continue
+				}
+				c.Groups = append(c.Groups, &Group{
+					Name:    oldName,
+					Targets: newNames,
+				})
+			}
+		}
+		c = dedupeConfig(c)
 	}
 
 	return &c, nil

--- a/bake/hclparser/hclparser.go
+++ b/bake/hclparser/hclparser.go
@@ -49,29 +49,29 @@ type parser struct {
 	attrs map[string]*hcl.Attribute
 	funcs map[string]*functionDef
 
-	blocks      map[string]map[string][]*hcl.Block
-	blockValues map[*hcl.Block]reflect.Value
-	blockTypes  map[string]reflect.Type
+	blocks       map[string]map[string][]*hcl.Block
+	blockValues  map[*hcl.Block]reflect.Value
+	blockEvalCtx map[*hcl.Block]*hcl.EvalContext
+	blockTypes   map[string]reflect.Type
 
 	ectx *hcl.EvalContext
 
 	progress  map[string]struct{}
 	progressF map[string]struct{}
 	progressB map[*hcl.Block]map[string]struct{}
-	doneF     map[string]struct{}
 	doneB     map[*hcl.Block]map[string]struct{}
 }
 
 var errUndefined = errors.New("undefined")
 
-func (p *parser) loadDeps(exp hcl.Expression, exclude map[string]struct{}, allowMissing bool) hcl.Diagnostics {
+func (p *parser) loadDeps(ectx *hcl.EvalContext, exp hcl.Expression, exclude map[string]struct{}, allowMissing bool) hcl.Diagnostics {
 	fns, hcldiags := funcCalls(exp)
 	if hcldiags.HasErrors() {
 		return hcldiags
 	}
 
 	for _, fn := range fns {
-		if err := p.resolveFunction(fn); err != nil {
+		if err := p.resolveFunction(ectx, fn); err != nil {
 			if allowMissing && errors.Is(err, errUndefined) {
 				continue
 			}
@@ -131,7 +131,7 @@ func (p *parser) loadDeps(exp hcl.Expression, exclude map[string]struct{}, allow
 				return wrapErrorDiagnostic("Invalid expression", err, exp.Range().Ptr(), exp.Range().Ptr())
 			}
 		} else {
-			if err := p.resolveValue(v.RootName()); err != nil {
+			if err := p.resolveValue(ectx, v.RootName()); err != nil {
 				if allowMissing && errors.Is(err, errUndefined) {
 					continue
 				}
@@ -145,16 +145,16 @@ func (p *parser) loadDeps(exp hcl.Expression, exclude map[string]struct{}, allow
 
 // resolveFunction forces evaluation of a function, storing the result into the
 // parser.
-func (p *parser) resolveFunction(name string) error {
-	if _, ok := p.doneF[name]; ok {
+func (p *parser) resolveFunction(ectx *hcl.EvalContext, name string) error {
+	if _, ok := p.ectx.Functions[name]; ok {
+		return nil
+	}
+	if _, ok := ectx.Functions[name]; ok {
 		return nil
 	}
 	f, ok := p.funcs[name]
 	if !ok {
-		if _, ok := p.ectx.Functions[name]; ok {
-			return nil
-		}
-		return errors.Wrapf(errUndefined, "function %q does not exit", name)
+		return errors.Wrapf(errUndefined, "function %q does not exist", name)
 	}
 	if _, ok := p.progressF[name]; ok {
 		return errors.Errorf("function cycle not allowed for %s", name)
@@ -204,7 +204,7 @@ func (p *parser) resolveFunction(name string) error {
 		return diags
 	}
 
-	if diags := p.loadDeps(f.Result.Expr, params, false); diags.HasErrors() {
+	if diags := p.loadDeps(p.ectx, f.Result.Expr, params, false); diags.HasErrors() {
 		return diags
 	}
 
@@ -214,7 +214,6 @@ func (p *parser) resolveFunction(name string) error {
 	if diags.HasErrors() {
 		return diags
 	}
-	p.doneF[name] = struct{}{}
 	p.ectx.Functions[name] = v
 
 	return nil
@@ -222,8 +221,11 @@ func (p *parser) resolveFunction(name string) error {
 
 // resolveValue forces evaluation of a named value, storing the result into the
 // parser.
-func (p *parser) resolveValue(name string) (err error) {
+func (p *parser) resolveValue(ectx *hcl.EvalContext, name string) (err error) {
 	if _, ok := p.ectx.Variables[name]; ok {
+		return nil
+	}
+	if _, ok := ectx.Variables[name]; ok {
 		return nil
 	}
 	if _, ok := p.progress[name]; ok {
@@ -242,9 +244,10 @@ func (p *parser) resolveValue(name string) (err error) {
 	if _, builtin := p.opt.Vars[name]; !ok && !builtin {
 		vr, ok := p.vars[name]
 		if !ok {
-			return errors.Wrapf(errUndefined, "variable %q does not exit", name)
+			return errors.Wrapf(errUndefined, "variable %q does not exist", name)
 		}
 		def = vr.Default
+		ectx = p.ectx
 	}
 
 	if def == nil {
@@ -257,10 +260,10 @@ func (p *parser) resolveValue(name string) (err error) {
 		return
 	}
 
-	if diags := p.loadDeps(def.Expr, nil, true); diags.HasErrors() {
+	if diags := p.loadDeps(ectx, def.Expr, nil, true); diags.HasErrors() {
 		return diags
 	}
-	vv, diags := def.Expr.Value(p.ectx)
+	vv, diags := def.Expr.Value(ectx)
 	if diags.HasErrors() {
 		return diags
 	}
@@ -364,18 +367,43 @@ func (p *parser) resolveBlock(block *hcl.Block, target *hcl.BodySchema) (err err
 		return FilterExcludeBody(block.Body, filter)
 	}
 
-	// load dependencies from all targeted properties
+	// prepare the output destination and evaluation context
 	t, ok := p.blockTypes[block.Type]
 	if !ok {
 		return nil
 	}
+	var output reflect.Value
+	var ectx *hcl.EvalContext
+	if prev, ok := p.blockValues[block]; ok {
+		output = prev
+		ectx = p.blockEvalCtx[block]
+	} else {
+		output = reflect.New(t)
+		setLabel(output, block.Labels[0]) // early attach labels, so we can reference them
+
+		type ectxI interface {
+			EvalContext(base *hcl.EvalContext, block *hcl.Block) *hcl.EvalContext
+		}
+		if v, ok := output.Interface().(ectxI); ok {
+			ectx = v.EvalContext(p.ectx, block)
+			if ectx != p.ectx && ectx.Parent() != p.ectx {
+				return errors.Errorf("EvalContext must return a context with the correct parent")
+			}
+		} else {
+			ectx = p.ectx
+		}
+	}
+	p.blockValues[block] = output
+	p.blockEvalCtx[block] = ectx
+
+	// load dependencies from all targeted properties
 	schema, _ := gohcl.ImpliedBodySchema(reflect.New(t).Interface())
 	content, _, diag := body().PartialContent(schema)
 	if diag.HasErrors() {
 		return diag
 	}
 	for _, a := range content.Attributes {
-		diag := p.loadDeps(a.Expr, nil, true)
+		diag := p.loadDeps(ectx, a.Expr, nil, true)
 		if diag.HasErrors() {
 			return diag
 		}
@@ -388,18 +416,10 @@ func (p *parser) resolveBlock(block *hcl.Block, target *hcl.BodySchema) (err err
 	}
 
 	// decode!
-	var output reflect.Value
-	if prev, ok := p.blockValues[block]; ok {
-		output = prev
-	} else {
-		output = reflect.New(t)
-		setLabel(output, block.Labels[0]) // early attach labels, so we can reference them
-	}
-	diag = gohcl.DecodeBody(body(), p.ectx, output.Interface())
+	diag = gohcl.DecodeBody(body(), ectx, output.Interface())
 	if diag.HasErrors() {
 		return diag
 	}
-	p.blockValues[block] = output
 
 	// mark all targeted properties as done
 	for _, a := range content.Attributes {
@@ -417,7 +437,7 @@ func (p *parser) resolveBlock(block *hcl.Block, target *hcl.BodySchema) (err err
 		}
 	}
 
-	// store the result into the evaluation context (so if can be referenced)
+	// store the result into the evaluation context (so it can be referenced)
 	outputType, err := gocty.ImpliedType(output.Interface())
 	if err != nil {
 		return err
@@ -475,20 +495,20 @@ func Parse(b hcl.Body, opt Opt, val interface{}) hcl.Diagnostics {
 		attrs: map[string]*hcl.Attribute{},
 		funcs: map[string]*functionDef{},
 
-		blocks:      map[string]map[string][]*hcl.Block{},
-		blockValues: map[*hcl.Block]reflect.Value{},
-		blockTypes:  map[string]reflect.Type{},
+		blocks:       map[string]map[string][]*hcl.Block{},
+		blockValues:  map[*hcl.Block]reflect.Value{},
+		blockEvalCtx: map[*hcl.Block]*hcl.EvalContext{},
+		blockTypes:   map[string]reflect.Type{},
+
+		ectx: &hcl.EvalContext{
+			Variables: map[string]cty.Value{},
+			Functions: Stdlib(),
+		},
 
 		progress:  map[string]struct{}{},
 		progressF: map[string]struct{}{},
 		progressB: map[*hcl.Block]map[string]struct{}{},
-
-		doneF: map[string]struct{}{},
-		doneB: map[*hcl.Block]map[string]struct{}{},
-		ectx: &hcl.EvalContext{
-			Variables: map[string]cty.Value{},
-			Functions: stdlibFunctions,
-		},
+		doneB:     map[*hcl.Block]map[string]struct{}{},
 	}
 
 	for _, v := range defs.Variables {
@@ -532,7 +552,7 @@ func Parse(b hcl.Body, opt Opt, val interface{}) hcl.Diagnostics {
 	delete(p.attrs, "function")
 
 	for k := range p.opt.Vars {
-		_ = p.resolveValue(k)
+		_ = p.resolveValue(p.ectx, k)
 	}
 
 	for _, a := range content.Attributes {
@@ -548,7 +568,7 @@ func Parse(b hcl.Body, opt Opt, val interface{}) hcl.Diagnostics {
 	}
 
 	for k := range p.vars {
-		if err := p.resolveValue(k); err != nil {
+		if err := p.resolveValue(p.ectx, k); err != nil {
 			if diags, ok := err.(hcl.Diagnostics); ok {
 				return diags
 			}
@@ -558,7 +578,7 @@ func Parse(b hcl.Body, opt Opt, val interface{}) hcl.Diagnostics {
 	}
 
 	for k := range p.funcs {
-		if err := p.resolveFunction(k); err != nil {
+		if err := p.resolveFunction(p.ectx, k); err != nil {
 			if diags, ok := err.(hcl.Diagnostics); ok {
 				return diags
 			}
@@ -678,7 +698,7 @@ func Parse(b hcl.Body, opt Opt, val interface{}) hcl.Diagnostics {
 	}
 
 	for k := range p.attrs {
-		if err := p.resolveValue(k); err != nil {
+		if err := p.resolveValue(p.ectx, k); err != nil {
 			if diags, ok := err.(hcl.Diagnostics); ok {
 				return diags
 			}

--- a/bake/hclparser/stdlib.go
+++ b/bake/hclparser/stdlib.go
@@ -124,3 +124,11 @@ var timestampFunc = function.New(&function.Spec{
 		return cty.StringVal(time.Now().UTC().Format(time.RFC3339)), nil
 	},
 })
+
+func Stdlib() map[string]function.Function {
+	funcs := make(map[string]function.Function, len(stdlibFunctions))
+	for k, v := range stdlibFunctions {
+		funcs[k] = v
+	}
+	return funcs
+}


### PR DESCRIPTION
:hammer: Fixes #1150 and #1312

This PR implements the proposal from https://github.com/docker/buildx/issues/1150#issuecomment-1146204434, setting a matrix property on targets which can be used to easily parameterize builds such as https://github.com/docker/buildx/issues/1312#issue-1369020589:

```hcl
group "validate" {
  targets = ["validate-lint", "validate-vendor", "validate-docs", "validate-authors"]
}

target "validate-lint" {
  dockerfile = "./hack/dockerfiles/lint.Dockerfile"
  output = ["type=cacheonly"]
}

target "validate-vendor" {
  dockerfile = "./hack/dockerfiles/vendor.Dockerfile"
  target = "validate"
  output = ["type=cacheonly"]
}


target "validate-docs" {
  dockerfile = "./hack/dockerfiles/docs.Dockerfile"
  target = "validate"
  output = ["type=cacheonly"]
}

target "validate-authors" {
  dockerfile = "./hack/dockerfiles/authors.Dockerfile"
  target = "validate"
  output = ["type=cacheonly"]
}
```

With this PR, the above example can be simplified to:

```hcl
group "validate" {
  targets = ["validate-lint", "validate-vendor", "validate-docs", "validate-authors"]
}

target "validate" {
  matrix = {
    tgt = ["lint", "vendor", "docs", "authors"]
  }
  name = "validate-${tgt}"
  dockerfile = "./hack/dockerfiles/${tgt}.Dockerfile"
  target = "validate"
  output = ["type=cacheonly"]
}
```

See the added tests for more information on the functionality - I'll add some docs once it's clear there's some consensus on the design + implementation.

There's still some work to be done around the matrix feature, though I'd be happy to do them as follow-ups, I think there's enough functionality to review in this PR. Specifically, we should consider:
- :heavy_check_mark: Can we provide a shortcut to easily refer to all targets from a matrix without needing to manually specify them (see in the above example, where the `["lint", "vendor", "docs", "authors"]` is effectively duplicated, once in the matrix definition and once in the group definition)? We could implicitly turn the old label from the target (`validate` in this case) into a group that contains all the targets (so the `validate` group would be automatically created). This feels like the simplest option, but I'm not sure about the semantics of automatically creating groups :thinking: 
- Should we allow for a GitHub-matrix like syntax, to `include` or `exclude` specific matrix combinations? I think this would be useful, though I'm not sure of the exact syntax we'd want for this.
- Should we support matrixes for groups as well? There's no reason why not, and adds consistency, but I struggle to see a concrete use case.