### PR TITLE
test: register docker worker with containerd snapshotter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,7 @@ jobs:
       matrix:
         worker:
           - docker
+          - docker\+containerd  # same as docker, but with containerd snapshotter
           - docker-container
           - remote
         pkg:
@@ -101,8 +102,8 @@ jobs:
           export TEST_REPORT_SUFFIX=-${{ github.job }}-$(echo "${{ matrix.pkg }}-${{ matrix.skip-integration-tests }}-${{ matrix.worker }}" | tr -dc '[:alnum:]-\n\r' | tr '[:upper:]' '[:lower:]')
           ./hack/test
         env:
-          TEST_DOCKERD: "${{ (matrix.worker == 'docker' || matrix.worker == 'docker-container') && '1' || '0' }}"
-          TESTFLAGS: "${{ (matrix.worker == 'docker') && env.TESTFLAGS_DOCKER || env.TESTFLAGS }} --run=//worker=${{ matrix.worker }}$"
+          TEST_DOCKERD: "${{ startsWith(matrix.worker, 'docker') && '1' || '0' }}"
+          TESTFLAGS: "${{ (matrix.worker == 'docker' || matrix.worker == 'docker\\+containerd') && env.TESTFLAGS_DOCKER || env.TESTFLAGS }} --run=//worker=${{ matrix.worker }}$"
           TESTPKGS: "${{ matrix.pkg }}"
           SKIP_INTEGRATION_TESTS: "${{ matrix.skip-integration-tests }}"
       -

--- a/tests/build.go
+++ b/tests/build.go
@@ -106,7 +106,7 @@ func testImageIDOutput(t *testing.T, sb integration.Sandbox) {
 
 	cmd := buildxCmd(
 		sb,
-		withArgs("build", "-q", outFlag, "--iidfile", filepath.Join(targetDir, "iid.txt"), "--metadata-file", filepath.Join(targetDir, "md.json"), dir),
+		withArgs("build", "-q", "--provenance", "false", outFlag, "--iidfile", filepath.Join(targetDir, "iid.txt"), "--metadata-file", filepath.Join(targetDir, "md.json"), dir),
 	)
 	stdout := bytes.NewBuffer(nil)
 	cmd.Stdout = stdout

--- a/tests/inspect.go
+++ b/tests/inspect.go
@@ -33,6 +33,8 @@ func testInspect(t *testing.T, sb integration.Sandbox) {
 			driver = strings.TrimSpace(v)
 		}
 	}
+
 	require.Equal(t, sb.Address(), name)
-	require.Equal(t, sb.Name(), driver)
+	sbDriver, _, _ := strings.Cut(sb.Name(), "+")
+	require.Equal(t, sbDriver, driver)
 }

--- a/tests/ls.go
+++ b/tests/ls.go
@@ -23,9 +23,10 @@ func testLs(t *testing.T, sb integration.Sandbox) {
 	out, err := lsCmd(sb)
 	require.NoError(t, err, string(out))
 
+	sbDriver, _, _ := strings.Cut(sb.Name(), "+")
 	for _, line := range strings.Split(out, "\n") {
 		if strings.Contains(line, sb.Address()) {
-			require.Contains(t, line, sb.Name())
+			require.Contains(t, line, sbDriver)
 			return
 		}
 	}

--- a/tests/workers/docker.go
+++ b/tests/workers/docker.go
@@ -14,10 +14,15 @@ func InitDockerWorker() {
 	integration.Register(&dockerWorker{
 		id: "docker",
 	})
+	integration.Register(&dockerWorker{
+		id:                    "docker+containerd",
+		containerdSnapshotter: true,
+	})
 }
 
 type dockerWorker struct {
-	id string
+	id                    string
+	containerdSnapshotter bool
 }
 
 func (c dockerWorker) Name() string {
@@ -30,7 +35,8 @@ func (c dockerWorker) Rootless() bool {
 
 func (c dockerWorker) New(ctx context.Context, cfg *integration.BackendConfig) (b integration.Backend, cl func() error, err error) {
 	moby := integration.Moby{
-		ID: c.id,
+		ID:                    c.id,
+		ContainerdSnapshotter: c.containerdSnapshotter,
 	}
 	bk, bkclose, err := moby.New(ctx, cfg)
 	if err != nil {


### PR DESCRIPTION
follow-up https://github.com/docker/buildx/pull/1886#discussion_r1233562589

Adds `docker+containerd` worker to our matrix to be able to test against dockerd with containerd storage enabled.