### PR TITLE
[0.11 backport] build: mark result handle build as internal

### DIFF
--- a/build/result.go
+++ b/build/result.go
@@ -160,6 +160,7 @@ func NewResultHandle(ctx context.Context, cc *client.Client, opt client.SolveOpt
 		opt.Ref = ""
 		opt.Exports = nil
 		opt.CacheExports = nil
+		opt.Internal = true
 		_, respErr = cc.Build(ctx, opt, "buildx", func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
 			res, err := evalDefinition(ctx, c, def)
 			if err != nil {


### PR DESCRIPTION
* backport of #1954 