### PR TITLE
Add Bearer token support

### DIFF
--- a/driver/kubernetes/context/load.go
+++ b/driver/kubernetes/context/load.go
@@ -23,6 +23,7 @@ type EndpointMeta struct {
 	AuthProvider     *clientcmdapi.AuthProviderConfig `json:",omitempty"`
 	Exec             *clientcmdapi.ExecConfig         `json:",omitempty"`
 	UsernamePassword *UsernamePassword                `json:"usernamePassword,omitempty"`
+	Token            string                           `json:"token,omitempty"`
 }
 
 // UsernamePassword contains username/password auth info
@@ -76,6 +77,9 @@ func (c *Endpoint) KubernetesConfig() clientcmd.ClientConfig {
 	if c.UsernamePassword != nil {
 		authInfo.Username = c.UsernamePassword.Username
 		authInfo.Password = c.UsernamePassword.Password
+	}
+	if c.Token != "" {
+		authInfo.Token = c.Token
 	}
 	authInfo.AuthProvider = c.AuthProvider
 	authInfo.Exec = c.Exec

--- a/driver/kubernetes/context/save.go
+++ b/driver/kubernetes/context/save.go
@@ -68,6 +68,7 @@ func FromKubeConfig(kubeconfig, kubeContext, namespaceOverride string) (Endpoint
 			AuthProvider:     clientcfg.AuthProvider,
 			Exec:             clientcfg.ExecProvider,
 			UsernamePassword: usernamePassword,
+			Token:            clientcfg.BearerToken,
 		},
 		TLSData: tlsData,
 	}, nil


### PR DESCRIPTION
Investigating #1884 it turned out that Bearer token is not being passed along from config file, resulting in described issues. This PR adds Bearer Token support for authentication.

This fix was tested with GitLab Kubernetes Agent Server successfully. 