### PR TITLE
kubernetes driver: add support for proxy-url

### DIFF
--- a/driver/kubernetes/context/load.go
+++ b/driver/kubernetes/context/load.go
@@ -19,6 +19,7 @@ import (
 type EndpointMeta struct {
 	context.EndpointMetaBase
 	DefaultNamespace string                           `json:",omitempty"`
+	ProxyURL         string                           `json:",omitempty"`
 	AuthProvider     *clientcmdapi.AuthProviderConfig `json:",omitempty"`
 	Exec             *clientcmdapi.ExecConfig         `json:",omitempty"`
 	UsernamePassword *UsernamePassword                `json:"usernamePassword,omitempty"`
@@ -62,6 +63,9 @@ func (c *Endpoint) KubernetesConfig() clientcmd.ClientConfig {
 	cfg := clientcmdapi.NewConfig()
 	cluster := clientcmdapi.NewCluster()
 	cluster.Server = c.Host
+	if c.ProxyURL != "" {
+		cluster.ProxyURL = c.ProxyURL
+	}
 	cluster.InsecureSkipTLSVerify = c.SkipTLSVerify
 	authInfo := clientcmdapi.NewAuthInfo()
 	if c.TLSData != nil {

--- a/driver/kubernetes/context/save.go
+++ b/driver/kubernetes/context/save.go
@@ -21,6 +21,17 @@ func FromKubeConfig(kubeconfig, kubeContext, namespaceOverride string) (Endpoint
 	if err != nil {
 		return Endpoint{}, err
 	}
+
+	var proxyURLString string
+	if clientcfg.Proxy != nil {
+		proxyURL, err := clientcfg.Proxy(nil)
+		if err != nil {
+			return Endpoint{}, err
+		}
+
+		proxyURLString = proxyURL.String()
+	}
+
 	var ca, key, cert []byte
 	if ca, err = readFileOrDefault(clientcfg.CAFile, clientcfg.CAData); err != nil {
 		return Endpoint{}, err
@@ -53,6 +64,7 @@ func FromKubeConfig(kubeconfig, kubeContext, namespaceOverride string) (Endpoint
 				SkipTLSVerify: clientcfg.Insecure,
 			},
 			DefaultNamespace: ns,
+			ProxyURL:         proxyURLString,
 			AuthProvider:     clientcfg.AuthProvider,
 			Exec:             clientcfg.ExecProvider,
 			UsernamePassword: usernamePassword,


### PR DESCRIPTION
Hi there :),
Sorry about the previous PR, I opened it prematurely before finalizing all tests, and preparing a proper PR 🙏.
Hopefully, I'm properly following your contribution guidelines, and if I need to change anything please LMK.

This PR attempts to add support in `kuberenetes driver` for `proxy-url` config in the `KUBECONFIG` file - 
[official docs here](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/#proxy).

The PR initializes the k8s client config created in `KubernetesConfig` receiver method with the right `proxy-url` parameter.

As a workaround, we were using `HTTPS_PROXY` env var, but that forces every request that `buildx` sends to use the same proxy as well.
This feature, allows **only** the traffic that goes to the k8s cluster (kubeapi) - to be routed via the proxy. 



Signed-off-by: Elran Shefer <elran.shefer@velocity.tech>