### PR TITLE
cli: add shell completion

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -85,6 +85,21 @@ func ReadLocalFiles(names []string) ([]File, error) {
 	return out, nil
 }
 
+func ListTargets(files []File) ([]string, error) {
+	c, err := ParseFiles(files, nil)
+	if err != nil {
+		return nil, err
+	}
+	var targets []string
+	for _, g := range c.Groups {
+		targets = append(targets, g.Name)
+	}
+	for _, t := range c.Targets {
+		targets = append(targets, t.Name)
+	}
+	return dedupSlice(targets), nil
+}
+
 func ReadTargets(ctx context.Context, files []File, targets, overrides []string, defaults map[string]string) (map[string]*Target, map[string]*Group, error) {
 	c, err := ParseFiles(files, defaults)
 	if err != nil {

--- a/commands/bake.go
+++ b/commands/bake.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/buildx/build"
 	"github.com/docker/buildx/builder"
 	"github.com/docker/buildx/util/buildflags"
+	"github.com/docker/buildx/util/cobrautil/completion"
 	"github.com/docker/buildx/util/confutil"
 	"github.com/docker/buildx/util/dockerutil"
 	"github.com/docker/buildx/util/progress"
@@ -230,6 +231,7 @@ func bakeCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 			// Other common flags (noCache, pull and progress) are processed in runBake function.
 			return runBake(dockerCli, args, options, cFlags)
 		},
+		ValidArgsFunction: completion.BakeTargets(options.files),
 	}
 
 	flags := cmd.Flags()

--- a/commands/build.go
+++ b/commands/build.go
@@ -23,7 +23,6 @@ import (
 	"github.com/docker/buildx/store"
 	"github.com/docker/buildx/store/storeutil"
 	"github.com/docker/buildx/util/buildflags"
-	"github.com/docker/buildx/util/cobrautil/completion"
 	"github.com/docker/buildx/util/ioset"
 	"github.com/docker/buildx/util/progress"
 	"github.com/docker/buildx/util/tracing"
@@ -254,7 +253,9 @@ func buildCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 			}
 			return runBuild(dockerCli, options)
 		},
-		ValidArgsFunction: completion.Disable,
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return nil, cobra.ShellCompDirectiveFilterDirs
+		},
 	}
 
 	var platformsDefault []string

--- a/commands/build.go
+++ b/commands/build.go
@@ -23,6 +23,7 @@ import (
 	"github.com/docker/buildx/store"
 	"github.com/docker/buildx/store/storeutil"
 	"github.com/docker/buildx/util/buildflags"
+	"github.com/docker/buildx/util/cobrautil/completion"
 	"github.com/docker/buildx/util/ioset"
 	"github.com/docker/buildx/util/progress"
 	"github.com/docker/buildx/util/tracing"
@@ -253,6 +254,7 @@ func buildCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 			}
 			return runBuild(dockerCli, options)
 		},
+		ValidArgsFunction: completion.Disable,
 	}
 
 	var platformsDefault []string

--- a/commands/create.go
+++ b/commands/create.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/buildx/store"
 	"github.com/docker/buildx/store/storeutil"
 	"github.com/docker/buildx/util/cobrautil"
+	"github.com/docker/buildx/util/cobrautil/completion"
 	"github.com/docker/buildx/util/confutil"
 	"github.com/docker/buildx/util/dockerutil"
 	"github.com/docker/cli/cli"
@@ -319,6 +320,7 @@ func createCmd(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCreate(dockerCli, options, args)
 		},
+		ValidArgsFunction: completion.Disable,
 	}
 
 	flags := cmd.Flags()

--- a/commands/diskusage.go
+++ b/commands/diskusage.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/docker/buildx/builder"
+	"github.com/docker/buildx/util/cobrautil/completion"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/opts"
@@ -115,6 +116,7 @@ func duCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 			options.builder = rootOpts.builder
 			return runDiskUsage(dockerCli, options)
 		},
+		ValidArgsFunction: completion.Disable,
 	}
 
 	flags := cmd.Flags()

--- a/commands/imagetools/create.go
+++ b/commands/imagetools/create.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/docker/buildx/builder"
+	"github.com/docker/buildx/util/cobrautil/completion"
 	"github.com/docker/buildx/util/imagetools"
 	"github.com/docker/buildx/util/progress"
 	"github.com/docker/cli/cli/command"
@@ -273,6 +274,7 @@ func createCmd(dockerCli command.Cli, opts RootOptions) *cobra.Command {
 			options.builder = *opts.Builder
 			return runCreate(dockerCli, options, args)
 		},
+		ValidArgsFunction: completion.Disable,
 	}
 
 	flags := cmd.Flags()

--- a/commands/imagetools/inspect.go
+++ b/commands/imagetools/inspect.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"github.com/docker/buildx/builder"
+	"github.com/docker/buildx/util/cobrautil/completion"
 	"github.com/docker/buildx/util/imagetools"
 	"github.com/docker/cli-docs-tool/annotation"
 	"github.com/docker/cli/cli"
@@ -52,6 +53,7 @@ func inspectCmd(dockerCli command.Cli, rootOpts RootOptions) *cobra.Command {
 			options.builder = *rootOpts.Builder
 			return runInspect(dockerCli, options, args[0])
 		},
+		ValidArgsFunction: completion.Disable,
 	}
 
 	flags := cmd.Flags()

--- a/commands/imagetools/root.go
+++ b/commands/imagetools/root.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"github.com/docker/buildx/util/cobrautil/completion"
 	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
 )
@@ -11,8 +12,9 @@ type RootOptions struct {
 
 func RootCmd(dockerCli command.Cli, opts RootOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "imagetools",
-		Short: "Commands to work on images in registry",
+		Use:               "imagetools",
+		Short:             "Commands to work on images in registry",
+		ValidArgsFunction: completion.Disable,
 	}
 
 	cmd.AddCommand(

--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -113,7 +113,7 @@ func inspectCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 			}
 			return runInspect(dockerCli, options)
 		},
-		ValidArgsFunction: completion.Disable,
+		ValidArgsFunction: completion.BuilderNames(dockerCli),
 	}
 
 	flags := cmd.Flags()

--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/docker/buildx/builder"
+	"github.com/docker/buildx/util/cobrautil/completion"
 	"github.com/docker/buildx/util/platformutil"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
@@ -112,6 +113,7 @@ func inspectCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 			}
 			return runInspect(dockerCli, options)
 		},
+		ValidArgsFunction: completion.Disable,
 	}
 
 	flags := cmd.Flags()

--- a/commands/install.go
+++ b/commands/install.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/docker/buildx/util/cobrautil"
+	"github.com/docker/buildx/util/cobrautil/completion"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/config"
@@ -46,7 +47,8 @@ func installCmd(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runInstall(dockerCli, options)
 		},
-		Hidden: true,
+		Hidden:            true,
+		ValidArgsFunction: completion.Disable,
 	}
 
 	// hide builder persistent flag for this command

--- a/commands/ls.go
+++ b/commands/ls.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/buildx/builder"
 	"github.com/docker/buildx/store/storeutil"
 	"github.com/docker/buildx/util/cobrautil"
+	"github.com/docker/buildx/util/cobrautil/completion"
 	"github.com/docker/buildx/util/platformutil"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
@@ -126,6 +127,7 @@ func lsCmd(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runLs(dockerCli, options)
 		},
+		ValidArgsFunction: completion.Disable,
 	}
 
 	// hide builder persistent flag for this command

--- a/commands/prune.go
+++ b/commands/prune.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/docker/buildx/builder"
+	"github.com/docker/buildx/util/cobrautil/completion"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/opts"
@@ -139,6 +140,7 @@ func pruneCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 			options.builder = rootOpts.builder
 			return runPrune(dockerCli, options)
 		},
+		ValidArgsFunction: completion.Disable,
 	}
 
 	flags := cmd.Flags()

--- a/commands/rm.go
+++ b/commands/rm.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/buildx/builder"
 	"github.com/docker/buildx/store"
 	"github.com/docker/buildx/store/storeutil"
+	"github.com/docker/buildx/util/cobrautil/completion"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/moby/buildkit/util/appcontext"
@@ -92,6 +93,7 @@ func rmCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 			}
 			return runRm(dockerCli, options)
 		},
+		ValidArgsFunction: completion.Disable,
 	}
 
 	flags := cmd.Flags()

--- a/commands/rm.go
+++ b/commands/rm.go
@@ -93,7 +93,7 @@ func rmCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 			}
 			return runRm(dockerCli, options)
 		},
-		ValidArgsFunction: completion.Disable,
+		ValidArgsFunction: completion.BuilderNames(dockerCli),
 	}
 
 	flags := cmd.Flags()

--- a/commands/root.go
+++ b/commands/root.go
@@ -5,6 +5,7 @@ import (
 
 	imagetoolscmd "github.com/docker/buildx/commands/imagetools"
 	"github.com/docker/buildx/controller/remote"
+	"github.com/docker/buildx/util/cobrautil/completion"
 	"github.com/docker/buildx/util/logutil"
 	"github.com/docker/cli-docs-tool/annotation"
 	"github.com/docker/cli/cli"
@@ -93,6 +94,11 @@ func addCommands(cmd *cobra.Command, dockerCli command.Cli) {
 	if isExperimental() {
 		remote.AddControllerCommands(cmd, dockerCli)
 	}
+
+	cmd.RegisterFlagCompletionFunc( //nolint:errcheck
+		"builder",
+		completion.BuilderNames(dockerCli),
+	)
 }
 
 func rootFlags(options *rootOptions, flags *pflag.FlagSet) {

--- a/commands/root.go
+++ b/commands/root.go
@@ -23,6 +23,9 @@ func NewRootCmd(name string, isPlugin bool, dockerCli command.Cli) *cobra.Comman
 		Annotations: map[string]string{
 			annotation.CodeDelimiter: `"`,
 		},
+		CompletionOptions: cobra.CompletionOptions{
+			HiddenDefaultCmd: true,
+		},
 	}
 	if isPlugin {
 		cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {

--- a/commands/stop.go
+++ b/commands/stop.go
@@ -47,7 +47,7 @@ func stopCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 			}
 			return runStop(dockerCli, options)
 		},
-		ValidArgsFunction: completion.Disable,
+		ValidArgsFunction: completion.BuilderNames(dockerCli),
 	}
 
 	return cmd

--- a/commands/stop.go
+++ b/commands/stop.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/docker/buildx/builder"
+	"github.com/docker/buildx/util/cobrautil/completion"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/moby/buildkit/util/appcontext"
@@ -46,6 +47,7 @@ func stopCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 			}
 			return runStop(dockerCli, options)
 		},
+		ValidArgsFunction: completion.Disable,
 	}
 
 	return cmd

--- a/commands/uninstall.go
+++ b/commands/uninstall.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/docker/buildx/util/cobrautil"
+	"github.com/docker/buildx/util/cobrautil/completion"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/config"
@@ -52,7 +53,8 @@ func uninstallCmd(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runUninstall(dockerCli, options)
 		},
-		Hidden: true,
+		Hidden:            true,
+		ValidArgsFunction: completion.Disable,
 	}
 
 	// hide builder persistent flag for this command

--- a/commands/use.go
+++ b/commands/use.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/docker/buildx/store/storeutil"
+	"github.com/docker/buildx/util/cobrautil/completion"
 	"github.com/docker/buildx/util/dockerutil"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
@@ -78,6 +79,7 @@ func useCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 			}
 			return runUse(dockerCli, options)
 		},
+		ValidArgsFunction: completion.Disable,
 	}
 
 	flags := cmd.Flags()

--- a/commands/use.go
+++ b/commands/use.go
@@ -79,7 +79,7 @@ func useCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 			}
 			return runUse(dockerCli, options)
 		},
-		ValidArgsFunction: completion.Disable,
+		ValidArgsFunction: completion.BuilderNames(dockerCli),
 	}
 
 	flags := cmd.Flags()

--- a/commands/version.go
+++ b/commands/version.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/docker/buildx/util/cobrautil"
+	"github.com/docker/buildx/util/cobrautil/completion"
 	"github.com/docker/buildx/version"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
@@ -23,6 +24,7 @@ func versionCmd(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runVersion(dockerCli)
 		},
+		ValidArgsFunction: completion.Disable,
 	}
 
 	// hide builder persistent flag for this command

--- a/util/cobrautil/completion/completion.go
+++ b/util/cobrautil/completion/completion.go
@@ -1,0 +1,12 @@
+package completion
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// ValidArgsFn defines a completion func to be returned to fetch completion options
+type ValidArgsFn func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)
+
+func Disable(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return nil, cobra.ShellCompDirectiveNoSpace
+}

--- a/util/cobrautil/completion/completion.go
+++ b/util/cobrautil/completion/completion.go
@@ -4,6 +4,9 @@ import (
 	"strings"
 
 	"github.com/docker/buildx/bake"
+	"github.com/docker/buildx/builder"
+	"github.com/docker/buildx/store/storeutil"
+	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
 )
 
@@ -31,6 +34,27 @@ func BakeTargets(files []string) ValidArgsFn {
 		for _, tgt := range tgts {
 			if strings.HasPrefix(tgt, toComplete) {
 				filtered = append(filtered, tgt)
+			}
+		}
+		return filtered, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+func BuilderNames(dockerCli command.Cli) ValidArgsFn {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		txn, release, err := storeutil.GetStore(dockerCli)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+		defer release()
+		builders, err := builder.GetBuilders(dockerCli, txn)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+		var filtered []string
+		for _, b := range builders {
+			if toComplete == "" || strings.HasPrefix(b.Name, toComplete) {
+				filtered = append(filtered, b.Name)
 			}
 		}
 		return filtered, cobra.ShellCompDirectiveNoFileComp


### PR DESCRIPTION
closes #1674 
partially solves #1072

Add completion to:
* List builder names for `--builder` persistent flag and as arg for some cmds
* Folders (context) for build command
* List bake targets

```
$ docker __completeNoDesc buildx --builder ""
builder
builder2
buildkit0106
buildkit093
remote-builder
default
desktop-linux
docker201016
docker2300
docker2400
:4
Completion ended with directive: ShellCompDirectiveNoFileComp
```

```
$ docker __completeNoDesc buildx --builder "do"
docker201016
docker2300
docker2400
:4
Completion ended with directive: ShellCompDirectiveNoFileComp
```

For bake, can be tested within this repo:

```
$ docker __completeNoDesc buildx ""
bake
build
create
du
help
imagetools
inspect
ls
prune
rm
stop
use
version
:4
Completion ended with directive: ShellCompDirectiveNoFileComp
```

```
$ docker __completeNoDesc buildx bake ""
default
validate
meta-helper
_common
lint
validate-vendor
validate-docs
validate-authors
validate-generated-files
update-vendor
update-docs
update-authors
update-generated-files
mod-outdated
test
binaries
binaries-cross
release
image
image-cross
image-local
:4
Completion ended with directive: ShellCompDirectiveNoFileComp
```

```
$ docker __completeNoDesc buildx bake "v"
validate
validate-vendor
validate-docs
validate-authors
validate-generated-files
:4
Completion ended with directive: ShellCompDirectiveNoFileComp
```