### PR TITLE
build: fixup resolvePaths for remote context path

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -670,9 +670,11 @@ func dockerUlimitToControllerUlimit(u *dockeropts.UlimitOpt) *controllerapi.Ulim
 // and replaces them to absolute paths.
 func resolvePaths(options *controllerapi.BuildOptions) (_ *controllerapi.BuildOptions, err error) {
 	if options.ContextPath != "" && options.ContextPath != "-" {
-		options.ContextPath, err = filepath.Abs(options.ContextPath)
-		if err != nil {
-			return nil, err
+		if !urlutil.IsGitURL(options.ContextPath) && !urlutil.IsURL(options.ContextPath) {
+			options.ContextPath, err = filepath.Abs(options.ContextPath)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	if options.DockerfileName != "" && options.DockerfileName != "-" {

--- a/commands/build_test.go
+++ b/commands/build_test.go
@@ -36,6 +36,11 @@ func TestResolvePaths(t *testing.T) {
 			want:    controllerapi.BuildOptions{ContextPath: "-"},
 		},
 		{
+			name:    "contextpath-ssh",
+			options: controllerapi.BuildOptions{ContextPath: "git@github.com:docker/buildx.git"},
+			want:    controllerapi.BuildOptions{ContextPath: "git@github.com:docker/buildx.git"},
+		},
+		{
 			name:    "dockerfilename",
 			options: controllerapi.BuildOptions{DockerfileName: "test"},
 			want:    controllerapi.BuildOptions{DockerfileName: filepath.Join(tmpwd, "test")},


### PR DESCRIPTION
Fixes a regression introduced in #1581 - the context path can be a URL, which would not work when using the controller path.

This fixes the detection to not resolve the path to the current working directory if it's a URL, similar to the logic for named contexts.