### PR TITLE
build: avoid resolution of dockerfile if context is remote

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -681,8 +681,10 @@ func dockerUlimitToControllerUlimit(u *dockeropts.UlimitOpt) *controllerapi.Ulim
 // resolvePaths resolves all paths contained in controllerapi.BuildOptions
 // and replaces them to absolute paths.
 func resolvePaths(options *controllerapi.BuildOptions) (_ *controllerapi.BuildOptions, err error) {
+	localContext := false
 	if options.ContextPath != "" && options.ContextPath != "-" {
 		if !build.IsRemoteURL(options.ContextPath) {
+			localContext = true
 			options.ContextPath, err = filepath.Abs(options.ContextPath)
 			if err != nil {
 				return nil, err
@@ -690,13 +692,14 @@ func resolvePaths(options *controllerapi.BuildOptions) (_ *controllerapi.BuildOp
 		}
 	}
 	if options.DockerfileName != "" && options.DockerfileName != "-" {
-		if !urlutil.IsURL(options.DockerfileName) {
+		if localContext && !urlutil.IsURL(options.DockerfileName) {
 			options.DockerfileName, err = filepath.Abs(options.DockerfileName)
 			if err != nil {
 				return nil, err
 			}
 		}
 	}
+
 	var contexts map[string]string
 	for k, v := range options.NamedContexts {
 		if build.IsRemoteURL(v) || strings.HasPrefix(v, "docker-image://") {

--- a/commands/build_test.go
+++ b/commands/build_test.go
@@ -42,13 +42,18 @@ func TestResolvePaths(t *testing.T) {
 		},
 		{
 			name:    "dockerfilename",
-			options: controllerapi.BuildOptions{DockerfileName: "test"},
-			want:    controllerapi.BuildOptions{DockerfileName: filepath.Join(tmpwd, "test")},
+			options: controllerapi.BuildOptions{DockerfileName: "test", ContextPath: "."},
+			want:    controllerapi.BuildOptions{DockerfileName: filepath.Join(tmpwd, "test"), ContextPath: tmpwd},
 		},
 		{
 			name:    "dockerfilename-dash",
-			options: controllerapi.BuildOptions{DockerfileName: "-"},
-			want:    controllerapi.BuildOptions{DockerfileName: "-"},
+			options: controllerapi.BuildOptions{DockerfileName: "-", ContextPath: "."},
+			want:    controllerapi.BuildOptions{DockerfileName: "-", ContextPath: tmpwd},
+		},
+		{
+			name:    "dockerfilename-remote",
+			options: controllerapi.BuildOptions{DockerfileName: "test", ContextPath: "git@github.com:docker/buildx.git"},
+			want:    controllerapi.BuildOptions{DockerfileName: "test", ContextPath: "git@github.com:docker/buildx.git"},
 		},
 		{
 			name: "contexts",


### PR DESCRIPTION
In 566f41b598b350c2e92df69a4b8392863ae47faf, we added a check to ensure that we avoid resolving http URLs for Dockerfile. However, we have another circumstance we should not resolve the path in - if the context is a remote context, the dockerfile is resolved in that context (see build.go#LoadInputs for more information) :facepalm:

Therefore, we should only resolve the dockerfile to a local directory if the context is also resolved to a local directory.