### PR TITLE
controller: only capture the result when invoked through a controller

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -211,7 +211,7 @@ func runBuild(dockerCli command.Cli, in buildOptions) error {
 			return errors.Wrap(err, "removing image ID file")
 		}
 	}
-	resp, _, err := cbuild.RunBuild(ctx, dockerCli, opts, os.Stdin, progress, nil)
+	resp, _, err := cbuild.RunBuild(ctx, dockerCli, opts, os.Stdin, progress, nil, false)
 	if err != nil {
 		return err
 	}

--- a/controller/local/controller.go
+++ b/controller/local/controller.go
@@ -48,7 +48,7 @@ func (b *localController) Build(ctx context.Context, options controllerapi.Build
 	}
 	defer b.buildOnGoing.Store(false)
 
-	resp, res, buildErr := cbuild.RunBuild(ctx, b.dockerCli, options, in, progressMode, nil)
+	resp, res, buildErr := cbuild.RunBuild(ctx, b.dockerCli, options, in, progressMode, nil, true)
 	// NOTE: RunBuild can return *build.ResultContext even on error.
 	if res != nil {
 		b.buildConfig = buildConfig{

--- a/controller/remote/controller.go
+++ b/controller/remote/controller.go
@@ -143,7 +143,7 @@ func serveCmd(dockerCli command.Cli) *cobra.Command {
 
 			// prepare server
 			b := NewServer(func(ctx context.Context, options *controllerapi.BuildOptions, stdin io.Reader, statusChan chan *client.SolveStatus) (*client.SolveResponse, *build.ResultContext, error) {
-				return cbuild.RunBuild(ctx, dockerCli, *options, stdin, "quiet", statusChan)
+				return cbuild.RunBuild(ctx, dockerCli, *options, stdin, "quiet", statusChan, true)
 			})
 			defer b.Close()
 


### PR DESCRIPTION
This ensures that the code used to capture and evaluated a result is only executed when built through the controller. Otherwise, no build result should be recorded.

This ensures that new code added to capture and store the build result for debugging isn't used when BUILDX_EXPERIMENTAL is not set.

See https://github.com/docker/buildx/pull/1640#issuecomment-1513321529 for more information.

**This should be removed at some point in the future** - however, for now, we should have something like this to prevent breaking the state of master while we work on the debugging functionality.