### PR TITLE
Support new compose features in bake

### DIFF
--- a/bake/compose.go
+++ b/bake/compose.go
@@ -75,6 +75,14 @@ func ParseCompose(cfgs []compose.ConfigFile, envs map[string]string) (*Config, e
 				dockerfileInlineP = &dockerfileInline
 			}
 
+			var additionalContexts map[string]string
+			if s.Build.AdditionalContexts != nil {
+				additionalContexts = map[string]string{}
+				for k, v := range s.Build.AdditionalContexts {
+					additionalContexts[k] = v
+				}
+			}
+
 			var secrets []string
 			for _, bs := range s.Build.Secrets {
 				secret, err := composeToBuildkitSecret(bs, cfg.Secrets[bs.Source])
@@ -95,6 +103,7 @@ func ParseCompose(cfgs []compose.ConfigFile, envs map[string]string) (*Config, e
 			t := &Target{
 				Name:             targetName,
 				Context:          contextPathP,
+				Contexts:         additionalContexts,
 				Dockerfile:       dockerfilePathP,
 				DockerfileInline: dockerfileInlineP,
 				Tags:             s.Build.Tags,

--- a/bake/compose.go
+++ b/bake/compose.go
@@ -69,6 +69,11 @@ func ParseCompose(cfgs []compose.ConfigFile, envs map[string]string) (*Config, e
 				dockerfilePath := s.Build.Dockerfile
 				dockerfilePathP = &dockerfilePath
 			}
+			var dockerfileInlineP *string
+			if s.Build.DockerfileInline != "" {
+				dockerfileInline := s.Build.DockerfileInline
+				dockerfileInlineP = &dockerfileInline
+			}
 
 			var secrets []string
 			for _, bs := range s.Build.Secrets {
@@ -88,11 +93,12 @@ func ParseCompose(cfgs []compose.ConfigFile, envs map[string]string) (*Config, e
 
 			g.Targets = append(g.Targets, targetName)
 			t := &Target{
-				Name:       targetName,
-				Context:    contextPathP,
-				Dockerfile: dockerfilePathP,
-				Tags:       s.Build.Tags,
-				Labels:     labels,
+				Name:             targetName,
+				Context:          contextPathP,
+				Dockerfile:       dockerfilePathP,
+				DockerfileInline: dockerfileInlineP,
+				Tags:             s.Build.Tags,
+				Labels:           labels,
 				Args: flatten(s.Build.Args.Resolve(func(val string) (string, bool) {
 					if val, ok := s.Environment[val]; ok && val != nil {
 						return *val, true

--- a/bake/compose_test.go
+++ b/bake/compose_test.go
@@ -21,6 +21,8 @@ services:
   webapp:
     build:
       context: ./dir
+      additional_contexts:
+        foo: /bar
       dockerfile: Dockerfile-alternate
       network:
         none
@@ -63,6 +65,7 @@ secrets:
 
 	require.Equal(t, "webapp", c.Targets[1].Name)
 	require.Equal(t, "./dir", *c.Targets[1].Context)
+	require.Equal(t, map[string]string{"foo": "/bar"}, c.Targets[1].Contexts)
 	require.Equal(t, "Dockerfile-alternate", *c.Targets[1].Dockerfile)
 	require.Equal(t, 1, len(c.Targets[1].Args))
 	require.Equal(t, ptrstr("123"), c.Targets[1].Args["buildno"])

--- a/bake/compose_test.go
+++ b/bake/compose_test.go
@@ -33,6 +33,11 @@ services:
       secrets:
         - token
         - aws
+  webapp2:
+    build:
+      context: ./dir
+      dockerfile_inline: |
+        FROM alpine
 secrets:
   token:
     environment: ENV_TOKEN
@@ -46,9 +51,9 @@ secrets:
 	require.Equal(t, 1, len(c.Groups))
 	require.Equal(t, "default", c.Groups[0].Name)
 	sort.Strings(c.Groups[0].Targets)
-	require.Equal(t, []string{"db", "webapp"}, c.Groups[0].Targets)
+	require.Equal(t, []string{"db", "webapp", "webapp2"}, c.Groups[0].Targets)
 
-	require.Equal(t, 2, len(c.Targets))
+	require.Equal(t, 3, len(c.Targets))
 	sort.Slice(c.Targets, func(i, j int) bool {
 		return c.Targets[i].Name < c.Targets[j].Name
 	})
@@ -68,6 +73,10 @@ secrets:
 		"id=token,env=ENV_TOKEN",
 		"id=aws,src=/root/.aws/credentials",
 	}, c.Targets[1].Secrets)
+
+	require.Equal(t, "webapp2", c.Targets[2].Name)
+	require.Equal(t, "./dir", *c.Targets[2].Context)
+	require.Equal(t, "FROM alpine\n", *c.Targets[2].DockerfileInline)
 }
 
 func TestNoBuildOutOfTreeService(t *testing.T) {


### PR DESCRIPTION
:arrow_up: Follow-up to https://github.com/docker/buildx/pull/1753 (cc @nicksieger)

[compose-go v1.13.0](https://github.com/compose-spec/compose-go/releases/tag/v1.13.0) supports the new `dockerfile_inline` and `additional_contexts` properties, so we should translate them to the relevant bake construct.

Will probably need an update in https://docs.docker.com/build/bake/compose-file/ after merging.