### PR TITLE
invoke: Allow JSON array for entrypoint and args flags in long form 

### DIFF
--- a/docs/guides/debugging.md
+++ b/docs/guides/debugging.md
@@ -49,6 +49,16 @@ bin    etc    lib    mnt    proc   run    srv    tmp    var
 dev    home   media  opt    root   sbin   sys    usr    work
 ```
 
+Optional long form allows you specifying detailed configurations of the process. 
+It must be CSV-styled comma-separated key-value pairs.
+Supported keys are `args` (can be JSON array format), `entrypoint` (can be JSON array format), `env` (can be JSON array format), `user`, `cwd` and `tty` (bool).
+
+Example:
+
+```
+$ docker buildx build --invoke 'entrypoint=["sh"],"args=[""-c"", ""env | grep -e FOO -e AAA""]","env=[""FOO=bar"", ""AAA=bbb""]"' .
+```
+
 #### `on-error`
 
 If you want to start a debug session when a build fails, you can use


### PR DESCRIPTION
This commit allows specifying a JSON array to the long-form entrypoint and args.
Non-JSON-array value can still be specified. Buildx treats the value as a JSON
array only when it can be parsed as a JSON array.

```console
$ BUILDX_EXPERIMENTAL=1 /tmp/out/buildx build --invoke 'entrypoint=["sh"],"args=[""-c"", ""env | grep FOO""]",env=FOO=bar' /tmp/ctx3
[+] Building 1.2s (8/8) FINISHED                        docker-container:latest
 => [internal] connecting to local controller                              0.0s
 => [internal] load build definition from Dockerfile                       0.0s
 => => transferring dockerfile: 100B                                       0.0s
 => [internal] load metadata for docker.io/library/busybox:latest          0.7s
 => [internal] load .dockerignore                                          0.0s
 => => transferring context: 2B                                            0.0s
 => [1/4] FROM docker.io/library/busybox@sha256:560af6915bfc8d7630e50e212  0.0s
 => => resolve docker.io/library/busybox@sha256:560af6915bfc8d7630e50e212  0.0s
 => CACHED [4/4] RUN echo 3 > /3                                           0.0s
 => CACHED [2/4] RUN echo hi > /hi                                         0.0s
 => CACHED [3/4] RUN echo 2 > /2                                           0.0s
WARNING: No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
Launching interactive container. Press Ctrl-a-c to switch to monitor console
Interactive container was restarted with process "2o79c3g3qs1yyo3gixzr1o6in". Press Ctrl-a-c to switch to the new container
FOO=bar
```
