### PR TITLE
build: error on attests on non-multiplatform driver

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -454,7 +454,7 @@ func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt Op
 			attests[k] = *v
 		}
 	}
-	supportsAttestations := bopts.LLBCaps.Contains(apicaps.CapID("exporter.image.attestations"))
+	supportsAttestations := bopts.LLBCaps.Contains(apicaps.CapID("exporter.image.attestations")) && nodeDriver.Features(ctx)[driver.MultiPlatform]
 	if len(attests) > 0 {
 		if !supportsAttestations {
 			return nil, nil, errors.Errorf("attestations are not supported by the current buildkitd")


### PR DESCRIPTION
On drivers that do not support multi-platform builds (the default `docker` driver), we do not support building attestations (unless using the containerd store).

We need to check this feature before attempting to build using attestations.

(thanks @cdupuis for the find :tada:)