### PR TITLE
builder: extra init error handling

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -108,7 +108,7 @@ func New(dockerCli command.Cli, opts ...Option) (_ *Builder, err error) {
 
 // Validate validates builder context
 func (b *Builder) Validate() error {
-	if b.NodeGroup.DockerContext {
+	if b.NodeGroup != nil && b.NodeGroup.DockerContext {
 		list, err := b.opts.dockerCli.ContextStore().List()
 		if err != nil {
 			return err

--- a/store/storeutil/storeutil.go
+++ b/store/storeutil/storeutil.go
@@ -61,7 +61,10 @@ func GetCurrentInstance(txn *store.Txn, dockerCli command.Cli) (*store.NodeGroup
 		return nil, err
 	}
 	if ng == nil {
-		ng, _ = GetNodeGroup(txn, dockerCli, dockerCli.CurrentContext())
+		ng, err = GetNodeGroup(txn, dockerCli, dockerCli.CurrentContext())
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return ng, nil


### PR DESCRIPTION
* Return errors from creating the `NodeGroup`
* Ensure that `b.NodeGroup != nil` before reading from it during validation

### Details
This was reported by a Compose user:
* docker/compose#10453