### PR TITLE
build: missing newline when printing build details on error

### DIFF
--- a/tests/build.go
+++ b/tests/build.go
@@ -3,10 +3,11 @@ package tests
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/moby/buildkit/util/testutil"
 	"github.com/moby/buildkit/util/testutil/integration"
 	"github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,6 +35,7 @@ var buildTests = []func(t *testing.T, sb integration.Sandbox){
 	testBuildRegistryExport,
 	testBuildTarExport,
 	testBuildMobyFromLocalImage,
+	testBuildDetailsLink,
 }
 
 func testBuild(t *testing.T, sb integration.Sandbox) {
@@ -185,6 +188,48 @@ RUN busybox | head -1 | grep v1.35.0
 	)
 	cmd.Stderr = os.Stderr
 	require.NoError(t, cmd.Run())
+}
+
+func testBuildDetailsLink(t *testing.T, sb integration.Sandbox) {
+	buildDetailsPattern := regexp.MustCompile(`(?m)^View build details: docker-desktop://dashboard/build/[^/]+/[^/]+/[^/]+\n$`)
+
+	// build simple dockerfile
+	dockerfile := []byte(`FROM busybox:latest
+RUN echo foo > /bar`)
+	dir := tmpdir(t, fstest.CreateFile("Dockerfile", dockerfile, 0600))
+	cmd := buildxCmd(sb, withArgs("build", "--output=type=cacheonly", dir))
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	require.False(t, buildDetailsPattern.MatchString(string(out)), fmt.Sprintf("build details link not expected in output, got %q", out))
+
+	// create desktop-build .lastaccess file
+	home, err := os.UserHomeDir() // TODO: sandbox should create a temp home dir and expose it through its interface
+	require.NoError(t, err)
+	dbDir := path.Join(home, ".docker", "desktop-build")
+	require.NoError(t, os.MkdirAll(dbDir, 0755))
+	dblaFile, err := os.Create(path.Join(dbDir, ".lastaccess"))
+	require.NoError(t, err)
+	defer func() {
+		dblaFile.Close()
+		if err := os.Remove(dblaFile.Name()); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// build again
+	cmd = buildxCmd(sb, withArgs("build", "--output=type=cacheonly", dir))
+	out, err = cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	require.True(t, buildDetailsPattern.MatchString(string(out)), fmt.Sprintf("expected build details link in output, got %q", out))
+
+	// build erroneous dockerfile
+	dockerfile = []byte(`FROM busybox:latest
+RUN exit 1`)
+	dir = tmpdir(t, fstest.CreateFile("Dockerfile", dockerfile, 0600))
+	cmd = buildxCmd(sb, withArgs("build", "--output=type=cacheonly", dir))
+	out, err = cmd.CombinedOutput()
+	require.Error(t, err, string(out))
+	require.True(t, buildDetailsPattern.MatchString(string(out)), fmt.Sprintf("expected build details link in output, got %q", out))
 }
 
 func createTestProject(t *testing.T) string {

--- a/util/desktop/desktop.go
+++ b/util/desktop/desktop.go
@@ -81,6 +81,6 @@ func (e *ErrorWithBuildRef) Print(w io.Writer) error {
 	if _, err := console.ConsoleFromFile(os.Stderr); err == nil {
 		term = true
 	}
-	fmt.Fprintf(w, "\n%s", BuildDetailsOutput(map[string]string{"default": e.Ref}, term))
+	fmt.Fprintf(w, "\n%s\n", BuildDetailsOutput(map[string]string{"default": e.Ref}, term))
 	return nil
 }


### PR DESCRIPTION
Before

```
foo@bar:~ $ docker buildx build .
...
------
Dockerfile:356
--------------------
 355 |     ARG TARGETPLATFORM
 356 | >>> RUN --mount=type=cache,sharing=locked,id=moby-rootlesskit-aptlib,target=/var/lib/apt \
 357 | >>>     --mount=type=cache,sharing=locked,id=moby-rootlesskit-aptcache,target=/var/cache/apt \
 358 | >>>         apt-get update && xx-apt-get install -y --no-install-recommends \
 359 | >>>             gcc libc6-dev
 360 |     ENV GO111MODULE=on
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get update && xx-apt-get install -y --no-install-recommends             gcc libc6-dev" did not complete successfully: exit code: 100

View build details: docker-desktop://dashboard/build/default/default/oj5lusuq2n0ufovvphbaxfjn0foo@bar:~ $
```

After

```
foo@bar:~ $ docker buildx build .
...
------
Dockerfile:356
--------------------
 355 |     ARG TARGETPLATFORM
 356 | >>> RUN --mount=type=cache,sharing=locked,id=moby-rootlesskit-aptlib,target=/var/lib/apt \
 357 | >>>     --mount=type=cache,sharing=locked,id=moby-rootlesskit-aptcache,target=/var/cache/apt \
 358 | >>>         apt-get update && xx-apt-get install -y --no-install-recommends \
 359 | >>>             gcc libc6-dev
 360 |     ENV GO111MODULE=on
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get update && xx-apt-get install -y --no-install-recommends             gcc libc6-dev" did not complete successfully: exit code: 100

View build details: docker-desktop://dashboard/build/default/default/oj5lusuq2n0ufovvphbaxfjn0
foo@bar:~ $
```