### PR TITLE
Revert "bake: fix incorrect dockerfile resolution against cwd:// context"

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -1048,11 +1048,11 @@ func toBuildOpt(t *Target, inp *Input) (*build.Options, error) {
 		bi.DockerfileInline = *t.DockerfileInline
 	}
 	updateContext(&bi, inp)
-	if strings.HasPrefix(bi.ContextPath, "cwd://") {
-		bi.ContextPath = path.Clean(strings.TrimPrefix(bi.ContextPath, "cwd://"))
-	}
 	if !build.IsRemoteURL(bi.ContextPath) && bi.ContextState == nil && !path.IsAbs(bi.DockerfilePath) {
 		bi.DockerfilePath = path.Join(bi.ContextPath, bi.DockerfilePath)
+	}
+	if strings.HasPrefix(bi.ContextPath, "cwd://") {
+		bi.ContextPath = path.Clean(strings.TrimPrefix(bi.ContextPath, "cwd://"))
 	}
 	for k, v := range bi.NamedContexts {
 		if strings.HasPrefix(v.Path, "cwd://") {

--- a/bake/bake_test.go
+++ b/bake/bake_test.go
@@ -386,19 +386,18 @@ func TestHCLCwdPrefix(t *testing.T) {
 	m, g, err := ReadTargets(ctx, []File{fp}, []string{"app"}, nil, nil)
 	require.NoError(t, err)
 
-	bo, err := TargetsToBuildOpt(m, &Input{})
+	require.Equal(t, 1, len(m))
+	_, ok := m["app"]
+	require.True(t, ok)
+
+	_, err = TargetsToBuildOpt(m, &Input{})
 	require.NoError(t, err)
 
-	require.Equal(t, 1, len(g))
-	require.Equal(t, []string{"app"}, g["default"].Targets)
-
-	require.Equal(t, 1, len(m))
-	require.Contains(t, m, "app")
 	require.Equal(t, "test", *m["app"].Dockerfile)
 	require.Equal(t, "foo", *m["app"].Context)
 
-	require.Equal(t, "foo/test", bo["app"].Inputs.DockerfilePath)
-	require.Equal(t, "foo", bo["app"].Inputs.ContextPath)
+	require.Equal(t, 1, len(g))
+	require.Equal(t, []string{"app"}, g["default"].Targets)
 }
 
 func TestOverrideMerge(t *testing.T) {


### PR DESCRIPTION
Revert "bake: fix incorrect dockerfile resolution against cwd:// context"

As discussed, since this is a behavior change, we should't pull this to a patch release.