### PR TITLE
bake: ignore profiles in compose definitions

### DIFF
--- a/bake/compose.go
+++ b/bake/compose.go
@@ -37,6 +37,7 @@ func ParseCompose(cfgs []compose.ConfigFile, envs map[string]string) (*Config, e
 	}, func(options *loader.Options) {
 		options.SetProjectName("bake", false)
 		options.SkipNormalization = true
+		options.Profiles = []string{"*"}
 	})
 	if err != nil {
 		return nil, err

--- a/bake/compose_test.go
+++ b/bake/compose_test.go
@@ -36,6 +36,8 @@ services:
         - token
         - aws
   webapp2:
+    profiles:
+      - test
     build:
       context: ./dir
       dockerfile_inline: |


### PR DESCRIPTION
fixes https://github.com/docker/buildx/issues/1902

If a profile is being set in the compose file, build will not run against this service unless this profile is enabled: https://docs.docker.com/compose/compose-file/03-compose-file/#profiles

For compose it makes sense but bake doesn't have any support for profiles so I think we should just ignore them: https://github.com/compose-spec/compose-go/blob/532cd92682a3f00c22c1286f7eedccab2a232baa/types/project.go#L258