### PR TITLE
build: assume '.' if no args are passed

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -415,9 +415,13 @@ func buildCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 		Use:     "build [OPTIONS] PATH | URL | -",
 		Aliases: []string{"b"},
 		Short:   "Start a build",
-		Args:    cli.ExactArgs(1),
+		Args:    cli.RequiresMaxArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			options.contextPath = args[0]
+			if len(args) == 0 {
+				options.contextPath = "."
+			} else {
+				options.contextPath = args[0]
+			}
 			options.builder = rootOpts.builder
 			options.metadataFile = cFlags.metadataFile
 			options.noCache = false


### PR DESCRIPTION
Before:

```shell
$ docker build -t foo
ERROR: "docker buildx build" requires exactly 1 argument.
# swearing omitted
$ docker build -t foo .
[+] Building 0.4s (3/3) FINISHED
 => [internal] load .dockerignore                                                                                                                                                                            
  ...etc...
```

After:

```shell
$ docker build -t foo
[+] Building 0.4s (3/3) FINISHED
 => [internal] load .dockerignore                                                                                                                                                                            
  ...etc...
```

If this seems fine to you I can make a [similar change in docker/cli](https://github.com/docker/cli/compare/master...imjasonh:cli-1:assume-dot)