### PR TITLE
build: validate build args and labels

### DIFF
--- a/tests/build.go
+++ b/tests/build.go
@@ -42,6 +42,8 @@ var buildTests = []func(t *testing.T, sb integration.Sandbox){
 	testBuildDetailsLink,
 	testBuildProgress,
 	testBuildAnnotations,
+	testBuildBuildArgNoKey,
+	testBuildLabelNoKey,
 }
 
 func testBuild(t *testing.T, sb integration.Sandbox) {
@@ -357,4 +359,20 @@ func testBuildAnnotations(t *testing.T, sb integration.Sandbox) {
 
 	require.NotNil(t, img.Desc)
 	assert.Equal(t, "zzz", img.Desc.Annotations["example4"])
+}
+
+func testBuildBuildArgNoKey(t *testing.T, sb integration.Sandbox) {
+	dir := createTestProject(t)
+	cmd := buildxCmd(sb, withArgs("build", "--build-arg", "=TEST_STRING", dir))
+	out, err := cmd.CombinedOutput()
+	require.Error(t, err, string(out))
+	require.Equal(t, strings.TrimSpace(string(out)), `ERROR: invalid key-value pair "=TEST_STRING": empty key`)
+}
+
+func testBuildLabelNoKey(t *testing.T, sb integration.Sandbox) {
+	dir := createTestProject(t)
+	cmd := buildxCmd(sb, withArgs("build", "--label", "=TEST_STRING", dir))
+	out, err := cmd.CombinedOutput()
+	require.Error(t, err, string(out))
+	require.Equal(t, strings.TrimSpace(string(out)), `ERROR: invalid key-value pair "=TEST_STRING": empty key`)
 }


### PR DESCRIPTION
fixes https://github.com/docker/buildx/issues/2022

Adds validation for build arguments and labels that must have a key to be consistent with previous implementation of the `build` command in `docker/cli`.

We already have this validation for bake when we set new overrides: https://github.com/docker/buildx/blob/f6b7a3c522687b64bf406ca9ce48a1e9b5096f20/bake/bake.go#L430-L432 https://github.com/docker/buildx/blob/f6b7a3c522687b64bf406ca9ce48a1e9b5096f20/bake/bake.go#L456-L458 but missing for labels.