### PR TITLE
docs: monitor: Tiny fixes for help messages

### DIFF
--- a/docs/guides/debugging.md
+++ b/docs/guides/debugging.md
@@ -106,12 +106,12 @@ Available commands are:
   disconnect	disconnect a client from a buildx server. Specific session ID can be specified an arg
   exec		execute a process in the interactive container
   exit		exits monitor
-  help		shows this message
+  help		shows this message. Optionally pass a command name as an argument to print the detailed usage.
   kill		kill buildx server
   list		list buildx sessions
   ps		list processes invoked by "exec". Use "attach" to attach IO to that process
   reload	reloads the context and build it
-  rollback	re-runs the interactive container with initial rootfs contents
+  rollback	re-runs the interactive container with the step's rootfs contents
 ```
 
 ## Build controllers

--- a/monitor/commands/attach.go
+++ b/monitor/commands/attach.go
@@ -28,7 +28,7 @@ Usage:
   attach ID
 
 ID is for a session (visible via list command) or a process (visible via ps command).
-If you attached to a process, use Ctrl-c-a for switching the monitor to that process's STDIO.
+If you attached to a process, use Ctrl-a-c for switching the monitor to that process's STDIO.
 `,
 	}
 }


### PR DESCRIPTION
- 6f37d9bee7e6dd2aaf3813bd0414c4aaee456740 : monitor: attach: fix typo in long help message
- ca08eb65e23672273311780e7897997f46462a93 : docs: debug: update the output of help command to the latest message