### PR TITLE
build: remove buildinfo

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -555,12 +555,6 @@ func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt Op
 				}
 			}
 		}
-		if e.Type == "docker" || e.Type == "image" || e.Type == "oci" {
-			// inline buildinfo attrs from build arg
-			if v, ok := opt.BuildArgs["BUILDKIT_INLINE_BUILDINFO_ATTRS"]; ok {
-				e.Attrs["buildinfo-attrs"] = v
-			}
-		}
 	}
 
 	so.Exports = opt.Exports
@@ -1487,9 +1481,6 @@ func waitContextDeps(ctx context.Context, index int, results *waitmap.Map, so *c
 				if dt, ok := rr.Metadata[exptypes.ExporterImageConfigKey+"/"+platform]; ok {
 					metadata[exptypes.ExporterImageConfigKey] = dt
 				}
-				if dt, ok := rr.Metadata[exptypes.ExporterBuildInfo+"/"+platform]; ok {
-					metadata[exptypes.ExporterBuildInfo] = dt
-				}
 				if len(metadata) > 0 {
 					dt, err := json.Marshal(metadata)
 					if err != nil {
@@ -1510,9 +1501,6 @@ func waitContextDeps(ctx context.Context, index int, results *waitmap.Map, so *c
 			metadata := make(map[string][]byte)
 			if dt, ok := rr.Metadata[exptypes.ExporterImageConfigKey]; ok {
 				metadata[exptypes.ExporterImageConfigKey] = dt
-			}
-			if dt, ok := rr.Metadata[exptypes.ExporterBuildInfo]; ok {
-				metadata[exptypes.ExporterBuildInfo] = dt
 			}
 			if len(metadata) > 0 {
 				dt, err := json.Marshal(metadata)

--- a/docs/reference/buildx_build.md
+++ b/docs/reference/buildx_build.md
@@ -125,7 +125,6 @@ Same as [`docker build` command](https://docs.docker.com/engine/reference/comman
 There are also useful built-in build args like:
 
 * `BUILDKIT_CONTEXT_KEEP_GIT_DIR=<bool>` trigger git context to keep the `.git` directory
-* `BUILDKIT_INLINE_BUILDINFO_ATTRS=<bool>` inline build info attributes in image config or not
 * `BUILDKIT_INLINE_CACHE=<bool>` inline cache metadata to image config or not
 * `BUILDKIT_MULTI_PLATFORM=<bool>` opt into deterministic output regardless of multi-platform output or not
 
@@ -286,26 +285,6 @@ $ cat metadata.json
 ```
 ```json
 {
-  "containerimage.buildinfo": {
-    "frontend": "dockerfile.v0",
-    "attrs": {
-      "context": "https://github.com/crazy-max/buildkit-buildsources-test.git#master",
-      "filename": "Dockerfile",
-      "source": "docker/dockerfile:master"
-    },
-    "sources": [
-      {
-        "type": "docker-image",
-        "ref": "docker.io/docker/buildx-bin:0.6.1@sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
-        "pin": "sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0"
-      },
-      {
-        "type": "docker-image",
-        "ref": "docker.io/library/alpine:3.13",
-        "pin": "sha256:026f721af4cf2843e07bba648e158fb35ecc876d822130633cc49f707f0fc88c"
-      }
-    ]
-  },
   "containerimage.config.digest": "sha256:2937f66a9722f7f4a2df583de2f8cb97fc9196059a410e7f00072fc918930e66",
   "containerimage.descriptor": {
     "annotations": {


### PR DESCRIPTION
:arrow_up: Follow up https://github.com/moby/buildkit/pull/3582.

BuildKit v0.11 has deprecated buildinfo, and BuildKit v0.12 will remove it, so we should remove it from Buildx as well.

We may want to hold on merging this until we vendor the next release of BuildKit - not exactly sure on release timing.