### PR TITLE
build(cli): allow passing in-stream using command.Cli

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -55,7 +55,7 @@ func defaultFilenames() []string {
 	return names
 }
 
-func ReadLocalFiles(names []string) ([]File, error) {
+func ReadLocalFiles(names []string, stdin io.Reader) ([]File, error) {
 	isDefault := false
 	if len(names) == 0 {
 		isDefault = true
@@ -67,7 +67,7 @@ func ReadLocalFiles(names []string) ([]File, error) {
 		var dt []byte
 		var err error
 		if n == "-" {
-			dt, err = io.ReadAll(os.Stdin)
+			dt, err = io.ReadAll(stdin)
 			if err != nil {
 				return nil, err
 			}

--- a/bake/bake_test.go
+++ b/bake/bake_test.go
@@ -1398,7 +1398,7 @@ func TestReadLocalFilesDefault(t *testing.T) {
 			for _, tf := range tt.filenames {
 				require.NoError(t, os.WriteFile(tf, []byte(tf), 0644))
 			}
-			files, err := ReadLocalFiles(nil)
+			files, err := ReadLocalFiles(nil, nil)
 			require.NoError(t, err)
 			if len(files) == 0 {
 				require.Equal(t, len(tt.expected), len(files))

--- a/commands/bake.go
+++ b/commands/bake.go
@@ -146,7 +146,7 @@ func runBake(dockerCli command.Cli, targets []string, in bakeOptions, cFlags com
 	if url != "" {
 		files, inp, err = bake.ReadRemoteFiles(ctx, nodes, url, in.files, printer)
 	} else {
-		files, err = bake.ReadLocalFiles(in.files)
+		files, err = bake.ReadLocalFiles(in.files, dockerCli.In())
 	}
 	if err != nil {
 		return err

--- a/commands/build.go
+++ b/commands/build.go
@@ -312,7 +312,7 @@ func getImageID(resp map[string]string) string {
 }
 
 func runBasicBuild(ctx context.Context, dockerCli command.Cli, opts *controllerapi.BuildOptions, options buildOptions, printer *progress.Printer) (*client.SolveResponse, error) {
-	resp, res, err := cbuild.RunBuild(ctx, dockerCli, *opts, os.Stdin, printer, false)
+	resp, res, err := cbuild.RunBuild(ctx, dockerCli, *opts, dockerCli.In(), printer, false)
 	if res != nil {
 		res.Done()
 	}
@@ -346,7 +346,7 @@ func runControllerBuild(ctx context.Context, dockerCli command.Cli, opts *contro
 	var retErr error
 	var resp *client.SolveResponse
 	f := ioset.NewSingleForwarder()
-	f.SetReader(os.Stdin)
+	f.SetReader(dockerCli.In())
 	if !options.noBuild {
 		pr, pw := io.Pipe()
 		f.SetWriter(pw, func() io.WriteCloser {

--- a/commands/debug-shell.go
+++ b/commands/debug-shell.go
@@ -47,7 +47,7 @@ func debugShellCmd(dockerCli command.Cli) *cobra.Command {
 
 			err = monitor.RunMonitor(ctx, "", nil, controllerapi.InvokeConfig{
 				Tty: true,
-			}, c, os.Stdin, os.Stdout, os.Stderr, printer)
+			}, c, dockerCli.In(), os.Stdout, os.Stderr, printer)
 			con.Reset()
 			return err
 		},

--- a/util/cobrautil/completion/completion.go
+++ b/util/cobrautil/completion/completion.go
@@ -19,7 +19,7 @@ func Disable(cmd *cobra.Command, args []string, toComplete string) ([]string, co
 
 func BakeTargets(files []string) ValidArgsFn {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		f, err := bake.ReadLocalFiles(files)
+		f, err := bake.ReadLocalFiles(files, nil)
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveError
 		}


### PR DESCRIPTION
Use command.Cli::In() if it is set, use os.Stdin otherwise.