### PR TITLE
ci: check repo origin on push tag event

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
 
   bin-image:
     runs-on: ubuntu-22.04
-    if: ${{ github.event_name != 'pull_request' }}
+    if: ${{ github.event_name != 'pull_request' && github.repository == 'docker/buildx' }}
     steps:
       -
         name: Checkout

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   open-pr:
     runs-on: ubuntu-22.04
-    if: "!github.event.release.prerelease"
+    if: ${{ github.event.release.prerelease != true && github.repository == 'docker/buildx' }}
     steps:
       -
         name: Checkout docs repo


### PR DESCRIPTION
Avoid pushing image or releasing docs reference from forks on push tag event. This way users can just create a GitHub Release.