### PR TITLE
bake: local dockerfile support for remote definition

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -1070,6 +1070,24 @@ func toBuildOpt(t *Target, inp *Input) (*build.Options, error) {
 		if err != nil {
 			return nil, err
 		}
+	} else if !build.IsRemoteURL(bi.DockerfilePath) && strings.HasPrefix(bi.ContextPath, "cwd://") && (inp != nil && build.IsRemoteURL(inp.URL)) {
+		// We don't currently support reading a remote Dockerfile with a local
+		// context when doing a remote invocation because we automatically
+		// derive the dockerfile from the context atm:
+		//
+		// target "default" {
+		//  context = BAKE_CMD_CONTEXT
+		//  dockerfile = "Dockerfile.app"
+		// }
+		//
+		// > docker buildx bake https://github.com/foo/bar.git
+		// failed to solve: failed to read dockerfile: open /var/lib/docker/tmp/buildkit-mount3004544897/Dockerfile.app: no such file or directory
+		//
+		// To avoid mistakenly reading a local Dockerfile, we check if the
+		// Dockerfile exists locally and if so, we error out.
+		if _, err := os.Stat(filepath.Join(path.Clean(strings.TrimPrefix(bi.ContextPath, "cwd://")), bi.DockerfilePath)); err == nil {
+			return nil, errors.Errorf("reading a dockerfile for a remote build invocation is currently not supported")
+		}
 	}
 	if strings.HasPrefix(bi.ContextPath, "cwd://") {
 		bi.ContextPath = path.Clean(strings.TrimPrefix(bi.ContextPath, "cwd://"))

--- a/build/build.go
+++ b/build/build.go
@@ -1332,6 +1332,10 @@ func LoadInputs(ctx context.Context, d *driver.DriverHandle, inp Inputs, pw prog
 	case IsRemoteURL(inp.ContextPath):
 		if inp.DockerfilePath == "-" {
 			dockerfileReader = inp.InStream
+		} else if filepath.IsAbs(inp.DockerfilePath) {
+			dockerfileDir = filepath.Dir(inp.DockerfilePath)
+			dockerfileName = filepath.Base(inp.DockerfilePath)
+			target.FrontendAttrs["dockerfilekey"] = "dockerfile"
 		}
 		target.FrontendAttrs["context"] = inp.ContextPath
 	default:


### PR DESCRIPTION
fixes #1627

Allow to use a local dockerfile with a remote bake definition like we do for context using `cwd://` protocol.

Can be tested with https://github.com/crazy-max/buildx-buildkit-tests/tree/main/buildx-1627:

```bash
$ cd /tmp
$ cat <<EOT >> Dockerfile.app
FROM scratch
COPY foo /foo
EOT
$ docker buildx bake https://github.com/crazy-max/buildx-buildkit-tests.git#:buildx-1627
```