### PR TITLE
remote: avoid tls error if both key and cert are not set

### DIFF
--- a/driver/remote/factory.go
+++ b/driver/remote/factory.go
@@ -98,11 +98,11 @@ func (f *factory) New(ctx context.Context, cfg driver.InitConfig) (driver.Driver
 		if tls.caCert == "" {
 			missing = append(missing, "cacert")
 		}
-		if tls.cert == "" {
-			missing = append(missing, "cert")
-		}
-		if tls.key == "" {
+		if tls.cert != "" && tls.key == "" {
 			missing = append(missing, "key")
+		}
+		if tls.key != "" && tls.cert == "" {
+			missing = append(missing, "cert")
 		}
 		if len(missing) > 0 {
 			return nil, errors.Errorf("tls enabled, but missing keys %s", strings.Join(missing, ", "))


### PR DESCRIPTION
:hammer_and_wrench: Fixes what appears to be an oversight I made in https://github.com/docker/buildx/pull/1078.

Previously, we would explicitly error if all TLS parameters were not available. However, it is a perfectly valid use case to connect to a buildkit server that only serves TLS but which does not verify the client (which is possible today with buildctl) - see https://github.com/moby/buildkit/pull/236#issue-283525374:

> - Use a certificate and key on the server and a ca-certificate at the client
>   - an ephemeral key exchange is performed
>   - the client verifies the server certificate

To support this use case, we only need to error if only one of key or cert is set, and the other is not - if both are unspecified, the client will not present a certificate to the server.