### PR TITLE
[0.11 backport] update go to 1.20.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.20
+ARG GO_VERSION=1.20.5
 ARG XX_VERSION=1.2.1
 
 ARG DOCKER_VERSION=24.0.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.20.5
+ARG GO_VERSION=1.20.6
 ARG XX_VERSION=1.2.1
 
 ARG DOCKER_VERSION=24.0.2

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "GO_VERSION" {
-  default = "1.20"
+  default = "1.20.5"
 }
 variable "DOCS_FORMATS" {
   default = "md"

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "GO_VERSION" {
-  default = "1.20.5"
+  default = null
 }
 variable "DOCS_FORMATS" {
   default = "md"

--- a/hack/dockerfiles/docs.Dockerfile
+++ b/hack/dockerfiles/docs.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.20
+ARG GO_VERSION=1.20.6
 ARG FORMATS=md,yaml
 
 FROM golang:${GO_VERSION}-alpine AS docsgen

--- a/hack/dockerfiles/generated-files.Dockerfile
+++ b/hack/dockerfiles/generated-files.Dockerfile
@@ -9,7 +9,7 @@ ARG GO_VERSION="1.20.6"
 ARG PROTOC_VERSION="3.11.4"
 
 # protoc is dynamically linked to glibc so can't use alpine base
-FROM golang:${GO_VERSION}-buster AS base
+FROM golang:${GO_VERSION}-bookworm AS base
 RUN apt-get update && apt-get --no-install-recommends install -y git unzip
 ARG PROTOC_VERSION
 ARG TARGETOS

--- a/hack/dockerfiles/generated-files.Dockerfile
+++ b/hack/dockerfiles/generated-files.Dockerfile
@@ -5,7 +5,7 @@
 # Copyright The Buildx Authors.
 # Licensed under the Apache License, Version 2.0
 
-ARG GO_VERSION="1.20"
+ARG GO_VERSION="1.20.6"
 ARG PROTOC_VERSION="3.11.4"
 
 # protoc is dynamically linked to glibc so can't use alpine base

--- a/hack/dockerfiles/lint.Dockerfile
+++ b/hack/dockerfiles/lint.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.20
+ARG GO_VERSION=1.20.6
 
 FROM golang:${GO_VERSION}-alpine
 RUN apk add --no-cache git gcc musl-dev

--- a/hack/dockerfiles/vendor.Dockerfile
+++ b/hack/dockerfiles/vendor.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.20
+ARG GO_VERSION=1.20.6
 ARG MODOUTDATED_VERSION=v0.8.0
 
 FROM golang:${GO_VERSION}-alpine AS base


### PR DESCRIPTION
- [x] depends on https://github.com/docker/buildx/pull/1952
- backport https://github.com/docker/buildx/pull/1936
- backport https://github.com/docker/buildx/pull/1946

