### PR TITLE
build: prefer local image resolution for docker driver

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -593,7 +593,10 @@ func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt Op
 	}
 
 	if opt.Pull {
-		so.FrontendAttrs["image-resolve-mode"] = "pull"
+		so.FrontendAttrs["image-resolve-mode"] = pb.AttrImageResolveModeForcePull
+	} else if nodeDriver.IsMobyDriver() {
+		// moby driver always resolves local images by default
+		so.FrontendAttrs["image-resolve-mode"] = pb.AttrImageResolveModePreferLocal
 	}
 	if opt.Target != "" {
 		so.FrontendAttrs["target"] = opt.Target

--- a/tests/integration.go
+++ b/tests/integration.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/containerd/continuity/fs/fstest"
@@ -54,4 +55,21 @@ func buildxCmd(sb integration.Sandbox, opts ...cmdOpt) *exec.Cmd {
 	}
 
 	return cmd
+}
+
+func dockerCmd(sb integration.Sandbox, opts ...cmdOpt) *exec.Cmd {
+	cmd := exec.Command("docker")
+	cmd.Env = append([]string{}, os.Environ()...)
+	for _, opt := range opts {
+		opt(cmd)
+	}
+	if context := sb.DockerAddress(); context != "" {
+		cmd.Env = append(cmd.Env, "DOCKER_CONTEXT="+context)
+	}
+	return cmd
+}
+
+func isDockerWorker(sb integration.Sandbox) bool {
+	sbDriver, _, _ := strings.Cut(sb.Name(), "+")
+	return sbDriver == "docker"
 }


### PR DESCRIPTION
If pull option is not set we should prefer local image resolution for docker driver. In follow-up we should look at making the `--pull` flag accepting a specific state like the `docker run` command does: https://docs.docker.com/engine/reference/commandline/run/#pull