### PR TITLE
`--load` with moby containerd store should use the `oci` exporter

### DIFF
--- a/util/dockerutil/client.go
+++ b/util/dockerutil/client.go
@@ -63,6 +63,23 @@ func (c *Client) LoadImage(ctx context.Context, name string, status progress.Wri
 	}, nil
 }
 
+func (c *Client) Features(ctx context.Context, name string) map[Feature]bool {
+	features := make(map[Feature]bool)
+	if dapi, err := c.API(name); err == nil {
+		if info, err := dapi.Info(ctx); err == nil {
+			for _, v := range info.DriverStatus {
+				switch v[0] {
+				case "driver-type":
+					if v[1] == "io.containerd.snapshotter.v1" {
+						features[OCIImporter] = true
+					}
+				}
+			}
+		}
+	}
+	return features
+}
+
 type waitingWriter struct {
 	*io.PipeWriter
 	f      func()

--- a/util/dockerutil/features.go
+++ b/util/dockerutil/features.go
@@ -1,0 +1,5 @@
+package dockerutil
+
+type Feature string
+
+const OCIImporter Feature = "OCI importer"


### PR DESCRIPTION
Moby with the containerd store supports importing multi-platform OCI images, which means we *should* be able to add functionality to have `--load` work with multi-platform images.

Before:
```
$ buildx build . --platform linux/amd64,linux/arm64 --builder container --load
[+] Building 0.1s (1/1) FINISHED                                                                                         docker-container:container
 => [internal] connecting to local controller                                                                                                  0.0s
ERROR: failed to build: docker exporter does not currently support exporting manifest lists
```

After:
```
$ buildx build . --platform linux/amd64,linux/arm64 --builder container --load
[+] Building 4.0s (24/24) FINISHED                                                                                       docker-container:container
 => [internal] connecting to local controller                                                                                                  0.0s
 => [internal] load build definition from Dockerfile                                                                                           0.0s
 => => transferring dockerfile: 2.20kB                                                                                                         0.0s
...
 => exporting to docker image format                                                                                                              0.6s
 => => exporting layers                                                                                                                        0.0s
 => => exporting manifest sha256:c0dfaa2978d8ea698f0af7ce2a36373789ed20deffd837a4504891f04c28e0f4                                              0.0s
 => => exporting config sha256:6c835b10e81d195b8795ae810667bff2c0c6565430f16f3649f5e4d4f2b6a650                                                0.0s
 => => exporting attestation manifest sha256:b11b99e5db8890a7e66713e4476d20d2d6fa622519140830d3097ef3112d7ed3                                  0.0s
 => => exporting manifest sha256:ecae44f665a1727aea6c7a2adff17ebc2f954ae5aad957443e5aa35b24277983                                              0.0s
 => => exporting config sha256:dbca1a6373dd85c3bb3ea08a6d980fc7674976126ddcfdbcc2bd61c2b57dfebe                                                0.0s
 => => exporting manifest list sha256:c2b6927cbd1a651e05e462294d11e546d83a4b1c4146d0c8195c234d8f98d490                                         0.0s
 => => sending tarball                                                                                                                         0.6s
 => importing to docker  
```

This patch works by translating the `docker` exporter to an `oci` exporter (which supports multi-platform exports), just as we were previously translating the `docker` exporter to the `moby` exporter for the moby case.

I *think* this should just work? I've done some basic tests with some sample bake files, and build commands from my history, and get the expected results (and don't get any different behavior on non-containerd moby) :tada:

(I can add some integration tests once #1770 merges)

cc @tonistiigi @vvoland @rumpl

## Related issues

- https://github.com/docker/roadmap/issues/371
- Fixes https://github.com/docker/buildx/issues/1522 (cc @TBBle)
