### PR TITLE
Fix a couple `--invoke` entrypoint interaction bugs

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -726,6 +726,9 @@ func parseInvokeConfig(invoke string) (cfg invokeConfig, err error) {
 			cfg.Cmd = append(cfg.Cmd, value) // TODO: support JSON
 		case "entrypoint":
 			cfg.Entrypoint = append(cfg.Entrypoint, value) // TODO: support JSON
+			if cfg.Cmd == nil {
+				cfg.Cmd = []string{}
+			}
 		case "env":
 			cfg.Env = append(cfg.Env, value)
 		case "user":

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -282,6 +282,7 @@ func (m *monitor) startInvoke(ctx context.Context, pid string, cfg controllerapi
 	}
 	if len(cfg.Entrypoint) == 0 && len(cfg.Cmd) == 0 {
 		cfg.Entrypoint = []string{"sh"} // launch shell by default
+		cfg.Cmd = []string{}
 	}
 	go func() {
 		// Start a new invoke


### PR DESCRIPTION
When running `--invoke` against images that have `Cmd` set, the interactions with `Entrypoint` start to cause issues like the following:

    /usr/local/bin/bash: /usr/local/bin/bash: cannot execute binary file

Or:

    sh: can't open 'bash': No such file or directory

This patch fixes those by explicitly setting `Cmd` to be empty if it is unspecified and `Entrypoint` is being set, which matches `docker`'s behavior:

    $ docker image inspect --format '{{ json .Config.Entrypoint }} + {{ json .Config.Cmd }}' bash
    ["docker-entrypoint.sh"] + ["bash"]
    $ docker create --name foo --entrypoint bash bash
    $ docker container inspect --format '{{ json .Config.Entrypoint }} + {{ json .Config.Cmd }}' foo
    ["bash"] + null
    $ docker rm foo
    $ docker create --name foo bash ls
    $ docker container inspect --format '{{ json .Config.Entrypoint }} + {{ json .Config.Cmd }}' foo
    ["docker-entrypoint.sh"] + ["ls"]

(There are still some weird edge cases in the interaction between the `InvokeConfig` and the original image config, but this fixes the most irritating for me and the rest are going to be deeper changes that are possibly less acceptable. 😅)