### PR TITLE
debug: fix short-form custom command name on `--invoke` isn't used

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -719,6 +719,7 @@ func parseInvokeConfig(invoke string) (cfg invokeConfig, err error) {
 	}
 	if len(fields) == 1 && !strings.Contains(fields[0], "=") {
 		cfg.Cmd = []string{fields[0]}
+		cfg.NoCmd = false
 		return cfg, nil
 	}
 	cfg.NoUser = true


### PR DESCRIPTION
This fixes the bug that `--invoke` ignores command name specified as the short-form argument. Sorry, this seems introduced in https://github.com/docker/buildx/pull/1970 that uses `InvokeConfig.NoCmd` in an incorrect way in the short-form flag :pray: .

master branch:

Command name (`ps`) on the short-form flag is ignored.

```console
$ BUILDX_EXPERIMENTAL=1 /tmp/out/buildx build --invoke ps /tmp/ctx3/
...
Launching interactive container. Press Ctrl-a-c to switch to monitor console
Interactive container was restarted with process "a41yfa5q4d20h1ezin01ndcun". Press Ctrl-a-c to switch to the new container
root@buildkitsandbox:/# 
```

This PR:

Command name (`ps`) is enabled.

```
$ BUILDX_EXPERIMENTAL=1 /tmp/out/buildx build --invoke ps /tmp/ctx3/
...
Launching interactive container. Press Ctrl-a-c to switch to monitor console
Interactive container was restarted with process "su15exc88brmlsj7ae7c77nzv". Press Ctrl-a-c to switch to the new container
    PID TTY          TIME CMD
      1 pts/0    00:00:00 ps
```
