### PR TITLE
Fix AWS Authentication when mixing static creds and IAM profile

### DIFF
--- a/util/buildflags/cache.go
+++ b/util/buildflags/cache.go
@@ -88,6 +88,12 @@ func addAwsCredentials(ci *controllerapi.CacheOptionsEntry) {
 	if ci.Type != "s3" {
 		return
 	}
+	_, okAccessKeyID := ci.Attrs["access_key_id"]
+	_, okSecretAccessKey := ci.Attrs["secret_access_key"]
+	// If the user provides access_key_id, secret_access_key, do not override the session token.
+	if okAccessKeyID && okSecretAccessKey {
+		return
+	}
 	ctx := context.TODO()
 	awsConfig, err := awsconfig.LoadDefaultConfig(ctx)
 	if err != nil {
@@ -97,10 +103,10 @@ func addAwsCredentials(ci *controllerapi.CacheOptionsEntry) {
 	if err != nil {
 		return
 	}
-	if _, ok := ci.Attrs["access_key_id"]; !ok && credentials.AccessKeyID != "" {
+	if !okAccessKeyID && credentials.AccessKeyID != "" {
 		ci.Attrs["access_key_id"] = credentials.AccessKeyID
 	}
-	if _, ok := ci.Attrs["secret_access_key"]; !ok && credentials.SecretAccessKey != "" {
+	if !okSecretAccessKey && credentials.SecretAccessKey != "" {
 		ci.Attrs["secret_access_key"] = credentials.SecretAccessKey
 	}
 	if _, ok := ci.Attrs["session_token"]; !ok && credentials.SessionToken != "" {


### PR DESCRIPTION
When the user supply static creds, we must not enrich them with a session token which is unrelated.