### PR TITLE
build: read body response to check for erroneous image export to docker

### DIFF
--- a/util/dockerutil/progress.go
+++ b/util/dockerutil/progress.go
@@ -1,15 +1,19 @@
-package progress
+package dockerutil
 
 import (
+	"errors"
 	"io"
 	"time"
 
+	"github.com/docker/buildx/util/progress"
+	"github.com/docker/cli/cli/streams"
+	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/identity"
 	"github.com/opencontainers/go-digest"
 )
 
-func FromReader(w Writer, name string, rc io.ReadCloser) {
+func fromReader(w progress.Writer, name string, rc io.ReadCloser) error {
 	dgst := digest.FromBytes([]byte(identity.NewID()))
 	tm := time.Now()
 
@@ -23,7 +27,12 @@ func FromReader(w Writer, name string, rc io.ReadCloser) {
 		Vertexes: []*client.Vertex{&vtx},
 	})
 
-	_, err := io.Copy(io.Discard, rc)
+	err := jsonmessage.DisplayJSONMessagesToStream(rc, streams.NewOut(io.Discard), nil)
+	if err != nil {
+		if jerr, ok := err.(*jsonmessage.JSONError); ok {
+			err = errors.New(jerr.Message)
+		}
+	}
 
 	tm2 := time.Now()
 	vtx2 := vtx
@@ -34,4 +43,5 @@ func FromReader(w Writer, name string, rc io.ReadCloser) {
 	w.Write(&client.SolveStatus{
 		Vertexes: []*client.Vertex{&vtx2},
 	})
+	return err
 }


### PR DESCRIPTION
- fixes https://github.com/docker/buildx/issues/593
- fixes https://github.com/docker/build-push-action/issues/321

```dockerfile
FROM nvidia/cuda:12.1.0-cudnn8-devel-ubi9
RUN dd if=/dev/zero of=/output.dat bs=8192M count=1
RUN uname -a
```

```
#6 [2/3] RUN dd if=/dev/zero of=/output.dat bs=8192M count=1
#6 9.653 0+1 records in
#6 9.653 0+1 records out
#6 9.657 2147479552 bytes (2.1 GB, 2.0 GiB) copied, 9.53004 s, 225 MB/s
#6 DONE 12.0s

#7 [3/3] RUN uname -a
#7 0.066 Linux buildkitsandbox 5.15.0-1042-azure #49-Ubuntu SMP Tue Jul 11 17:28:46 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
#7 DONE 0.1s

#8 exporting to docker image format
#8 exporting layers
#8 exporting layers 14.1s done
#8 exporting manifest sha256:00f00d30fad0d29a48903e5bd5e62f0eb4fa3e64cc4c0c457068e2fb9580e274 done
#8 exporting config sha256:8c50355a7c7c256edf058253f8b9835766f22147d8e09e37f00012992ce1c0e0 done
#8 sending tarball
#8 sending tarball 95.6s done
#8 DONE 109.7s

#9 importing to docker
#9 ERROR: Error processing tar file(exit status 1): write /blobs/sha256/d7e3fb36b984700f58ea61a1ccb9d122cf4a1a13955c6ed82607ea370ac48a05: no space left on device
------
 > importing to docker:
------
```

```
$ docker buildx create --name foo
$ docker buildx build --load -t foo .
```
