### PR TITLE
bake: fix BAKE_CMD_CONTEXT relative path resolution

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -1012,7 +1012,8 @@ func checkPath(p string) error {
 	if err != nil {
 		return err
 	}
-	if strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+	parts := strings.Split(rel, string(os.PathSeparator))
+	if parts[0] == ".." {
 		return errors.Errorf("path %s is outside of the working directory, please set BAKE_ALLOW_REMOTE_FS_ACCESS=1", p)
 	}
 	return nil

--- a/bake/bake.go
+++ b/bake/bake.go
@@ -1000,6 +1000,10 @@ func checkPath(p string) error {
 		}
 		return err
 	}
+	p, err = filepath.Abs(p)
+	if err != nil {
+		return err
+	}
 	wd, err := os.Getwd()
 	if err != nil {
 		return err

--- a/tests/bake.go
+++ b/tests/bake.go
@@ -20,6 +20,7 @@ func bakeCmd(sb integration.Sandbox, dir string, args ...string) (string, error)
 
 var bakeTests = []func(t *testing.T, sb integration.Sandbox){
 	testBakeRemote,
+	testBakeRemoteCmdContext,
 }
 
 func testBakeRemote(t *testing.T, sb integration.Sandbox) {
@@ -47,6 +48,40 @@ EOT
 	addr := gitutil.GitServeHTTP(git, t)
 
 	out, err := bakeCmd(sb, dir, addr, "--set", "*.output=type=local,dest="+dirDest)
+	require.NoError(t, err, out)
+
+	require.FileExists(t, filepath.Join(dirDest, "foo"))
+}
+
+func testBakeRemoteCmdContext(t *testing.T, sb integration.Sandbox) {
+	bakefile := []byte(`
+target "default" {
+	context = BAKE_CMD_CONTEXT
+	dockerfile-inline = <<EOT
+FROM scratch
+COPY foo /foo
+EOT
+}
+`)
+	dirSpec := tmpdir(
+		t,
+		fstest.CreateFile("docker-bake.hcl", bakefile, 0600),
+	)
+	dirSrc := tmpdir(
+		t,
+		fstest.CreateFile("foo", []byte("foo"), 0600),
+	)
+	dirDest := t.TempDir()
+
+	git, err := gitutil.New(gitutil.WithWorkingDir(dirSpec))
+	require.NoError(t, err)
+
+	gitutil.GitInit(git, t)
+	gitutil.GitAdd(git, t, "docker-bake.hcl")
+	gitutil.GitCommit(git, t, "initial commit")
+	addr := gitutil.GitServeHTTP(git, t)
+
+	out, err := bakeCmd(sb, dirSrc, addr, "--set", "*.output=type=local,dest="+dirDest)
 	require.NoError(t, err, out)
 
 	require.FileExists(t, filepath.Join(dirDest, "foo"))

--- a/tests/bake.go
+++ b/tests/bake.go
@@ -10,10 +10,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func bakeCmd(sb integration.Sandbox, dir string, args ...string) (string, error) {
-	args = append([]string{"bake", "--progress=quiet"}, args...)
-	cmd := buildxCmd(sb, args...)
-	cmd.Dir = dir
+func bakeCmd(sb integration.Sandbox, opts ...cmdOpt) (string, error) {
+	opts = append([]cmdOpt{withArgs("bake", "--progress=quiet")}, opts...)
+	cmd := buildxCmd(sb, opts...)
 	out, err := cmd.CombinedOutput()
 	return string(out), err
 }
@@ -49,7 +48,7 @@ EOT
 	gitutil.GitCommit(git, t, "initial commit")
 	addr := gitutil.GitServeHTTP(git, t)
 
-	out, err := bakeCmd(sb, dir, addr, "--set", "*.output=type=local,dest="+dirDest)
+	out, err := bakeCmd(sb, withDir(dir), withArgs(addr, "--set", "*.output=type=local,dest="+dirDest))
 	require.NoError(t, err, out)
 
 	require.FileExists(t, filepath.Join(dirDest, "foo"))
@@ -83,7 +82,7 @@ EOT
 	gitutil.GitCommit(git, t, "initial commit")
 	addr := gitutil.GitServeHTTP(git, t)
 
-	out, err := bakeCmd(sb, dirSrc, addr, "--set", "*.output=type=local,dest="+dirDest)
+	out, err := bakeCmd(sb, withDir(dirSrc), withArgs(addr, "--set", "*.output=type=local,dest="+dirDest))
 	require.NoError(t, err, out)
 
 	require.FileExists(t, filepath.Join(dirDest, "foo"))
@@ -123,7 +122,7 @@ EOT
 	gitutil.GitCommit(gitSrc, t, "initial commit")
 	addrSrc := gitutil.GitServeHTTP(gitSrc, t)
 
-	out, err := bakeCmd(sb, "/tmp", addrSpec, addrSrc, "--set", "*.output=type=local,dest="+dirDest)
+	out, err := bakeCmd(sb, withDir("/tmp"), withArgs(addrSpec, addrSrc, "--set", "*.output=type=local,dest="+dirDest))
 	require.NoError(t, err, out)
 
 	require.FileExists(t, filepath.Join(dirDest, "foo"))
@@ -157,7 +156,7 @@ COPY super-cool.txt /
 	gitutil.GitCommit(git, t, "initial commit")
 	addr := gitutil.GitServeHTTP(git, t)
 
-	out, err := bakeCmd(sb, "/tmp", addr, "--set", "*.output=type=local,dest="+dirDest)
+	out, err := bakeCmd(sb, withDir("/tmp"), withArgs(addr, "--set", "*.output=type=local,dest="+dirDest))
 	require.NoError(t, err, out)
 
 	require.FileExists(t, filepath.Join(dirDest, "super-cool.txt"))

--- a/tests/bake.go
+++ b/tests/bake.go
@@ -1,0 +1,53 @@
+package tests
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/containerd/continuity/fs/fstest"
+	"github.com/docker/buildx/util/gitutil"
+	"github.com/moby/buildkit/util/testutil/integration"
+	"github.com/stretchr/testify/require"
+)
+
+func bakeCmd(sb integration.Sandbox, dir string, args ...string) (string, error) {
+	args = append([]string{"bake", "--progress=quiet"}, args...)
+	cmd := buildxCmd(sb, args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+var bakeTests = []func(t *testing.T, sb integration.Sandbox){
+	testBakeRemote,
+}
+
+func testBakeRemote(t *testing.T, sb integration.Sandbox) {
+	bakefile := []byte(`
+target "default" {
+	dockerfile-inline = <<EOT
+FROM scratch
+COPY foo /foo
+EOT
+}
+`)
+	dir := tmpdir(
+		t,
+		fstest.CreateFile("docker-bake.hcl", bakefile, 0600),
+		fstest.CreateFile("foo", []byte("foo"), 0600),
+	)
+	dirDest := t.TempDir()
+
+	git, err := gitutil.New(gitutil.WithWorkingDir(dir))
+	require.NoError(t, err)
+
+	gitutil.GitInit(git, t)
+	gitutil.GitAdd(git, t, "docker-bake.hcl", "foo")
+	gitutil.GitCommit(git, t, "initial commit")
+	addr := gitutil.GitServeHTTP(git, t)
+
+	out, err := bakeCmd(sb, dir, addr, "--set", "*.output=type=local,dest="+dirDest)
+	require.NoError(t, err, out)
+
+	require.FileExists(t, filepath.Join(dirDest, "foo"))
+}

--- a/tests/build.go
+++ b/tests/build.go
@@ -148,11 +148,10 @@ RUN cp /etc/foo /etc/bar
 FROM scratch
 COPY --from=base /etc/bar /bar
 `)
-	dir, err := tmpdir(
+	dir := tmpdir(
 		t,
 		fstest.CreateFile("Dockerfile", dockerfile, 0600),
 		fstest.CreateFile("foo", []byte("foo"), 0600),
 	)
-	require.NoError(t, err)
 	return dir
 }

--- a/tests/inspect.go
+++ b/tests/inspect.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func inspectCmd(sb integration.Sandbox, args ...string) (string, error) {
-	args = append([]string{"inspect"}, args...)
-	cmd := buildxCmd(sb, args...)
+func inspectCmd(sb integration.Sandbox, opts ...cmdOpt) (string, error) {
+	opts = append([]cmdOpt{withArgs("inspect")}, opts...)
+	cmd := buildxCmd(sb, opts...)
 	out, err := cmd.CombinedOutput()
 	return string(out), err
 }

--- a/tests/integration.go
+++ b/tests/integration.go
@@ -20,6 +20,12 @@ func tmpdir(t *testing.T, appliers ...fstest.Applier) string {
 
 type cmdOpt func(*exec.Cmd)
 
+func withEnv(env ...string) cmdOpt {
+	return func(cmd *exec.Cmd) {
+		cmd.Env = append(cmd.Env, env...)
+	}
+}
+
 func withArgs(args ...string) cmdOpt {
 	return func(cmd *exec.Cmd) {
 		cmd.Args = append(cmd.Args, args...)

--- a/tests/integration.go
+++ b/tests/integration.go
@@ -7,14 +7,15 @@ import (
 
 	"github.com/containerd/continuity/fs/fstest"
 	"github.com/moby/buildkit/util/testutil/integration"
+	"github.com/stretchr/testify/require"
 )
 
-func tmpdir(t *testing.T, appliers ...fstest.Applier) (string, error) {
+func tmpdir(t *testing.T, appliers ...fstest.Applier) string {
+	t.Helper()
 	tmpdir := t.TempDir()
-	if err := fstest.Apply(appliers...).Apply(tmpdir); err != nil {
-		return "", err
-	}
-	return tmpdir, nil
+	err := fstest.Apply(appliers...).Apply(tmpdir)
+	require.NoError(t, err)
+	return tmpdir
 }
 
 func buildxCmd(sb integration.Sandbox, args ...string) *exec.Cmd {

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -21,6 +21,7 @@ func init() {
 func TestIntegration(t *testing.T) {
 	var tests []func(t *testing.T, sb integration.Sandbox)
 	tests = append(tests, buildTests...)
+	tests = append(tests, bakeTests...)
 	tests = append(tests, inspectTests...)
 	tests = append(tests, lsTests...)
 	testIntegration(t, tests...)

--- a/tests/ls.go
+++ b/tests/ls.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func lsCmd(sb integration.Sandbox, args ...string) (string, error) {
-	args = append([]string{"ls"}, args...)
-	cmd := buildxCmd(sb, args...)
+func lsCmd(sb integration.Sandbox, opts ...cmdOpt) (string, error) {
+	opts = append([]cmdOpt{withArgs("ls")}, opts...)
+	cmd := buildxCmd(sb, opts...)
 	out, err := cmd.CombinedOutput()
 	return string(out), err
 }

--- a/util/gitutil/gitutil.go
+++ b/util/gitutil/gitutil.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -66,6 +67,14 @@ func (c *Git) IsDirty() bool {
 
 func (c *Git) RootDir() (string, error) {
 	return c.clean(c.run("rev-parse", "--show-toplevel"))
+}
+
+func (c *Git) GitDir() (string, error) {
+	dir, err := c.RootDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, ".git"), nil
 }
 
 func (c *Git) RemoteURL() (string, error) {

--- a/util/gitutil/testutil.go
+++ b/util/gitutil/testutil.go
@@ -39,9 +39,10 @@ func GitCheckoutBranch(c *Git, tb testing.TB, name string) {
 	require.Empty(tb, out)
 }
 
-func GitAdd(c *Git, tb testing.TB, file string) {
+func GitAdd(c *Git, tb testing.TB, files ...string) {
 	tb.Helper()
-	_, err := fakeGit(c, "add", file)
+	args := append([]string{"add"}, files...)
+	_, err := fakeGit(c, args...)
 	require.NoError(tb, err)
 }
 

--- a/util/gitutil/testutilserve.go
+++ b/util/gitutil/testutilserve.go
@@ -1,0 +1,62 @@
+package gitutil
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func GitServeHTTP(c *Git, t testing.TB) (url string) {
+	t.Helper()
+	gitUpdateServerInfo(c, t)
+	ctx, cancel := context.WithCancel(context.TODO())
+
+	ready := make(chan struct{})
+	done := make(chan struct{})
+
+	name := "test.git"
+	dir, err := c.GitDir()
+	if err != nil {
+		cancel()
+	}
+
+	var addr string
+	go func() {
+		mux := http.NewServeMux()
+		prefix := fmt.Sprintf("/%s/", name)
+		mux.Handle(prefix, http.StripPrefix(prefix, http.FileServer(http.Dir(dir))))
+		l, err := net.Listen("tcp", "localhost:0")
+		if err != nil {
+			panic(err)
+		}
+
+		addr = l.Addr().String()
+
+		close(ready)
+
+		s := http.Server{Handler: mux} //nolint:gosec // potential attacks are not relevant for tests
+		go s.Serve(l)
+		<-ctx.Done()
+		s.Shutdown(context.TODO())
+		l.Close()
+
+		close(done)
+	}()
+	<-ready
+
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+	return fmt.Sprintf("http://%s/%s", addr, name)
+}
+
+func gitUpdateServerInfo(c *Git, tb testing.TB) {
+	tb.Helper()
+	_, err := fakeGit(c, "update-server-info")
+	require.NoError(tb, err)
+}


### PR DESCRIPTION
:hammer_and_wrench: Fixes path resolution issue with `BAKE_CMD_CONTEXT`.

In https://docs.docker.com/build/bake/remote-definition/, the following snippet no longer works:

```
$ docker buildx bake "https://github.com/tonistiigi/buildx.git#remote-test" --print
{
  "target": {
    "default": {
      "context": ".",
      "dockerfile": "Dockerfile",
      "dockerfile-inline": "FROM alpine\nWORKDIR /src\nCOPY . .\nRUN ls -l \u0026\u0026 stop\n"
    }
  }
}
```

Instead returning the following error:

```
$ docker buildx bake "https://github.com/tonistiigi/buildx.git#remote-test" --print
ERROR: Rel: can't make . relative to /home/jedevc/Documents/Docker/buildx
```

This issue comes from https://github.com/docker/buildx/blob/341fb65f6f568696ed5e2585eb747aedaed7ee1a/bake/bake.go#L1007-L1010

To resolve this issue, we need to ensure that the passed path is an absolute path, instead of the relative path `.`.

To prevent further regression, I add a couple of tests to build against a remote git repo (which is where most of the code in this PR comes from :scream:).

cc @crazy-max @dvdksn 