### PR TITLE
build: sublogger to show docker load progress output

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -552,7 +552,9 @@ func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt Op
 						return nil, nil, err
 					}
 					defers = append(defers, cancel)
-					opt.Exports[i].Output = wrapWriteCloser(w)
+					opt.Exports[i].Output = func(_ map[string]string) (io.WriteCloser, error) {
+						return w, nil
+					}
 				}
 			} else if !nodeDriver.Features(ctx)[driver.DockerExporter] {
 				return nil, nil, notSupported(nodeDriver, driver.DockerExporter)
@@ -1605,12 +1607,6 @@ func handleLowercaseDockerfile(dir, p string) string {
 		return filepath.Join(filepath.Dir(p), "dockerfile")
 	}
 	return p
-}
-
-func wrapWriteCloser(wc io.WriteCloser) func(map[string]string) (io.WriteCloser, error) {
-	return func(map[string]string) (io.WriteCloser, error) {
-		return wc, nil
-	}
 }
 
 var nodeIdentifierMu sync.Mutex

--- a/util/dockerutil/client.go
+++ b/util/dockerutil/client.go
@@ -60,8 +60,10 @@ func (c *Client) LoadImage(ctx context.Context, name string, status progress.Wri
 				return
 			}
 
-			prog := progress.WithPrefix(status, "", false)
-			if err := fromReader(prog, "importing to docker", resp.Body); err != nil {
+			status = progress.ResetTime(status)
+			if err := progress.Wrap("importing to docker", status.Write, func(l progress.SubLogger) error {
+				return fromReader(l, resp.Body)
+			}); err != nil {
 				handleErr(err)
 			}
 		},


### PR DESCRIPTION
Adds sublogger to show load progress when importing to docker:

https://github.com/docker/buildx/assets/1951866/9da993bc-1f71-4222-93a2-621a51715ec7

```
$ docker buildx create --name foo
$ docker buildx --builder foo bake --load https://github.com/crazy-max/docker-docker.git
...
#35 exporting to docker image format
#35 exporting layers
#35 exporting layers 7.3s done
#35 exporting manifest sha256:3ddc93cb4082a582552e7b32cfe439ae4fc2c003f353a8259e055a8b9e373fb6 0.0s done
#35 exporting config sha256:b2f1eaf0595fd4ccb26c63715aca3698d6433d9e34220cd8db358e0332d2b18e 0.0s done
#35 sending tarball
#35 ...

#36 importing to docker
#36 loading layer 4270763b4b7f 294.91kB / 27.73MB 3.0s done
#36 loading layer fc8ab555be16 557.06kB / 70.77MB 2.5s done
#36 loading layer b7eb284ce929 163.84kB / 13.78MB 1.7s done
#36 loading layer 13a4dd8d8fd7 557.06kB / 52.93MB 1.5s done
#36 loading layer 5f70bf18a086 32B / 32B 1.0s done
#36 loading layer a7f29fd70512 196.61kB / 17.46MB 1.0s done
#36 loading layer a950fc94a643 196.61kB / 17.78MB 0.8s done
#36 loading layer d859045f8607 458.75kB / 45.74MB 0.5s done
#36 loading layer 12aba25a1c9f 332B / 332B 0.1s done
#36 loading layer 0dbb41e3c807 116B / 116B 0.1s done
#36 loading layer 089d02ae3a66 546B / 546B 0.1s done
#36 loading layer a08aa04b3edb 1.02kB / 1.02kB 0.1s done
#36 DONE 3.0s
```