### PR TITLE
k8s: fix missing kubeconfig check from endpoint

### DIFF
--- a/builder/node.go
+++ b/builder/node.go
@@ -82,12 +82,12 @@ func (b *Builder) LoadNodes(ctx context.Context, withData bool) (_ []Node, err e
 				contextStore := b.opts.dockerCli.ContextStore()
 
 				var kcc driver.KubeClientConfig
-				kcc, err = ctxkube.ConfigFromContext(n.Endpoint, contextStore)
+				kcc, err = ctxkube.ConfigFromEndpoint(n.Endpoint, contextStore)
 				if err != nil {
 					// err is returned if n.Endpoint is non-context name like "unix:///var/run/docker.sock".
 					// try again with name="default".
 					// FIXME(@AkihiroSuda): n should retain real context name.
-					kcc, err = ctxkube.ConfigFromContext("default", contextStore)
+					kcc, err = ctxkube.ConfigFromEndpoint("default", contextStore)
 					if err != nil {
 						logrus.Error(err)
 					}


### PR DESCRIPTION
Reported by @jer-k on Slack: https://dockercommunity.slack.com/archives/C7S7A40MP/p1689292389773349

> It appears that https://github.com/docker/buildx/pull/1430 (cc: @crazy-max)) removed the `commands/util.go` file. That file was the only place that called `ctxkube.ConfigFromEndpoint`: https://github.com/docker/buildx/blob/69421182cac77598aa6bba886f5241d71e57f00a/driver/kubernetes/context/load.go#L168
> 
> From what I can tell, this makes it so any buildx instances that are using the Kubernetes driver require either
> 1. `KUBECONFIG=<path_to_config>` to be prepended to any `docker buildx` commands
> 2. `KUBECONFIG` is exported as an environment variable in your shell
> 3. `.kube/config` to point to the cluster
> 
> Previously though `ctxkube.ConfigFromEndpoint` would extract the kubeconfig path from the `buildx/instances/<name>` file. Was this meant to be removed? It isn't a huge deal as I can resolve my issue with one of the above three approaches. I'm more so just curious :slightly_smiling_face:

It has been an oversight during this refactoring.