### PR TITLE
fix two bugs in bake-reference.md

### DIFF
--- a/docs/bake-reference.md
+++ b/docs/bake-reference.md
@@ -69,16 +69,16 @@ The following example shows the same Bake file in the HCL format:
 
 ```hcl
 variable "TAG" {
-  "default" = "latest"
+  default = "latest"
 }
 
 group "default" {
-  "targets" = ["latest"]
+  targets = ["webapp"]
 }
 
 target "webapp" {
-  "dockerfile" = "Dockerfile"
-  "tags" = ["docker.io/username/webapp:${TAG}"]
+  dockerfile = "Dockerfile"
+  tags = ["docker.io/username/webapp:${TAG}"]
 }
 ```
 


### PR DESCRIPTION
Before this change, there were two bugs:
- the HCL was not valid. in hcl, argument names can't be quoted
- the target argument should be a real target