### PR TITLE
hack: force go version to 1.20.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.20
+ARG GO_VERSION=1.20.5
 ARG XX_VERSION=1.2.1
 
 ARG DOCKER_VERSION=24.0.2

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "GO_VERSION" {
-  default = "1.20"
+  default = "1.20.5"
 }
 variable "DOCS_FORMATS" {
   default = "md"


### PR DESCRIPTION
A temporary workaround for "http: invalid Host header" introduced in go 1.20.6.

In the future, we should probably keep this pinned to minor versions to prevent these kind of breakages. We can bump these manually in the future without much effort.

This also fixes our CI in the meantime :)