### PR TITLE
kubernetes driver // allow custom annotations and labels

### DIFF
--- a/docs/reference/buildx_create.md
+++ b/docs/reference/buildx_create.md
@@ -141,7 +141,7 @@ to achieve that.
 
 Passes additional driver-specific options.
 
-Note: When using quoted values for example for the `nodeselector` or
+Note: When using quoted values for the `nodeselector`, `annotations`, `labels` or
 `tolerations` options, ensure that quotes are escaped correctly for your shell.
 
 #### `docker` driver
@@ -165,6 +165,8 @@ No driver options.
 - `limits.memory` - Sets the limit memory value specified in bytes or with a valid suffix. Example `limits.memory=500Mi`, `limits.memory=4G`
 - `serviceaccount` - Sets the created pod's service account. Example `serviceaccount=example-sa`
 - `"nodeselector=label1=value1,label2=value2"` - Sets the kv of `Pod` nodeSelector. No Defaults. Example `nodeselector=kubernetes.io/arch=arm64`
+- `"annotations=domain/thing1=value1,domain/thing2=value2"` - Sets additional annotations on the deployments and pods. No Defaults. Example `annotations=example.com/owner=sarah`
+- `"labels=domain/thing1=value1,domain/thing2=value2"` - Sets additional labels on the deployments and pods. No Defaults. Example `labels=example.com/team=rd`
 - `"tolerations=key=foo,value=bar;key=foo2,operator=exists;key=foo3,effect=NoSchedule"` - Sets the `Pod` tolerations. Accepts the same values as the kube manifest tolera>tions. Key-value pairs are separated by `,`, tolerations are separated by `;`. No Defaults. Example `tolerations=operator=exists`
 - `rootless=(true|false)` - Run the container as a non-root user without `securityContext.privileged`. Needs Kubernetes 1.19 or later. [Using Ubuntu host kernel is recommended](https://github.com/moby/buildkit/blob/master/docs/rootless.md). Defaults to false.
 - `loadbalance=(sticky|random)` - Load-balancing strategy. If set to "sticky", the pod is chosen using the hash of the context path. Defaults to "sticky"

--- a/driver/kubernetes/manifest/manifest.go
+++ b/driver/kubernetes/manifest/manifest.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/buildx/util/platformutil"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -31,24 +32,32 @@ type DeploymentOpt struct {
 	// files mounted at /etc/buildkitd
 	ConfigFiles map[string][]byte
 
-	Rootless       bool
-	NodeSelector   map[string]string
-	Tolerations    []corev1.Toleration
-	RequestsCPU    string
-	RequestsMemory string
-	LimitsCPU      string
-	LimitsMemory   string
-	Platforms      []v1.Platform
+	Rootless          bool
+	NodeSelector      map[string]string
+	CustomAnnotations map[string]string
+	CustomLabels      map[string]string
+	Tolerations       []corev1.Toleration
+	RequestsCPU       string
+	RequestsMemory    string
+	LimitsCPU         string
+	LimitsMemory      string
+	Platforms         []v1.Platform
 }
 
 const (
 	containerName      = "buildkitd"
 	AnnotationPlatform = "buildx.docker.com/platform"
+	LabelApp           = "app"
+)
+
+var (
+	ErrReservedAnnotationPlatform = errors.Errorf("the annotation \"%s\" is reserved and cannot be customized", AnnotationPlatform)
+	ErrReservedLabelApp           = errors.Errorf("the label \"%s\" is reserved and cannot be customized", LabelApp)
 )
 
 func NewDeployment(opt *DeploymentOpt) (d *appsv1.Deployment, c []*corev1.ConfigMap, err error) {
 	labels := map[string]string{
-		"app": opt.Name,
+		LabelApp: opt.Name,
 	}
 	annotations := map[string]string{}
 	replicas := int32(opt.Replicas)
@@ -57,6 +66,20 @@ func NewDeployment(opt *DeploymentOpt) (d *appsv1.Deployment, c []*corev1.Config
 
 	if len(opt.Platforms) > 0 {
 		annotations[AnnotationPlatform] = strings.Join(platformutil.Format(opt.Platforms), ",")
+	}
+
+	for k, v := range opt.CustomAnnotations {
+		if k == AnnotationPlatform {
+			return nil, nil, ErrReservedAnnotationPlatform
+		}
+		annotations[k] = v
+	}
+
+	for k, v := range opt.CustomLabels {
+		if k == LabelApp {
+			return nil, nil, ErrReservedLabelApp
+		}
+		labels[k] = v
 	}
 
 	d = &appsv1.Deployment{


### PR DESCRIPTION
This implements custom annotations and labels to be included in kubernetes manifests. Currently, the user has to patch them in a subsequent call.

Motivation: We provide a tool for developers to create/remove buildx builders on a shared k8s cluster. To prevent wasting resources, the buildx deployments are patched with a label (for filtering) and an annotation (an `expire-after` timestamp). A cron janitor eventually finds and removes them. The user may also refresh the timestamp in order to retain their cache for longer if they desire.

Issue: Because creating the builder and patching the annotations requires two calls, I need to handle the cases when the `create` call fails. This isn't always possible in an exception handler, for instance when this happens on a CI server that gets killed abruptly. This forces the janitor to include additional heuristics to find and remove the leaked deployments. It would be simpler if these annotations would be included from the start.