### PR TITLE
bump go.mod to 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/docker/buildx
 
-go 1.19
+go 1.20
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.0


### PR DESCRIPTION
Basic interfaces satisfy 'comparable' starting with Go 1.20: 

https://github.com/docker/buildx/blob/afcaa8df5fdb9c8c908c8dae325d86a0f8f8c3ef/build/result.go#L32

https://github.com/docker/buildx/blob/afcaa8df5fdb9c8c908c8dae325d86a0f8f8c3ef/vendor/github.com/moby/buildkit/solver/result/result.go#L48