### PR TITLE
driver: update BuildKit version constraint for docker driver

### DIFF
--- a/driver/docker/version.go
+++ b/driver/docker/version.go
@@ -153,7 +153,7 @@ var mobyBuildkitVersions = []mobyBuildkitVersion{
 		BuildkitVersion:       "v0.10.6+4f0ee09",
 	},
 	{
-		MobyVersionConstraint: "23.0.2",
+		MobyVersionConstraint: ">= 23.0.2-0, < 23.0.4-0",
 		BuildkitVersion:       "v0.10.6+70f2ad5",
 	},
 	{

--- a/driver/docker/version_test.go
+++ b/driver/docker/version_test.go
@@ -105,7 +105,11 @@ func TestResolveBuildKitVersion(t *testing.T) {
 		},
 		{
 			mobyVersion: "23.0.2-rc.1",
-			expected:    "v0.10+unknown",
+			expected:    "v0.10.6+70f2ad5",
+		},
+		{
+			mobyVersion: "23.0.3",
+			expected:    "v0.10.6+70f2ad5",
 		},
 		{
 			mobyVersion: "23.0.4",


### PR DESCRIPTION
follow-up https://github.com/moby/moby/releases/tag/v23.0.3