### PR TITLE
build: add GO_EXTRA_FLAGS argument

### DIFF
--- a/hack/build
+++ b/hack/build
@@ -9,8 +9,9 @@ set -e
 
 : "${CGO_ENABLED=0}"
 : "${GO_PKG=github.com/docker/buildx}"
+: "${GO_EXTRA_FLAGS=}"
 : "${GO_LDFLAGS=-X ${GO_PKG}/version.Version=${VERSION} -X ${GO_PKG}/version.Revision=${REVISION} -X ${GO_PKG}/version.Package=${PACKAGE}}"
 : "${GO_EXTRA_LDFLAGS=}"
 
 set -x
-CGO_ENABLED=$CGO_ENABLED go build -mod vendor -trimpath -ldflags "${GO_LDFLAGS} ${GO_EXTRA_LDFLAGS}" -o "${DESTDIR}/docker-buildx" ./cmd/buildx
+CGO_ENABLED=$CGO_ENABLED go build -mod vendor -trimpath ${GO_EXTRA_FLAGS} -ldflags "${GO_LDFLAGS} ${GO_EXTRA_LDFLAGS}" -o "${DESTDIR}/docker-buildx" ./cmd/buildx


### PR DESCRIPTION
This is useful for setting things like -buildmode=pie when packaging docker-buildx for distributions.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>