### PR TITLE
Various context fixups

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -1105,7 +1105,7 @@ func toBuildOpt(t *Target, inp *Input) (*build.Options, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(sshSpecs) == 0 && buildflags.IsGitSSH(contextPath) {
+	if len(sshSpecs) == 0 && (buildflags.IsGitSSH(bi.ContextPath) || (inp != nil && buildflags.IsGitSSH(inp.URL))) {
 		sshSpecs = append(sshSpecs, &controllerapi.SSH{ID: "default"})
 	}
 	sshAttachment, err := controllerapi.CreateSSH(sshSpecs)

--- a/commands/build.go
+++ b/commands/build.go
@@ -30,6 +30,7 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	dockeropts "github.com/docker/cli/opts"
+	"github.com/docker/docker/builder/remotecontext/urlutil"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
@@ -689,9 +690,11 @@ func resolvePaths(options *controllerapi.BuildOptions) (_ *controllerapi.BuildOp
 		}
 	}
 	if options.DockerfileName != "" && options.DockerfileName != "-" {
-		options.DockerfileName, err = filepath.Abs(options.DockerfileName)
-		if err != nil {
-			return nil, err
+		if !urlutil.IsURL(options.DockerfileName) {
+			options.DockerfileName, err = filepath.Abs(options.DockerfileName)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	var contexts map[string]string


### PR DESCRIPTION
:bug: More context bug fixes :tada:

See commit messages for more details.

1. Fixes resolving the context for remote bake files over SSH:

   ```
   $ docker buildx bake git@github.com:docker/buildx.git
   [+] Building 3.8s (2/2) FINISHED                                                                                                                                 docker-container:container
    => CACHED [internal] load git source git@github.com:docker/buildx.git                                                                                                                 3.2s
    => ERROR [internal] load git source git@github.com:docker/buildx.git                                                                                                                  0.0s 
   ------                                                                                                                                                                                      
   > [internal] load git source git@github.com:docker/buildx.git:
   ------
   ERROR: failed to solve: failed to read dockerfile: failed to load cache key: unset ssh forward key default
   ```

   https://github.com/docker/buildx/pull/1711 only fixed this for `--print`, we actually do two loads of the same context: one for bake to read the file, and another for the build to read the contents of the Dockerfile.

2. Fixes resolving dockerfile URLs for the controller:

   ```
   $ docker buildx build -f https://raw.githubusercontent.com/docker/buildx/master/hack/dockerfiles/lint.Dockerfile .
   INFO: connecting to buildx server
   INFO: no buildx server found; launching...
   [+] Building 0.0s (0/0)                                                                                                                                                                     
   ERROR: failed to build: rpc error: code = Unknown desc = could not find /home/jedevc/Documents/Docker/buildx/https:/raw.githubusercontent.com/docker/buildx/master/hack/dockerfiles: stat /home/jedevc/Documents/Docker/buildx/https:/raw.githubusercontent.com/docker/buildx/master/hack/dockerfiles: no such file or directory
   ```

   https://github.com/docker/buildx/pull/1701 only fixes this for the context path, I wasn't aware that the Dockerfile path is explicitly allowed to be an HTTP URL:

   https://github.com/docker/buildx/blob/672eeed9a627d578746438e2bd611772ed7f9288/build/build.go#L1314-L1323