### PR TITLE
test: fix non-deterministic compose context path

### DIFF
--- a/bake/bake_test.go
+++ b/bake/bake_test.go
@@ -295,6 +295,9 @@ services:
 
 	ctx := context.TODO()
 
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
 	m, g, err := ReadTargets(ctx, []File{fp, fp2, fp3}, []string{"default"}, nil, nil)
 	require.NoError(t, err)
 
@@ -303,7 +306,7 @@ services:
 
 	require.True(t, ok)
 	require.Equal(t, "Dockerfile.webapp", *m["webapp"].Dockerfile)
-	require.Equal(t, "/src/bake", *m["webapp"].Context)
+	require.Equal(t, cwd, *m["webapp"].Context)
 	require.Equal(t, ptrstr("1"), m["webapp"].Args["buildno"])
 	require.Equal(t, ptrstr("12"), m["webapp"].Args["buildno2"])
 
@@ -342,6 +345,9 @@ services:
 
 	ctx := context.TODO()
 
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
 	m, _, err := ReadTargets(ctx, []File{fp}, []string{"web.app"}, nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(m))
@@ -364,7 +370,7 @@ services:
 	_, ok = m["web_app"]
 	require.True(t, ok)
 	require.Equal(t, "Dockerfile.webapp", *m["web_app"].Dockerfile)
-	require.Equal(t, "/src/bake", *m["web_app"].Context)
+	require.Equal(t, cwd, *m["web_app"].Context)
 	require.Equal(t, ptrstr("1"), m["web_app"].Args["buildno"])
 	require.Equal(t, ptrstr("12"), m["web_app"].Args["buildno2"])
 
@@ -543,6 +549,9 @@ services:
 
 	ctx := context.TODO()
 
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
 	m, _, err := ReadTargets(ctx, []File{fp, fp2}, []string{"app1", "app2"}, nil, nil)
 	require.NoError(t, err)
 
@@ -555,7 +564,7 @@ services:
 	require.Equal(t, "Dockerfile", *m["app1"].Dockerfile)
 	require.Equal(t, ".", *m["app1"].Context)
 	require.Equal(t, "Dockerfile", *m["app2"].Dockerfile)
-	require.Equal(t, "/src/bake", *m["app2"].Context)
+	require.Equal(t, cwd, *m["app2"].Context)
 }
 
 func TestReadContextFromTargetChain(t *testing.T) {

--- a/bake/compose_test.go
+++ b/bake/compose_test.go
@@ -22,7 +22,7 @@ services:
     build:
       context: ./dir
       additional_contexts:
-        foo: /bar
+        foo: ./bar
       dockerfile: Dockerfile-alternate
       network:
         none
@@ -49,6 +49,9 @@ secrets:
     file: /root/.aws/credentials
 `)
 
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
 	c, err := ParseCompose([]compose.ConfigFile{{Content: dt}}, nil)
 	require.NoError(t, err)
 
@@ -62,12 +65,12 @@ secrets:
 		return c.Targets[i].Name < c.Targets[j].Name
 	})
 	require.Equal(t, "db", c.Targets[0].Name)
-	require.Equal(t, "/src/bake/db", *c.Targets[0].Context)
+	require.Equal(t, filepath.Join(cwd, "db"), *c.Targets[0].Context)
 	require.Equal(t, []string{"docker.io/tonistiigi/db"}, c.Targets[0].Tags)
 
 	require.Equal(t, "webapp", c.Targets[1].Name)
-	require.Equal(t, "/src/bake/dir", *c.Targets[1].Context)
-	require.Equal(t, map[string]string{"foo": "/bar"}, c.Targets[1].Contexts)
+	require.Equal(t, filepath.Join(cwd, "dir"), *c.Targets[1].Context)
+	require.Equal(t, map[string]string{"foo": filepath.Join(cwd, "bar")}, c.Targets[1].Contexts)
 	require.Equal(t, "Dockerfile-alternate", *c.Targets[1].Dockerfile)
 	require.Equal(t, 1, len(c.Targets[1].Args))
 	require.Equal(t, ptrstr("123"), c.Targets[1].Args["buildno"])
@@ -80,7 +83,7 @@ secrets:
 	}, c.Targets[1].Secrets)
 
 	require.Equal(t, "webapp2", c.Targets[2].Name)
-	require.Equal(t, "/src/bake/dir", *c.Targets[2].Context)
+	require.Equal(t, filepath.Join(cwd, "dir"), *c.Targets[2].Context)
 	require.Equal(t, "FROM alpine\n", *c.Targets[2].DockerfileInline)
 }
 


### PR DESCRIPTION
related to https://github.com/docker/buildx/pull/1971

Since https://github.com/docker/buildx/pull/1971 the context path is now absolute and although the tests run fine in our containerized environment, it wouldn't work running the tests locally, such as:

```
=== CONT  TestReadTargetsCompose
    bake_test.go:306: 
        	Error Trace:	X:/dev/neard/www/github/docker_org/buildx/bake/bake_test.go:306
        	Error:      	Not equal: 
        	            	expected: "/src/bake"
        	            	actual  : "/home/foo/buildx/bake"
```