### PR TITLE
inspect: display builder features

### DIFF
--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -10,10 +10,12 @@ import (
 	"time"
 
 	"github.com/docker/buildx/builder"
+	"github.com/docker/buildx/driver"
 	"github.com/docker/buildx/util/cobrautil/completion"
 	"github.com/docker/buildx/util/platformutil"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/debug"
 	"github.com/docker/go-units"
 	"github.com/moby/buildkit/util/appcontext"
 	"github.com/spf13/cobra"
@@ -92,6 +94,18 @@ func runInspect(dockerCli command.Cli, in inspectOptions) error {
 					fmt.Fprintf(w, "Buildkit:\t%s\n", nodes[i].Version)
 				}
 				fmt.Fprintf(w, "Platforms:\t%s\n", strings.Join(platformutil.FormatInGroups(n.Node.Platforms, n.Platforms), ", "))
+				if debug.IsEnabled() {
+					fmt.Fprintf(w, "Features:\n")
+					features := nodes[i].Driver.Features(ctx)
+					featKeys := make([]string, 0, len(features))
+					for k := range features {
+						featKeys = append(featKeys, string(k))
+					}
+					sort.Strings(featKeys)
+					for _, k := range featKeys {
+						fmt.Fprintf(w, "\t%s:\t%t\n", k, features[driver.Feature(k)])
+					}
+				}
 				if len(nodes[i].Labels) > 0 {
 					fmt.Fprintf(w, "Labels:\n")
 					for _, k := range sortedKeys(nodes[i].Labels) {

--- a/docs/reference/buildx_inspect.md
+++ b/docs/reference/buildx_inspect.md
@@ -84,3 +84,9 @@ GC Policy rule#3:
  All:        true
  Keep Bytes: 24.21GiB
 ```
+
+`debug` flag can also be used to get more information about the builder:
+
+```console
+$ docker --debug buildx inspect elated_tesla
+```

--- a/driver/features.go
+++ b/driver/features.go
@@ -5,7 +5,7 @@ type Feature string
 const OCIExporter Feature = "OCI exporter"
 const DockerExporter Feature = "Docker exporter"
 
-const CacheExport Feature = "cache export"
-const MultiPlatform Feature = "multiple platforms"
+const CacheExport Feature = "Cache export"
+const MultiPlatform Feature = "Multiple platforms"
 
-const HistoryAPI Feature = "history api"
+const HistoryAPI Feature = "History API"


### PR DESCRIPTION
While working on #1846, I wanted to know nodes capability for some builders. I think we should display the list of features when inspecting a builder.

```
$ docker --debug buildx inspect docker2010
Name:   docker2010
Driver: docker

Nodes:
Name:      docker2010
Endpoint:  docker2010
Status:    running
Buildkit:  v0.8.2+eeb7b65
Platforms: linux/amd64, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/arm/v7, linux/arm/v6
Features:
 Cache export:       false
 Docker exporter:    false
 History API:        false
 Multiple platforms: false
 OCI exporter:       false
```

```
$ docker --debug buildx inspect docker2010
Name:          default
Driver:        docker
Last Activity: 2023-05-30 12:30:59 +0000 UTC

Nodes:
Name:      default
Endpoint:  default
Status:    running
Buildkit:  v0.11.6
Platforms: linux/amd64, linux/amd64/v2, linux/amd64/v3, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/mips64le, linux/mips64, linux/arm/v7, linux/arm/v6
Features:
 Cache export:       false
 Docker exporter:    false
 History API:        true
 Multiple platforms: false
 OCI exporter:       false
GC Policy rule#0:
 All:           false
 Filters:       type==source.local,type==exec.cachemount,type==source.git.checkout
 Keep Duration: 172.8µs
 Keep Bytes:    2.764GiB
GC Policy rule#1:
 All:           false
 Keep Duration: 5.184ms
 Keep Bytes:    20GiB
GC Policy rule#2:
 All:        false
 Keep Bytes: 20GiB
GC Policy rule#3:
 All:        true
 Keep Bytes: 20GiB
```