### PR TITLE
build: fix missing "docker" driver name in build progress

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -233,6 +233,10 @@ func runBuild(dockerCli command.Cli, options buildOptions) (err error) {
 	if err != nil {
 		return err
 	}
+	_, err = b.LoadNodes(ctx, false)
+	if err != nil {
+		return err
+	}
 
 	ctx2, cancel := context.WithCancel(context.TODO())
 	defer cancel()


### PR DESCRIPTION
This was missing, since the driver property can only be fully populated after loading nodes from disk. So we add logic to load the nodes, and check for an error, which ensures that the "docker" driver is always correctly present in the progress description.

I think this was introduced in #1737, when I refactored the progress printing.

Before:

```
$ buildx build . --builder=desktop-linux
[+] Building 2.2s (10/10) FINISHED                                                                                           :desktop-linux
```

After:

```
$ buildx build . --builder=desktop-linux
[+] Building 0.9s (6/6) FINISHED                                                                                       docker:desktop-linux
```