### PR TITLE
build: toControllerOptions: micro-optimization

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -121,8 +121,8 @@ func (o *buildOptions) toControllerOptions() (*controllerapi.BuildOptions, error
 	}
 
 	// TODO: extract env var parsing to a method easily usable by library consumers
-	if v := os.Getenv("SOURCE_DATE_EPOCH"); v != "" {
-		if _, ok := opts.BuildArgs["SOURCE_DATE_EPOCH"]; !ok {
+	if _, ok := opts.BuildArgs["SOURCE_DATE_EPOCH"]; !ok {
+		if v := os.Getenv("SOURCE_DATE_EPOCH"); v != "" {
 			opts.BuildArgs["SOURCE_DATE_EPOCH"] = v
 		}
 	}


### PR DESCRIPTION
Swapping the order of these checks, which I guess is the most minimal optimization possible

    BenchmarkGetEnv-10    68764720    16.82  ns/op   0 B/op   0 allocs/op
    BenchmarkMap-10      454135184     2.635 ns/op   0 B/op   0 allocs/op