### PR TITLE
monitor: Allow launching container from non-exec op with `on-error`

### DIFF
--- a/build/invoke.go
+++ b/build/invoke.go
@@ -113,7 +113,7 @@ func (c *Container) Exec(ctx context.Context, cfg *controllerapi.InvokeConfig, s
 }
 
 func exec(ctx context.Context, resultCtx *ResultContext, cfg *controllerapi.InvokeConfig, ctr gateway.Container, stdin io.ReadCloser, stdout io.WriteCloser, stderr io.WriteCloser) error {
-	processCfg, err := resultCtx.getProcessConfig(cfg, stdin, stdout, stderr)
+	processCfg, err := resultCtx.getProcessConfig(ctx, cfg, stdin, stdout, stderr)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Following-up https://github.com/docker/buildx/pull/1640#issuecomment-1512785173 :

*From @jedevc 's comment:*

> We should support breaking on other failed commands, like COPY - atm, on-error stops in the right place, but I can't spawn any session. Even if we just drop into a default shell, with no extra args, environment variables, that's alright for now. This will be necessary to provide a good experience with monitor: breakpoint debugger on monitor and on IDEs (via DAP)  #1656 as well.

Currently `on-error` launches container only from the errored ExecOp. This commit allows it from FileOp (COPY instruction) as well.

Unfortunately buildkitd doesn't seem to return the container execution information (`*pb.Meta`) on non-exec op failure, so we lanch the container from the result of the previous op of the failed one. Currently this is supported only for FileOp but we can expand this feature for other types of Ops if needed in the future.

In the following example Dockerfile, the build fails on `COPY --from=dev /none /` and the debugger container is created by the result of the input (`COPY --from=dev /hi /`).

```dockerfile
FROM ghcr.io/stargz-containers/ubuntu:22.04 AS dev
RUN echo hi > /hi

FROM ghcr.io/stargz-containers/ubuntu:22.04
ENV a=test
COPY --from=dev /hi /
COPY --from=dev /none /
```

```console
$ BUILDX_EXPERIMENTAL=1 /tmp/out/buildx build --detach=false --invoke sh /tmp/ctx4
[+] Building 1.7s (9/9) FINISHED                        docker-container:latest
 => [internal] connecting to local controller                              0.0s
 => [internal] load build definition from Dockerfile                       0.0s
 => => transferring dockerfile: 210B                                       0.0s
 => [internal] load metadata for ghcr.io/stargz-containers/ubuntu:22.04    1.3s
 => [auth] stargz-containers/ubuntu:pull token for ghcr.io                 0.0s
 => [internal] load .dockerignore                                          0.0s
 => => transferring context: 2B                                            0.0s
 => [dev 1/2] FROM ghcr.io/stargz-containers/ubuntu:22.04@sha256:20fa2d7b  0.0s
 => => resolve ghcr.io/stargz-containers/ubuntu:22.04@sha256:20fa2d7bb4de  0.0s
 => CACHED [stage-1 2/3] COPY --from=dev /hi /                             0.0s
 => CACHED [dev 2/2] RUN echo hi > /hi                                     0.0s
 => ERROR [stage-1 3/3] COPY --from=dev /none /                            0.0s
------
 > [stage-1 3/3] COPY --from=dev /none /:
------
WARNING: No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
Launching interactive container. Press Ctrl-a-c to switch to monitor console
Interactive container was restarted with process "g5ak43dqhulym5vnp9qs4h37x". Press Ctrl-a-c to switch to the new container
# echo $a
test
# cat hi
hi
# 
```
