### PR TITLE
debug: secondary client build should not reuse solve opts

### DIFF
--- a/build/result.go
+++ b/build/result.go
@@ -72,7 +72,7 @@ func getResultAt(ctx context.Context, c *client.Client, solveOpt client.SolveOpt
 	resultCtxCh := make(chan *ResultContext)
 	errCh := make(chan error)
 	go func() {
-		_, err := c.Build(context.Background(), solveOpt, "buildx", func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
+		_, err := c.Build(context.Background(), client.SolveOpt{}, "buildx", func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			resultCtx := ResultContext{}


### PR DESCRIPTION
Since #1735 merged, each solve opt cannot be re-used. In this case, we don't actually need to re-use the whole solve opt, and can just use the empty one (as we used to before #1640).

Without this, invoke doesn't work, and processes will never actually start in the target container.

This problem goes away with something like #1750, but since that is still in draft, we can do a quick fixup in the meantime.