### PR TITLE
controller: refactor progress api

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -920,7 +920,7 @@ func BuildWithResultHandler(ctx context.Context, nodes []builder.Node, opt map[s
 							}
 							results.Set(resultKey(dp.driverIndex, k), res)
 							if resultHandleFunc != nil {
-								resultCtx, err := NewResultContext(cc, so, res)
+								resultCtx, err := NewResultContext(ctx, cc, so, res)
 								if err == nil {
 									resultHandleFunc(dp.driverIndex, resultCtx)
 								} else {

--- a/build/result.go
+++ b/build/result.go
@@ -19,8 +19,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func NewResultContext(c *client.Client, solveOpt client.SolveOpt, res *gateway.Result) (*ResultContext, error) {
-	ctx := context.Background()
+func NewResultContext(ctx context.Context, c *client.Client, solveOpt client.SolveOpt, res *gateway.Result) (*ResultContext, error) {
 	def, err := getDefinition(ctx, res)
 	if err != nil {
 		return nil, err

--- a/commands/bake.go
+++ b/commands/bake.go
@@ -17,7 +17,6 @@ import (
 	"github.com/docker/buildx/util/tracing"
 	"github.com/docker/cli/cli/command"
 	"github.com/moby/buildkit/util/appcontext"
-	"github.com/moby/buildkit/util/progress/progressui"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -118,7 +117,7 @@ func runBake(dockerCli command.Cli, targets []string, in bakeOptions, cFlags com
 	}
 
 	printer, err := progress.NewPrinter(ctx2, os.Stderr, os.Stderr, cFlags.progress,
-		progressui.WithDesc(progressTextDesc, progressConsoleDesc),
+		progress.WithDesc(progressTextDesc, progressConsoleDesc),
 	)
 	if err != nil {
 		return err

--- a/commands/build.go
+++ b/commands/build.go
@@ -279,7 +279,7 @@ func runControllerBuild(ctx context.Context, dockerCli command.Cli, options buil
 		return nil, errors.Errorf("Dockerfile or context from stdin is not supported with invoke")
 	}
 
-	c, err := controller.NewController(ctx, options.ControlOptions, dockerCli)
+	c, err := controller.NewController(ctx, options.ControlOptions, dockerCli, printer)
 	if err != nil {
 		return nil, err
 	}

--- a/commands/debug-shell.go
+++ b/commands/debug-shell.go
@@ -25,8 +25,13 @@ func debugShellCmd(dockerCli command.Cli) *cobra.Command {
 		Use:   "debug-shell",
 		Short: "Start a monitor",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			printer, err := progress.NewPrinter(context.TODO(), os.Stderr, os.Stderr, progressMode)
+			if err != nil {
+				return err
+			}
+
 			ctx := context.TODO()
-			c, err := controller.NewController(ctx, options, dockerCli)
+			c, err := controller.NewController(ctx, options, dockerCli, printer)
 			if err != nil {
 				return err
 			}
@@ -38,11 +43,6 @@ func debugShellCmd(dockerCli command.Cli) *cobra.Command {
 			con := console.Current()
 			if err := con.SetRaw(); err != nil {
 				return errors.Errorf("failed to configure terminal: %v", err)
-			}
-
-			printer, err := progress.NewPrinter(context.TODO(), os.Stderr, os.Stderr, progressMode)
-			if err != nil {
-				return err
 			}
 
 			err = monitor.RunMonitor(ctx, "", nil, controllerapi.InvokeConfig{

--- a/commands/debug-shell.go
+++ b/commands/debug-shell.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/buildx/controller/control"
 	controllerapi "github.com/docker/buildx/controller/pb"
 	"github.com/docker/buildx/monitor"
+	"github.com/docker/buildx/util/progress"
 	"github.com/docker/cli/cli/command"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -18,7 +19,7 @@ import (
 
 func debugShellCmd(dockerCli command.Cli) *cobra.Command {
 	var options control.ControlOptions
-	var progress string
+	var progressMode string
 
 	cmd := &cobra.Command{
 		Use:   "debug-shell",
@@ -38,9 +39,15 @@ func debugShellCmd(dockerCli command.Cli) *cobra.Command {
 			if err := con.SetRaw(); err != nil {
 				return errors.Errorf("failed to configure terminal: %v", err)
 			}
+
+			printer, err := progress.NewPrinter(context.TODO(), os.Stderr, os.Stderr, progressMode)
+			if err != nil {
+				return err
+			}
+
 			err = monitor.RunMonitor(ctx, "", nil, controllerapi.InvokeConfig{
 				Tty: true,
-			}, c, progress, os.Stdin, os.Stdout, os.Stderr)
+			}, c, os.Stdin, os.Stdout, os.Stderr, printer)
 			con.Reset()
 			return err
 		},
@@ -51,7 +58,7 @@ func debugShellCmd(dockerCli command.Cli) *cobra.Command {
 	flags.StringVar(&options.Root, "root", "", "Specify root directory of server to connect [experimental]")
 	flags.BoolVar(&options.Detach, "detach", runtime.GOOS == "linux", "Detach buildx server (supported only on linux) [experimental]")
 	flags.StringVar(&options.ServerConfig, "server-config", "", "Specify buildx server config file (used only when launching new server) [experimental]")
-	flags.StringVar(&progress, "progress", "auto", `Set type of progress output ("auto", "plain", "tty"). Use plain to show container output`)
+	flags.StringVar(&progressMode, "progress", "auto", `Set type of progress output ("auto", "plain", "tty"). Use plain to show container output`)
 
 	return cmd
 }

--- a/controller/control/controller.go
+++ b/controller/control/controller.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"io"
 
-	"github.com/containerd/console"
 	controllerapi "github.com/docker/buildx/controller/pb"
+	"github.com/docker/buildx/util/progress"
 	"github.com/moby/buildkit/client"
 )
 
 type BuildxController interface {
-	Build(ctx context.Context, options controllerapi.BuildOptions, in io.ReadCloser, w io.Writer, out console.File, progressMode string) (ref string, resp *client.SolveResponse, err error)
+	Build(ctx context.Context, options controllerapi.BuildOptions, in io.ReadCloser, progress progress.Writer) (ref string, resp *client.SolveResponse, err error)
 	// Invoke starts an IO session into the specified process.
 	// If pid doesn't matche to any running processes, it starts a new process with the specified config.
 	// If there is no container running or InvokeConfig.Rollback is speicfied, the process will start in a newly created container.

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -2,26 +2,35 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/docker/buildx/controller/control"
 	"github.com/docker/buildx/controller/local"
 	"github.com/docker/buildx/controller/remote"
+	"github.com/docker/buildx/util/progress"
 	"github.com/docker/cli/cli/command"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
-func NewController(ctx context.Context, opts control.ControlOptions, dockerCli command.Cli) (c control.BuildxController, err error) {
-	if !opts.Detach {
-		logrus.Infof("launching local buildx controller")
-		c = local.NewLocalBuildxController(ctx, dockerCli)
-		return c, nil
+func NewController(ctx context.Context, opts control.ControlOptions, dockerCli command.Cli, pw progress.Writer) (control.BuildxController, error) {
+	var name string
+	if opts.Detach {
+		name = "remote"
+	} else {
+		name = "local"
 	}
 
-	logrus.Infof("connecting to buildx server")
-	c, err = remote.NewRemoteBuildxController(ctx, dockerCli, opts)
+	var c control.BuildxController
+	err := progress.Wrap(fmt.Sprintf("[internal] connecting to %s controller", name), pw.Write, func(l progress.SubLogger) (err error) {
+		if opts.Detach {
+			c, err = remote.NewRemoteBuildxController(ctx, dockerCli, opts, l)
+		} else {
+			c = local.NewLocalBuildxController(ctx, dockerCli, l)
+		}
+		return err
+	})
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to use buildx server; use --detach=false")
+		return nil, errors.Wrap(err, "failed to start buildx controller")
 	}
 	return c, nil
 }

--- a/controller/local/controller.go
+++ b/controller/local/controller.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"sync/atomic"
 
-	"github.com/containerd/console"
 	"github.com/docker/buildx/build"
 	cbuild "github.com/docker/buildx/controller/build"
 	"github.com/docker/buildx/controller/control"
@@ -13,6 +12,7 @@ import (
 	controllerapi "github.com/docker/buildx/controller/pb"
 	"github.com/docker/buildx/controller/processes"
 	"github.com/docker/buildx/util/ioset"
+	"github.com/docker/buildx/util/progress"
 	"github.com/docker/cli/cli/command"
 	"github.com/moby/buildkit/client"
 	"github.com/pkg/errors"
@@ -42,13 +42,13 @@ type localController struct {
 	buildOnGoing atomic.Bool
 }
 
-func (b *localController) Build(ctx context.Context, options controllerapi.BuildOptions, in io.ReadCloser, w io.Writer, out console.File, progressMode string) (string, *client.SolveResponse, error) {
+func (b *localController) Build(ctx context.Context, options controllerapi.BuildOptions, in io.ReadCloser, progress progress.Writer) (string, *client.SolveResponse, error) {
 	if !b.buildOnGoing.CompareAndSwap(false, true) {
 		return "", nil, errors.New("build ongoing")
 	}
 	defer b.buildOnGoing.Store(false)
 
-	resp, res, buildErr := cbuild.RunBuild(ctx, b.dockerCli, options, in, progressMode, nil, true)
+	resp, res, buildErr := cbuild.RunBuild(ctx, b.dockerCli, options, in, progress, true)
 	// NOTE: RunBuild can return *build.ResultContext even on error.
 	if res != nil {
 		b.buildConfig = buildConfig{

--- a/controller/local/controller.go
+++ b/controller/local/controller.go
@@ -18,7 +18,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func NewLocalBuildxController(ctx context.Context, dockerCli command.Cli) control.BuildxController {
+func NewLocalBuildxController(ctx context.Context, dockerCli command.Cli, logger progress.SubLogger) control.BuildxController {
 	return &localController{
 		dockerCli: dockerCli,
 		ref:       "local",

--- a/controller/pb/progress.go
+++ b/controller/pb/progress.go
@@ -1,0 +1,102 @@
+package pb
+
+import (
+	control "github.com/moby/buildkit/api/services/control"
+	"github.com/moby/buildkit/client"
+)
+
+func ToControlStatus(s *client.SolveStatus) *StatusResponse {
+	resp := StatusResponse{}
+	for _, v := range s.Vertexes {
+		resp.Vertexes = append(resp.Vertexes, &control.Vertex{
+			Digest:        v.Digest,
+			Inputs:        v.Inputs,
+			Name:          v.Name,
+			Started:       v.Started,
+			Completed:     v.Completed,
+			Error:         v.Error,
+			Cached:        v.Cached,
+			ProgressGroup: v.ProgressGroup,
+		})
+	}
+	for _, v := range s.Statuses {
+		resp.Statuses = append(resp.Statuses, &control.VertexStatus{
+			ID:        v.ID,
+			Vertex:    v.Vertex,
+			Name:      v.Name,
+			Total:     v.Total,
+			Current:   v.Current,
+			Timestamp: v.Timestamp,
+			Started:   v.Started,
+			Completed: v.Completed,
+		})
+	}
+	for _, v := range s.Logs {
+		resp.Logs = append(resp.Logs, &control.VertexLog{
+			Vertex:    v.Vertex,
+			Stream:    int64(v.Stream),
+			Msg:       v.Data,
+			Timestamp: v.Timestamp,
+		})
+	}
+	for _, v := range s.Warnings {
+		resp.Warnings = append(resp.Warnings, &control.VertexWarning{
+			Vertex: v.Vertex,
+			Level:  int64(v.Level),
+			Short:  v.Short,
+			Detail: v.Detail,
+			Url:    v.URL,
+			Info:   v.SourceInfo,
+			Ranges: v.Range,
+		})
+	}
+	return &resp
+}
+
+func FromControlStatus(resp *StatusResponse) *client.SolveStatus {
+	s := client.SolveStatus{}
+	for _, v := range resp.Vertexes {
+		s.Vertexes = append(s.Vertexes, &client.Vertex{
+			Digest:        v.Digest,
+			Inputs:        v.Inputs,
+			Name:          v.Name,
+			Started:       v.Started,
+			Completed:     v.Completed,
+			Error:         v.Error,
+			Cached:        v.Cached,
+			ProgressGroup: v.ProgressGroup,
+		})
+	}
+	for _, v := range resp.Statuses {
+		s.Statuses = append(s.Statuses, &client.VertexStatus{
+			ID:        v.ID,
+			Vertex:    v.Vertex,
+			Name:      v.Name,
+			Total:     v.Total,
+			Current:   v.Current,
+			Timestamp: v.Timestamp,
+			Started:   v.Started,
+			Completed: v.Completed,
+		})
+	}
+	for _, v := range resp.Logs {
+		s.Logs = append(s.Logs, &client.VertexLog{
+			Vertex:    v.Vertex,
+			Stream:    int(v.Stream),
+			Data:      v.Msg,
+			Timestamp: v.Timestamp,
+		})
+	}
+	for _, v := range resp.Warnings {
+		s.Warnings = append(s.Warnings, &client.VertexWarning{
+			Vertex:     v.Vertex,
+			Level:      int(v.Level),
+			Short:      v.Short,
+			Detail:     v.Detail,
+			URL:        v.Url,
+			SourceInfo: v.Info,
+			Range:      v.Ranges,
+		})
+	}
+	return &s
+}

--- a/controller/pb/progress.go
+++ b/controller/pb/progress.go
@@ -1,9 +1,29 @@
 package pb
 
 import (
+	"github.com/docker/buildx/util/progress"
 	control "github.com/moby/buildkit/api/services/control"
 	"github.com/moby/buildkit/client"
+	"github.com/opencontainers/go-digest"
 )
+
+type writer struct {
+	ch chan<- *StatusResponse
+}
+
+func NewProgressWriter(ch chan<- *StatusResponse) progress.Writer {
+	return &writer{ch: ch}
+}
+
+func (w *writer) Write(status *client.SolveStatus) {
+	w.ch <- ToControlStatus(status)
+}
+
+func (w *writer) ValidateLogSource(digest.Digest, interface{}) bool {
+	return true
+}
+
+func (w *writer) ClearLogSource(interface{}) {}
 
 func ToControlStatus(s *client.SolveStatus) *StatusResponse {
 	resp := StatusResponse{}

--- a/controller/remote/client.go
+++ b/controller/remote/client.go
@@ -180,51 +180,7 @@ func (c *Client) build(ctx context.Context, ref string, options pb.BuildOptions,
 				}
 				return errors.Wrap(err, "failed to receive status")
 			}
-			s := client.SolveStatus{}
-			for _, v := range resp.Vertexes {
-				s.Vertexes = append(s.Vertexes, &client.Vertex{
-					Digest:        v.Digest,
-					Inputs:        v.Inputs,
-					Name:          v.Name,
-					Started:       v.Started,
-					Completed:     v.Completed,
-					Error:         v.Error,
-					Cached:        v.Cached,
-					ProgressGroup: v.ProgressGroup,
-				})
-			}
-			for _, v := range resp.Statuses {
-				s.Statuses = append(s.Statuses, &client.VertexStatus{
-					ID:        v.ID,
-					Vertex:    v.Vertex,
-					Name:      v.Name,
-					Total:     v.Total,
-					Current:   v.Current,
-					Timestamp: v.Timestamp,
-					Started:   v.Started,
-					Completed: v.Completed,
-				})
-			}
-			for _, v := range resp.Logs {
-				s.Logs = append(s.Logs, &client.VertexLog{
-					Vertex:    v.Vertex,
-					Stream:    int(v.Stream),
-					Data:      v.Msg,
-					Timestamp: v.Timestamp,
-				})
-			}
-			for _, v := range resp.Warnings {
-				s.Warnings = append(s.Warnings, &client.VertexWarning{
-					Vertex:     v.Vertex,
-					Level:      int(v.Level),
-					Short:      v.Short,
-					Detail:     v.Detail,
-					URL:        v.Url,
-					SourceInfo: v.Info,
-					Range:      v.Ranges,
-				})
-			}
-			statusChan <- &s
+			statusChan <- pb.FromControlStatus(resp)
 		}
 	})
 	if in != nil {

--- a/controller/remote/controller.go
+++ b/controller/remote/controller.go
@@ -21,6 +21,7 @@ import (
 	"github.com/docker/buildx/controller/control"
 	controllerapi "github.com/docker/buildx/controller/pb"
 	"github.com/docker/buildx/util/confutil"
+	"github.com/docker/buildx/util/progress"
 	"github.com/docker/buildx/version"
 	"github.com/docker/cli/cli/command"
 	"github.com/moby/buildkit/client"
@@ -142,8 +143,8 @@ func serveCmd(dockerCli command.Cli) *cobra.Command {
 			}()
 
 			// prepare server
-			b := NewServer(func(ctx context.Context, options *controllerapi.BuildOptions, stdin io.Reader, statusChan chan *client.SolveStatus) (*client.SolveResponse, *build.ResultContext, error) {
-				return cbuild.RunBuild(ctx, dockerCli, *options, stdin, "quiet", statusChan, true)
+			b := NewServer(func(ctx context.Context, options *controllerapi.BuildOptions, stdin io.Reader, progress progress.Writer) (*client.SolveResponse, *build.ResultContext, error) {
+				return cbuild.RunBuild(ctx, dockerCli, *options, stdin, progress, true)
 			})
 			defer b.Close()
 

--- a/controller/remote/controller.go
+++ b/controller/remote/controller.go
@@ -54,7 +54,7 @@ type serverConfig struct {
 	LogFile string `toml:"log_file"`
 }
 
-func NewRemoteBuildxController(ctx context.Context, dockerCli command.Cli, opts control.ControlOptions) (control.BuildxController, error) {
+func NewRemoteBuildxController(ctx context.Context, dockerCli command.Cli, opts control.ControlOptions, logger progress.SubLogger) (control.BuildxController, error) {
 	rootDir := opts.Root
 	if rootDir == "" {
 		rootDir = rootDataDir(dockerCli)
@@ -74,27 +74,32 @@ func NewRemoteBuildxController(ctx context.Context, dockerCli command.Cli, opts 
 	}
 
 	// start buildx server via subcommand
-	logrus.Info("no buildx server found; launching...")
-	launchFlags := []string{}
-	if opts.ServerConfig != "" {
-		launchFlags = append(launchFlags, "--config", opts.ServerConfig)
-	}
-	logFile, err := getLogFilePath(dockerCli, opts.ServerConfig)
-	if err != nil {
-		return nil, err
-	}
-	wait, err := launch(ctx, logFile, append([]string{serveCommandName}, launchFlags...)...)
-	if err != nil {
-		return nil, err
-	}
-	go wait()
+	err = logger.Wrap("no buildx server found; launching...", func() error {
+		launchFlags := []string{}
+		if opts.ServerConfig != "" {
+			launchFlags = append(launchFlags, "--config", opts.ServerConfig)
+		}
+		logFile, err := getLogFilePath(dockerCli, opts.ServerConfig)
+		if err != nil {
+			return err
+		}
+		wait, err := launch(ctx, logFile, append([]string{serveCommandName}, launchFlags...)...)
+		if err != nil {
+			return err
+		}
+		go wait()
 
-	// wait for buildx server to be ready
-	ctx2, cancel = context.WithTimeout(ctx, 10*time.Second)
-	c, err = newBuildxClientAndCheck(ctx2, filepath.Join(serverRoot, defaultSocketFilename))
-	cancel()
+		// wait for buildx server to be ready
+		ctx2, cancel = context.WithTimeout(ctx, 10*time.Second)
+		c, err = newBuildxClientAndCheck(ctx2, filepath.Join(serverRoot, defaultSocketFilename))
+		cancel()
+		if err != nil {
+			return errors.Wrap(err, "cannot connect to the buildx server")
+		}
+		return nil
+	})
 	if err != nil {
-		return nil, errors.Wrap(err, "cannot connect to the buildx server")
+		return nil, err
 	}
 	return &buildxController{c, serverRoot}, nil
 }

--- a/controller/remote/controller_nolinux.go
+++ b/controller/remote/controller_nolinux.go
@@ -6,12 +6,13 @@ import (
 	"context"
 
 	"github.com/docker/buildx/controller/control"
+	"github.com/docker/buildx/util/progress"
 	"github.com/docker/cli/cli/command"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
-func NewRemoteBuildxController(ctx context.Context, dockerCli command.Cli, opts control.ControlOptions) (control.BuildxController, error) {
+func NewRemoteBuildxController(ctx context.Context, dockerCli command.Cli, opts control.ControlOptions, logger progress.SubLogger) (control.BuildxController, error) {
 	return nil, errors.New("remote buildx unsupported")
 }
 

--- a/controller/remote/server.go
+++ b/controller/remote/server.go
@@ -13,7 +13,6 @@ import (
 	"github.com/docker/buildx/controller/processes"
 	"github.com/docker/buildx/util/ioset"
 	"github.com/docker/buildx/version"
-	controlapi "github.com/moby/buildkit/api/services/control"
 	"github.com/moby/buildkit/client"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
@@ -256,8 +255,7 @@ func (m *Server) Status(req *pb.StatusRequest, stream pb.Controller_StatusServer
 		if ss == nil {
 			break
 		}
-		cs := toControlStatus(ss)
-		if err := stream.Send(cs); err != nil {
+		if err := stream.Send(pb.ToControlStatus(ss)); err != nil {
 			return err
 		}
 	}
@@ -436,52 +434,4 @@ func (m *Server) Invoke(srv pb.Controller_InvokeServer) error {
 	})
 
 	return eg.Wait()
-}
-
-func toControlStatus(s *client.SolveStatus) *pb.StatusResponse {
-	resp := pb.StatusResponse{}
-	for _, v := range s.Vertexes {
-		resp.Vertexes = append(resp.Vertexes, &controlapi.Vertex{
-			Digest:        v.Digest,
-			Inputs:        v.Inputs,
-			Name:          v.Name,
-			Started:       v.Started,
-			Completed:     v.Completed,
-			Error:         v.Error,
-			Cached:        v.Cached,
-			ProgressGroup: v.ProgressGroup,
-		})
-	}
-	for _, v := range s.Statuses {
-		resp.Statuses = append(resp.Statuses, &controlapi.VertexStatus{
-			ID:        v.ID,
-			Vertex:    v.Vertex,
-			Name:      v.Name,
-			Total:     v.Total,
-			Current:   v.Current,
-			Timestamp: v.Timestamp,
-			Started:   v.Started,
-			Completed: v.Completed,
-		})
-	}
-	for _, v := range s.Logs {
-		resp.Logs = append(resp.Logs, &controlapi.VertexLog{
-			Vertex:    v.Vertex,
-			Stream:    int64(v.Stream),
-			Msg:       v.Data,
-			Timestamp: v.Timestamp,
-		})
-	}
-	for _, v := range s.Warnings {
-		resp.Warnings = append(resp.Warnings, &controlapi.VertexWarning{
-			Vertex: v.Vertex,
-			Level:  int64(v.Level),
-			Short:  v.Short,
-			Detail: v.Detail,
-			Url:    v.URL,
-			Info:   v.SourceInfo,
-			Ranges: v.Range,
-		})
-	}
-	return &resp
 }


### PR DESCRIPTION
:hammer: Implements https://github.com/docker/buildx/pull/1671#discussion_r1155875282:

> We should create the progress printer outside of each controller call, and pass it into the interface. Then we can lift printWarnings out of the controller entirely tada (should make things a bit neater).

:no_entry_sign: Replaces https://github.com/docker/buildx/pull/1671 (though this PR still doesn't fix the result printing, happy to do that once I get some initial thoughts on this approach)

Refactor the progress printer creation to the caller-side of the controller api. Then, instead of passing around status channels, we can simply pass around the higher level interface progress.Writer, which allows us to correctly pull warnings out of the remote controller.

WDYT @ktock?