### PR TITLE
docker: fix connection leak on features check

### DIFF
--- a/driver/docker/driver.go
+++ b/driver/docker/driver.go
@@ -69,6 +69,7 @@ func (d *Driver) Features() map[driver.Feature]bool {
 				useContainerdSnapshotter = true
 			}
 		}
+		c.Close()
 	}
 	return map[driver.Feature]bool{
 		driver.OCIExporter:    useContainerdSnapshotter,


### PR DESCRIPTION
The client created from the features request is left open, meaning a connection leak will happen if the docker driver is used as a library and a new instance of driver is created.

It would be better if a new client would not be created at all for this check, but the same client would be reused. I will follow-up with combining these but wanted to fix the issue first.