### PR TITLE
utils/buildflags: ParseEntitlements(): use BuildKit's parsing

### DIFF
--- a/util/buildflags/entitlements.go
+++ b/util/buildflags/entitlements.go
@@ -1,21 +1,15 @@
 package buildflags
 
-import (
-	"github.com/moby/buildkit/util/entitlements"
-	"github.com/pkg/errors"
-)
+import "github.com/moby/buildkit/util/entitlements"
 
 func ParseEntitlements(in []string) ([]entitlements.Entitlement, error) {
 	out := make([]entitlements.Entitlement, 0, len(in))
 	for _, v := range in {
-		switch v {
-		case "security.insecure":
-			out = append(out, entitlements.EntitlementSecurityInsecure)
-		case "network.host":
-			out = append(out, entitlements.EntitlementNetworkHost)
-		default:
-			return nil, errors.Errorf("invalid entitlement: %v", v)
+		e, err := entitlements.Parse(v)
+		if err != nil {
+			return nil, err
 		}
+		out = append(out, e)
 	}
 	return out, nil
 }


### PR DESCRIPTION
Use buildkit's parsing of entitlements to make sure that accepted values match what's accepted by BuildKit.