### PR TITLE
test: relax validation of TEST_BUILDKIT_IMAGE to reduce direct dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/containerd/containerd v1.7.0
 	github.com/containerd/continuity v0.3.0
 	github.com/containerd/typeurl/v2 v2.1.0
-	github.com/distribution/distribution/v3 v3.0.0-20230214150026-36d8c594d7aa
 	github.com/docker/cli v23.0.6+incompatible
 	github.com/docker/cli-docs-tool v0.5.1
 	github.com/docker/distribution v2.8.2+incompatible
@@ -87,6 +86,7 @@ require (
 	github.com/containerd/ttrpc v1.2.1 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/distribution/distribution/v3 v3.0.0-20230214150026-36d8c594d7aa // indirect
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect
 	github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c // indirect
 	github.com/docker/go-connections v0.4.0 // indirect

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/distribution/distribution/v3/reference"
 	"github.com/docker/buildx/tests/workers"
 	"github.com/moby/buildkit/util/testutil/integration"
 )
@@ -30,11 +29,9 @@ func testIntegration(t *testing.T, funcs ...func(t *testing.T, sb integration.Sa
 	mirroredImages := integration.OfficialImages("busybox:latest", "alpine:latest")
 	buildkitImage := "docker.io/moby/buildkit:buildx-stable-1"
 	if integration.IsTestDockerd() {
-		if img, ok := os.LookupEnv("TEST_BUILDKIT_IMAGE"); ok {
-			ref, err := reference.ParseNormalizedNamed(img)
-			if err == nil {
-				buildkitImage = ref.String()
-			}
+		if img, ok := os.LookupEnv("TEST_BUILDKIT_IMAGE"); ok && img != "" {
+			t.Log("using TEST_BUILDKIT_IMAGE", img)
+			buildkitImage = img
 		}
 	}
 	mirroredImages["moby/buildkit:buildx-stable-1"] = buildkitImage


### PR DESCRIPTION
commit 2d124e0ce954727d640fb3de81d8b36615e7b84f (https://github.com/docker/buildx/pull/1770) added some integration-tests, and as part of those tests added github.com/distribution/distribution/v3 as a direct dependency.

github.com/distribution/distribution/v3 is unreleased, and is still receiving backward breaking changes. While this dependency is already used elsewhere, it looks like the only use in buildx was for a sanity check of the custom TEST_BUILDKIT_IMAGE; we can probably relax that check to avoid adding the direct dependency.