### PR TITLE
Controller: Include CgroupParent in build.Options

### DIFF
--- a/controller/build/build.go
+++ b/controller/build/build.go
@@ -54,6 +54,7 @@ func RunBuild(ctx context.Context, dockerCli command.Cli, in controllerapi.Build
 			NamedContexts:  contexts,
 		},
 		BuildArgs:     in.BuildArgs,
+		CgroupParent:  in.CgroupParent,
 		ExtraHosts:    in.ExtraHosts,
 		Labels:        in.Labels,
 		NetworkMode:   in.NetworkMode,


### PR DESCRIPTION
The `--cgroup-parent` option had no effect in build containers due to the CgroupParent field in build.Options not being set. Related: moby/moby#45796.