### PR TITLE
Log error from WithError if found

### DIFF
--- a/util/logutil/format.go
+++ b/util/logutil/format.go
@@ -1,6 +1,7 @@
 package logutil
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 
@@ -12,5 +13,11 @@ type Formatter struct {
 }
 
 func (f *Formatter) Format(entry *logrus.Entry) ([]byte, error) {
-	return []byte(fmt.Sprintf("%s: %s\n", strings.ToUpper(entry.Level.String()), entry.Message)), nil
+	msg := bytes.NewBuffer(nil)
+	fmt.Fprintf(msg, "%s: %s", strings.ToUpper(entry.Level.String()), entry.Message)
+	if v, ok := entry.Data[logrus.ErrorKey]; ok {
+		fmt.Fprintf(msg, ": %v", v)
+	}
+	fmt.Fprintf(msg, "\n")
+	return msg.Bytes(), nil
 }


### PR DESCRIPTION
:arrow_up: Follow-up to https://github.com/docker/buildx/pull/924.

Should help to provide more details for https://github.com/moby/buildkit/issues/3027.

Previously, we would discard the error field provided, which provides valuable contextual information. This patch will include the error field if it is provided. A quick glance through our usage of `WithError` indicates that the errors shown should look mostly reasonable (e.g. we won't display duplicated info).

We still don't want to just print out all the available spans, since that will include the `spanID` and `traceID` from BuildKit, but this singular field is a well-known key, so we should include it whenever present.