### PR TITLE
monitor: improve error messages

### DIFF
--- a/monitor/commands/attach.go
+++ b/monitor/commands/attach.go
@@ -25,7 +25,7 @@ func (cm *AttachCmd) Info() types.CommandInfo {
 
 func (cm *AttachCmd) Exec(ctx context.Context, args []string) error {
 	if len(args) < 2 {
-		return errors.Errorf("server name must be passed")
+		return errors.Errorf("ID of session or process must be passed")
 	}
 	ref := args[1]
 	var id string
@@ -58,7 +58,11 @@ func (cm *AttachCmd) Exec(ctx context.Context, args []string) error {
 }
 
 func isProcessID(ctx context.Context, c types.Monitor, ref string) (bool, error) {
-	infos, err := c.ListProcesses(ctx, c.AttachedSessionID())
+	sid := c.AttachedSessionID()
+	if sid == "" {
+		return false, errors.Errorf("no attaching session")
+	}
+	infos, err := c.ListProcesses(ctx, sid)
 	if err != nil {
 		return false, err
 	}

--- a/monitor/commands/disconnect.go
+++ b/monitor/commands/disconnect.go
@@ -23,10 +23,16 @@ func (cm *DisconnectCmd) Exec(ctx context.Context, args []string) error {
 	target := cm.m.AttachedSessionID()
 	if len(args) >= 2 {
 		target = args[1]
+	} else if target == "" {
+		return errors.Errorf("no attaching session")
 	}
 	isProcess, err := isProcessID(ctx, cm.m, target)
 	if err == nil && isProcess {
-		if err := cm.m.DisconnectProcess(ctx, cm.m.AttachedSessionID(), target); err != nil {
+		sid := cm.m.AttachedSessionID()
+		if sid == "" {
+			return errors.Errorf("no attaching session")
+		}
+		if err := cm.m.DisconnectProcess(ctx, sid, target); err != nil {
 			return errors.Errorf("disconnecting from process failed %v", target)
 		}
 		return nil

--- a/monitor/commands/ps.go
+++ b/monitor/commands/ps.go
@@ -7,6 +7,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/docker/buildx/monitor/types"
+	"github.com/pkg/errors"
 )
 
 type PsCmd struct {
@@ -24,6 +25,9 @@ func (cm *PsCmd) Info() types.CommandInfo {
 
 func (cm *PsCmd) Exec(ctx context.Context, args []string) error {
 	ref := cm.m.AttachedSessionID()
+	if ref == "" {
+		return errors.Errorf("no attaching session")
+	}
 	plist, err := cm.m.ListProcesses(ctx, ref)
 	if err != nil {
 		return err


### PR DESCRIPTION
following-up #1760

This PR fixes monitor to print more understandable messages on errors:

- When `ps` fails because the monitor doesn't attach to any session, print `no attaching session` instead of `unknown ref ""`.
- Avoid `disconnect` silently failing when the monitor doesn't attach to any session. Print `no attaching session` error instead.
- Fix error message of `attach`'s arguments. (`server name must be passed` -> `ID of session or process must be passed`)