### PR TITLE
imagetools: Allow annotations for OCI image index

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -1101,7 +1101,7 @@ func BuildWithResultHandler(ctx context.Context, nodes []builder.Node, opt map[s
 								}
 							}
 
-							dt, desc, err := itpull.Combine(ctx, srcs)
+							dt, desc, err := itpull.Combine(ctx, srcs, nil)
 							if err != nil {
 								return err
 							}

--- a/docs/reference/buildx_imagetools_create.md
+++ b/docs/reference/buildx_imagetools_create.md
@@ -11,6 +11,7 @@ Create a new image based on source images
 
 | Name                             | Type          | Default | Description                                                                              |
 |:---------------------------------|:--------------|:--------|:-----------------------------------------------------------------------------------------|
+| `--annotation`                   | `stringArray` |         | Add annotation to the image                                                              |
 | [`--append`](#append)            |               |         | Append to existing manifest                                                              |
 | [`--builder`](#builder)          | `string`      |         | Override the configured builder instance                                                 |
 | [`--dry-run`](#dry-run)          |               |         | Show final image instead of pushing                                                      |

--- a/tests/imagetools.go
+++ b/tests/imagetools.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"encoding/json"
+	"os/exec"
 	"testing"
 
 	"github.com/containerd/containerd/platforms"
@@ -14,6 +15,7 @@ import (
 
 var imagetoolsTests = []func(t *testing.T, sb integration.Sandbox){
 	testImagetoolsInspectAndFilter,
+	testImagetoolsAnnotation,
 }
 
 func testImagetoolsInspectAndFilter(t *testing.T, sb integration.Sandbox) {
@@ -21,18 +23,7 @@ func testImagetoolsInspectAndFilter(t *testing.T, sb integration.Sandbox) {
 		t.Skip("imagetools tests are not driver specific and only run on docker-container")
 	}
 
-	dockerfile := []byte(`
-	FROM scratch
-	ARG TARGETARCH
-	COPY foo-${TARGETARCH} /foo
-	`)
-	dir := tmpdir(
-		t,
-		fstest.CreateFile("Dockerfile", dockerfile, 0600),
-		fstest.CreateFile("foo-amd64", []byte("foo-amd64"), 0600),
-		fstest.CreateFile("foo-arm64", []byte("foo-arm64"), 0600),
-	)
-
+	dir := createDockerfile(t)
 	registry, err := sb.NewRegistry()
 	if errors.Is(err, integration.ErrRequirements) {
 		t.Skip(err.Error())
@@ -76,4 +67,90 @@ func testImagetoolsInspectAndFilter(t *testing.T, sb integration.Sandbox) {
 
 	require.Equal(t, idx.Manifests[1].Digest, idx2.Manifests[0].Digest)
 	require.Equal(t, platforms.Format(*idx.Manifests[1].Platform), platforms.Format(*idx2.Manifests[0].Platform))
+}
+
+func testImagetoolsAnnotation(t *testing.T, sb integration.Sandbox) {
+	if sb.Name() != "docker-container" {
+		t.Skip("imagetools tests are not driver specific and only run on docker-container")
+	}
+
+	dir := createDockerfile(t)
+	registry, err := sb.NewRegistry()
+	if errors.Is(err, integration.ErrRequirements) {
+		t.Skip(err.Error())
+	}
+	require.NoError(t, err)
+	target := registry + "/buildx/imtools:latest"
+
+	out, err := buildCmd(sb, withArgs("--output", "type=registry,oci-mediatypes=true,name="+target, "--platform=linux/amd64,linux/arm64", "--provenance=false", dir))
+	require.NoError(t, err, string(out))
+
+	cmd := buildxCmd(sb, withArgs("imagetools", "inspect", target, "--raw"))
+	dt, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(dt))
+
+	var idx ocispecs.Index
+	err = json.Unmarshal(dt, &idx)
+	require.NoError(t, err)
+	require.Empty(t, idx.Annotations)
+
+	imagetoolsCmd := func(source []string) *exec.Cmd {
+		args := []string{"imagetools", "create", "-t", target, "--annotation", "index:foo=bar", "--annotation", "index:bar=baz",
+			"--annotation", "manifest-descriptor:foo=bar", "--annotation", "manifest-descriptor[linux/amd64]:bar=baz"}
+		args = append(args, source...)
+		return buildxCmd(sb, withArgs(args...))
+	}
+	sources := [][]string{
+		{
+			target,
+		},
+		{
+			target + "@" + string(idx.Manifests[0].Digest),
+			target + "@" + string(idx.Manifests[1].Digest),
+		},
+	}
+	for _, source := range sources {
+		cmd = imagetoolsCmd(source)
+		dt, err = cmd.CombinedOutput()
+		require.NoError(t, err, string(dt))
+
+		newTarget := registry + "/buildx/imtools:annotations"
+		cmd = buildxCmd(sb, withArgs("imagetools", "create", "-t", newTarget, target))
+		dt, err = cmd.CombinedOutput()
+		require.NoError(t, err, string(dt))
+
+		cmd = buildxCmd(sb, withArgs("imagetools", "inspect", newTarget, "--raw"))
+		dt, err = cmd.CombinedOutput()
+		require.NoError(t, err, string(dt))
+
+		err = json.Unmarshal(dt, &idx)
+		require.NoError(t, err)
+		require.Len(t, idx.Annotations, 2)
+		require.Equal(t, "bar", idx.Annotations["foo"])
+		require.Equal(t, "baz", idx.Annotations["bar"])
+		require.Len(t, idx.Manifests, 2)
+		for _, mfst := range idx.Manifests {
+			require.Equal(t, "bar", mfst.Annotations["foo"])
+			if platforms.Format(*mfst.Platform) == "linux/amd64" {
+				require.Equal(t, "baz", mfst.Annotations["bar"])
+			} else {
+				require.Empty(t, mfst.Annotations["bar"])
+			}
+		}
+	}
+}
+
+func createDockerfile(t *testing.T) string {
+	dockerfile := []byte(`
+	FROM scratch
+	ARG TARGETARCH
+	COPY foo-${TARGETARCH} /foo
+	`)
+	dir := tmpdir(
+		t,
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+		fstest.CreateFile("foo-amd64", []byte("foo-amd64"), 0600),
+		fstest.CreateFile("foo-arm64", []byte("foo-arm64"), 0600),
+	)
+	return dir
 }


### PR DESCRIPTION
Currently there isn't any way to add annotations to OCI image index for [multi-arch](https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners). The use case is to have a description in ["About this version"](https://github.com/inspektor-gadget/inspektor-gadget/pkgs/container/inspektor-gadget/106798013?tag=v0.18.1) in GitHub. It will introduce an optional flag of `--annotation` to `imagetools create` to allow adding OCI annotations.

Related: #1171 

### Testing Done:

#### OCI Image Index (annotation added)

```
$ ./bin/build/buildx  imagetools create  -t ghcr.io/inspektor-gadget/inspektor-gadget:v0.18.1 ghcr.io/inspektor-gadget/inspektor-gadget:v0.18.1@sha256:c3780808973801b24c80f8b46835b882fe0d69c08a4460333f28143569665861 ghcr.io/inspektor-gadget/inspektor-gadget:v0.18.1@sha256:d6d5661b02002aa8035e035e9210e3476e0401a948a86fabf104f71c2cbe0efe  --dry-run --annotation index:org.opencontainers.image.description="I am a description"
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:c3780808973801b24c80f8b46835b882fe0d69c08a4460333f28143569665861",
      "size": 2963,
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:d6d5661b02002aa8035e035e9210e3476e0401a948a86fabf104f71c2cbe0efe",
      "size": 2962,
      "platform": {
        "architecture": "arm64",
        "os": "linux"
      }
    }
  ],
  "annotations": {
    "org.opencontainers.image.description": "I am a description"
  }
}
```

#### Manifest Descriptor

```
$ ./bin/build/buildx  imagetools create  -t ghcr.io/inspektor-gadget/inspektor-gadget:v0.18.1 ghcr.io/inspektor-gadget/inspektor-gadget:v0.18.1@sha256:c3780808973801b24c80f8b46835b882fe0d69c08a4460333f28143569665861 ghcr.io/inspektor-gadget/inspektor-gadget:v0.18.1@sha256:d6d5661b02002aa8035e035e9210e3476e0401a948a86fabf104f71c2cbe0efe  --dry-run --annotation manifest-descriptor:org.opencontainers.image.description="I am a description"
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:c3780808973801b24c80f8b46835b882fe0d69c08a4460333f28143569665861",
      "size": 2963,
      "annotations": {
        "org.opencontainers.image.description": "I am a description"
      },
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:d6d5661b02002aa8035e035e9210e3476e0401a948a86fabf104f71c2cbe0efe",
      "size": 2962,
      "annotations": {
        "org.opencontainers.image.description": "I am a description"
      },
      "platform": {
        "architecture": "arm64",
        "os": "linux"
      }
    }
  ]
}

```

#### Docker manifest list (noop)

```
$ /bin/build/buildx  imagetools create  -t hello-world hello-world hello-world  --dry-run --annotation org.opencontainers.image.description="I am a description"
...
```