### PR TITLE
build: display build details link

### DIFF
--- a/cmd/buildx/main.go
+++ b/cmd/buildx/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/docker/buildx/commands"
+	"github.com/docker/buildx/util/desktop"
 	"github.com/docker/buildx/version"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli-plugins/manager"
@@ -85,6 +86,9 @@ func main() {
 		fmt.Fprintf(cmd.Err(), "ERROR: %+v", stack.Formatter(err))
 	} else {
 		fmt.Fprintf(cmd.Err(), "ERROR: %v\n", err)
+	}
+	if ebr, ok := err.(*desktop.ErrorWithBuildRef); ok {
+		ebr.Print(cmd.Err())
 	}
 
 	os.Exit(1)

--- a/commands/build.go
+++ b/commands/build.go
@@ -26,6 +26,7 @@ import (
 	"github.com/docker/buildx/store"
 	"github.com/docker/buildx/store/storeutil"
 	"github.com/docker/buildx/util/buildflags"
+	"github.com/docker/buildx/util/desktop"
 	"github.com/docker/buildx/util/ioset"
 	"github.com/docker/buildx/util/progress"
 	"github.com/docker/buildx/util/tracing"
@@ -238,6 +239,11 @@ func runBuild(dockerCli command.Cli, options buildOptions) (err error) {
 		return err
 	}
 
+	var term bool
+	if _, err := console.ConsoleFromFile(os.Stderr); err == nil {
+		term = true
+	}
+
 	ctx2, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	progressMode, err := options.toProgress()
@@ -273,7 +279,9 @@ func runBuild(dockerCli command.Cli, options buildOptions) (err error) {
 		return retErr
 	}
 
-	if progressMode == progress.PrinterModeQuiet {
+	if progressMode != progress.PrinterModeQuiet {
+		desktop.PrintBuildDetails(os.Stderr, printer.BuildRefs(), term)
+	} else {
 		fmt.Println(getImageID(resp.ExporterResponse))
 	}
 	if options.imageIDFile != "" {

--- a/commands/build.go
+++ b/commands/build.go
@@ -273,7 +273,7 @@ func runBuild(dockerCli command.Cli, options buildOptions) (err error) {
 		return retErr
 	}
 
-	if options.quiet {
+	if progressMode == progress.PrinterModeQuiet {
 		fmt.Println(getImageID(resp.ExporterResponse))
 	}
 	if options.imageIDFile != "" {

--- a/controller/pb/progress.go
+++ b/controller/pb/progress.go
@@ -19,6 +19,10 @@ func (w *writer) Write(status *client.SolveStatus) {
 	w.ch <- ToControlStatus(status)
 }
 
+func (w *writer) WriteBuildRef(target string, ref string) {
+	return
+}
+
 func (w *writer) ValidateLogSource(digest.Digest, interface{}) bool {
 	return true
 }

--- a/util/desktop/desktop.go
+++ b/util/desktop/desktop.go
@@ -1,0 +1,86 @@
+package desktop
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/containerd/console"
+)
+
+var (
+	bbEnabledOnce sync.Once
+	bbEnabled     bool
+)
+
+func BuildBackendEnabled() bool {
+	bbEnabledOnce.Do(func() {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return
+		}
+		_, err = os.Stat(filepath.Join(home, ".docker", "desktop-build", ".lastaccess"))
+		bbEnabled = err == nil
+	})
+	return bbEnabled
+}
+
+func BuildDetailsOutput(refs map[string]string, term bool) string {
+	if len(refs) == 0 {
+		return ""
+	}
+	refURL := func(ref string) string {
+		return fmt.Sprintf("docker-desktop://dashboard/build/%s", ref)
+	}
+	var out bytes.Buffer
+	out.WriteString("View build details: ")
+	multiTargets := len(refs) > 1
+	for target, ref := range refs {
+		if multiTargets {
+			out.WriteString(fmt.Sprintf("\n  %s: ", target))
+		}
+		if term {
+			out.WriteString(hyperlink(refURL(ref)))
+		} else {
+			out.WriteString(refURL(ref))
+		}
+	}
+	return out.String()
+}
+
+func PrintBuildDetails(w io.Writer, refs map[string]string, term bool) {
+	if out := BuildDetailsOutput(refs, term); out != "" {
+		fmt.Fprintf(w, "\n%s\n", out)
+	}
+}
+
+func hyperlink(url string) string {
+	// create an escape sequence using the OSC 8 format: https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
+	return fmt.Sprintf("\033]8;;%s\033\\%s\033]8;;\033\\", url, url)
+}
+
+type ErrorWithBuildRef struct {
+	Ref string
+	Err error
+	Msg string
+}
+
+func (e *ErrorWithBuildRef) Error() string {
+	return e.Err.Error()
+}
+
+func (e *ErrorWithBuildRef) Unwrap() error {
+	return e.Err
+}
+
+func (e *ErrorWithBuildRef) Print(w io.Writer) error {
+	var term bool
+	if _, err := console.ConsoleFromFile(os.Stderr); err == nil {
+		term = true
+	}
+	fmt.Fprintf(w, "\n%s", BuildDetailsOutput(map[string]string{"default": e.Ref}, term))
+	return nil
+}

--- a/util/progress/writer.go
+++ b/util/progress/writer.go
@@ -10,6 +10,7 @@ import (
 
 type Writer interface {
 	Write(*client.SolveStatus)
+	WriteBuildRef(string, string)
 	ValidateLogSource(digest.Digest, interface{}) bool
 	ClearLogSource(interface{})
 }
@@ -39,6 +40,10 @@ func Write(w Writer, name string, f func() error) {
 	w.Write(&client.SolveStatus{
 		Vertexes: []*client.Vertex{&vtx2},
 	})
+}
+
+func WriteBuildRef(w Writer, target string, ref string) {
+	w.WriteBuildRef(target, ref)
 }
 
 func NewChannel(w Writer) (chan *client.SolveStatus, chan struct{}) {


### PR DESCRIPTION
https://github.com/docker/buildx/assets/1951866/41a8935a-438f-48f4-be2c-957a56e80f8f

Display build details links if Docker Desktop build backend is enabled.

I'm using an OSC 8 escape sequence with the target links to be displayed in the terminal. Most of the terminal emulators auto-detect when a URL appears onscreen and allow to conveniently open them (e.g. via Ctrl+click or Cmd+click, or the right click menu). A hyperlink is opened upon encountering an OSC 8 escape sequence with the link. The list of supporting terminal emulators and terminal-based apps can be seen here: https://github.com/Alhadis/OSC8-Adoption/.

Atm it only displays links when build is completed and not for active builds. For active builds we need to put links right before build starts so user can just follow build status in desktop instead of his terminal. Would also need a callback to retrieve the ref when attributes are converted to solve opts.
