### PR TITLE
progress: make printer ready only after pausing logrus

### DIFF
--- a/util/progress/printer.go
+++ b/util/progress/printer.go
@@ -120,9 +120,8 @@ func NewPrinter(ctx context.Context, w io.Writer, out console.File, mode string,
 			pw.logSourceMap = map[digest.Digest]interface{}{}
 			pw.logMu.Unlock()
 
-			close(pw.ready)
-
 			resumeLogs := logutil.Pause(logrus.StandardLogger())
+			close(pw.ready)
 			// not using shared context to not disrupt display but let is finish reporting errors
 			pw.warnings, pw.err = progressui.DisplaySolveStatus(ctx, c, w, pw.status, opt.displayOpts...)
 			resumeLogs()


### PR DESCRIPTION
:arrow_up: Follow-up to #1737 (e826141af4bbd02872394b8ec1d1beb98b8c44f3)

This fixes a possible race where messages printed directly after calls to NewPrinter may appear before the printer starts. With this change, we delay all of the logs until after.

Example:

```
❯ docker buildx build . --target shell -t test --builder=dev
[+] Building 6.0s (26/26) FINISHED                                                                                            remote:dev
 => [internal] load build definition from Dockerfile                                                                                0.0s
 => => transferring dockerfile: 2.92kB                                                                                              0.0s
 => resolve image config for docker.io/docker/dockerfile:1                                                                          0.5s
 => CACHED docker-image://docker.io/docker/dockerfile:1@sha256:39b85bbfa7536a5feceb7372a0817649ecb2724562a38360f4d6a7782a409b14     0.0s
 => => resolve docker.io/docker/dockerfile:1@sha256:39b85bbfa7536a5feceb7372a0817649ecb2724562a38360f4d6a7782a409b14                0.0s
 => [internal] load .dockerignore                                                                                                   0.0s
 => => transferring context: 45B                                                                                                    0.0s
 => [internal] load metadata for docker.io/tonistiigi/xx:1.1.2                                                                      0.4s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                    0.5s
 => [internal] load metadata for docker.io/library/golang:1.20-alpine                                                               0.5s
 => [internal] load metadata for docker.io/library/docker:20.10.14                                                                  0.2s
 => [shell 1/9] FROM docker.io/library/alpine@sha256:02bb6f428431fbc2809c5d1b41eab5a68350194fb508869a33cb1af4444c9b11               0.0s
 => => resolve docker.io/library/alpine@sha256:02bb6f428431fbc2809c5d1b41eab5a68350194fb508869a33cb1af4444c9b11                     0.0s
 => [dockerd-release 1/1] FROM docker.io/library/docker:20.10.14@sha256:41978d1974f05f80e1aef23ac03040491a7e28bd4551d4b469b43e5583  0.0s
 => => resolve docker.io/library/docker:20.10.14@sha256:41978d1974f05f80e1aef23ac03040491a7e28bd4551d4b469b43e558341864e            0.0s
 => [internal] load build context                                                                                                   0.5s
 => => transferring context: 1.73MB                                                                                                 0.5s
 => [xx 1/1] FROM docker.io/tonistiigi/xx:1.1.2@sha256:9dde7edeb9e4a957ce78be9f8c0fbabe0129bf5126933cd3574888f443731cda             0.0s
 => => resolve docker.io/tonistiigi/xx:1.1.2@sha256:9dde7edeb9e4a957ce78be9f8c0fbabe0129bf5126933cd3574888f443731cda                0.0s
 => [golatest 1/1] FROM docker.io/library/golang:1.20-alpine@sha256:913de96707b0460bcfdfe422796bb6e559fc300f6c53286777805a9a3010a5  0.0s
 => => resolve docker.io/library/golang:1.20-alpine@sha256:913de96707b0460bcfdfe422796bb6e559fc300f6c53286777805a9a3010a5ea         0.0s
 => CACHED [gobase 1/3] COPY --from=xx / /                                                                                          0.0s
 => CACHED [gobase 2/3] RUN apk add --no-cache file git                                                                             0.0s
 => CACHED [gobase 3/3] WORKDIR /src                                                                                                0.0s
 => [buildx-version 1/1] RUN --mount=type=bind,target=. <<EOT (set -e...)                                                           0.3s
 => [buildx-build 1/1] RUN --mount=type=bind,target=.   --mount=type=cache,target=/root/.cache   --mount=type=cache,target=/go/pkg  3.4s 
 => CACHED [shell 2/9] RUN apk add --no-cache iptables tmux git vim less openssh                                                    0.0s 
 => CACHED [shell 3/9] RUN mkdir -p /usr/local/lib/docker/cli-plugins && ln -s /usr/local/bin/buildx /usr/local/lib/docker/cli-plu  0.0s 
 => CACHED [shell 4/9] COPY ./hack/demo-env/entrypoint.sh /usr/local/bin                                                            0.0s 
 => CACHED [shell 5/9] COPY ./hack/demo-env/tmux.conf /root/.tmux.conf                                                              0.0s
 => CACHED [shell 6/9] COPY --from=dockerd-release /usr/local/bin /usr/local/bin                                                    0.0s
 => CACHED [shell 7/9] WORKDIR /work                                                                                                0.0s
 => CACHED [shell 8/9] COPY ./hack/demo-env/examples .                                                                              0.0s
 => [shell 9/9] COPY --from=binaries / /usr/local/bin/                                                                              0.1s
WARNING: No output specified with remote driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
```