### PR TITLE
bake: fix map type checking to detect matrix property set to list

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -820,7 +820,7 @@ func (t *Target) GetEvalContexts(ectx *hcl.EvalContext, block *hcl.Block, loadDe
 		return nil, err
 	}
 
-	if !value.CanIterateElements() {
+	if !value.Type().IsMapType() && !value.Type().IsObjectType() {
 		return nil, errors.Errorf("matrix must be a map")
 	}
 	matrix := value.AsValueMap()

--- a/bake/hcl_test.go
+++ b/bake/hcl_test.go
@@ -1053,8 +1053,26 @@ func TestHCLMatrixBadTypes(t *testing.T) {
 
 	dt = []byte(`
 		target "default" {
+			matrix = ["test"]
+		}
+		`)
+	_, err = ParseFile(dt, "docker-bake.hcl")
+	require.Error(t, err)
+
+	dt = []byte(`
+		target "default" {
 			matrix = {
 				["a"] = ["b"]
+			}
+		}
+		`)
+	_, err = ParseFile(dt, "docker-bake.hcl")
+	require.Error(t, err)
+
+	dt = []byte(`
+		target "default" {
+			matrix = {
+				1 = 2
 			}
 		}
 		`)


### PR DESCRIPTION
:hammer_and_wrench: Fixes https://github.com/docker/buildx/issues/1721

The docs for `CanIterateElements` aren't quite correct - `AsValueMap` also needs to be able to convert each key into a string. All HCL maps have string keys, so this is fine, but we should explicitly ignore lists, even though you can iterate them (because they have int keys).