### PR TITLE
github: don't auto-add kind/ labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -2,7 +2,6 @@
 name: Bug Report
 description: Report a bug
 labels:
-  - kind/bug
   - status/triage
 
 body:


### PR DESCRIPTION
`kind` labels should only be manually added by maintainers after confirming the issue. Otherwise, it can be tricky to sort through all the issues when filtering for legitimate bugs.