### PR TITLE
inspect: display proxy config

### DIFF
--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -94,6 +94,13 @@ func runInspect(dockerCli command.Cli, in inspectOptions) error {
 					fmt.Fprintf(w, "Buildkit:\t%s\n", nodes[i].Version)
 				}
 				fmt.Fprintf(w, "Platforms:\t%s\n", strings.Join(platformutil.FormatInGroups(n.Node.Platforms, n.Platforms), ", "))
+				if len(nodes[i].ProxyConfig) > 0 {
+					fmt.Fprintf(w, "Proxy config:\n")
+					for _, k := range sortedKeys(nodes[i].ProxyConfig) {
+						v := nodes[i].ProxyConfig[k]
+						fmt.Fprintf(w, "\t%s:\t%s\n", k, v)
+					}
+				}
 				if debug.IsEnabled() {
 					fmt.Fprintf(w, "Features:\n")
 					features := nodes[i].Driver.Features(ctx)


### PR DESCRIPTION
related to https://github.com/docker/build-push-action/pull/872 where I wanted to set proxy envs through docker config but could not see if it was set without this change: https://github.com/docker/build-push-action/actions/runs/5175036309/jobs/9322112341#step:6:136

```
  /usr/bin/docker buildx inspect --bootstrap --builder builder-bd6fd9e2-bff4-4452-89fc-c77bdad3af8c
  #1 [internal] booting buildkit
  #1 pulling image moby/buildkit:buildx-stable-1 0.1s done
  #1 creating container buildx_buildkit_builder-bd6fd9e2-bff4-4452-89fc-c77bdad3af8c0
  #1 creating container buildx_buildkit_builder-bd6fd9e2-bff4-4452-89fc-c77bdad3af8c0 0.5s done
  #1 DONE 0.7s
  Name:          builder-bd6fd9e2-bff4-4452-89fc-c77bdad3af8c
  Driver:        docker-container
  Last Activity: 2023-06-05 08:36:32 +0000 UTC
  
  Nodes:
  Name:           builder-bd6fd9e2-bff4-4452-89fc-c77bdad3af8c0
  Endpoint:       unix:///var/run/docker.sock
  Driver Options: image="moby/buildkit:buildx-stable-1"
  Status:         running
  Flags:          --debug
  Buildkit:       v0.11.6
  Platforms:      linux/amd64, linux/amd64/v2, linux/amd64/v3, linux/amd64/v4, linux/386
  Labels:
   org.mobyproject.buildkit.worker.executor:         oci
   org.mobyproject.buildkit.worker.hostname:         736e3a301e01
   org.mobyproject.buildkit.worker.network:          host
   org.mobyproject.buildkit.worker.oci.process-mode: sandbox
   org.mobyproject.buildkit.worker.selinux.enabled:  false
   org.mobyproject.buildkit.worker.snapshotter:      overlayfs
  Proxy config:
   HTTPS_PROXY: http://localhost:3128
   HTTP_PROXY:  http://localhost:3128
  GC Policy rule#0:
   All:           false
   Filters:       type==source.local,type==exec.cachemount,type==source.git.checkout
   Keep Duration: 48h0m0s
   Keep Bytes:    488.3MiB
  GC Policy rule#1:
   All:           false
   Keep Duration: 1440h0m0s
   Keep Bytes:    8.382GiB
  GC Policy rule#2:
   All:        false
   Keep Bytes: 8.382GiB
  GC Policy rule#3:
   All:        true
   Keep Bytes: 8.382GiB
```