### PR TITLE
feat: support memory/cpu driver options for docker-container

### DIFF
--- a/docs/reference/buildx_create.md
+++ b/docs/reference/buildx_create.md
@@ -150,9 +150,18 @@ No driver options.
 
 #### `docker-container` driver
 
-- `image=IMAGE` - Sets the container image to be used for running buildkit.
-- `network=NETMODE` - Sets the network mode for running the buildkit container.
-- `cgroup-parent=CGROUP` - Sets the cgroup parent of the buildkit container if docker is using the "cgroupfs" driver. Defaults to `/docker/buildx`.
+- `image=IMAGE` - Sets the BuildKit image to use for the container.
+- `memory=MEMORY` - Sets the amount of memory the container can use.
+- `memory-swap=MEMORY_SWAP` - Sets the memory swap limit for the container.
+- `cpu-quota=CPU_QUOTA` - Imposes a CPU CFS quota on the container.
+- `cpu-period=CPU_PERIOD` - Sets the CPU CFS scheduler period for the container.
+- `cpu-shares=CPU_SHARES` - Configures CPU shares (relative weight) of the container.
+- `cpuset-cpus=CPUSET_CPUS` - Limits the set of CPU cores the container can use.
+- `cpuset-mems=CPUSET_MEMS` - Limits the set of CPU memory nodes the container can use.
+- `network=NETMODE` - Sets the network mode for the container.
+- `cgroup-parent=CGROUP` - Sets the cgroup parent of the container if docker is using the "cgroupfs" driver. Defaults to `/docker/buildx`.
+
+Before you configure the resource limits for the container, read about [configuring runtime resource constraints for containers](https://docs.docker.com/config/containers/resource_constraints/).
 
 #### `kubernetes` driver
 

--- a/driver/docker-container/driver.go
+++ b/driver/docker-container/driver.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/buildx/util/confutil"
 	"github.com/docker/buildx/util/imagetools"
 	"github.com/docker/buildx/util/progress"
+	"github.com/docker/cli/opts"
 	dockertypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
@@ -40,6 +41,13 @@ type Driver struct {
 	factory      driver.Factory
 	netMode      string
 	image        string
+	memory       opts.MemBytes
+	memorySwap   opts.MemSwapBytes
+	cpuQuota     int64
+	cpuPeriod    int64
+	cpuShares    int64
+	cpusetCpus   string
+	cpusetMems   string
 	cgroupParent string
 	env          []string
 }
@@ -125,6 +133,27 @@ func (d *Driver) create(ctx context.Context, l progress.SubLogger) error {
 		}
 		if d.netMode != "" {
 			hc.NetworkMode = container.NetworkMode(d.netMode)
+		}
+		if d.memory != 0 {
+			hc.Resources.Memory = int64(d.memory)
+		}
+		if d.memorySwap != 0 {
+			hc.Resources.MemorySwap = int64(d.memorySwap)
+		}
+		if d.cpuQuota != 0 {
+			hc.Resources.CPUQuota = d.cpuQuota
+		}
+		if d.cpuPeriod != 0 {
+			hc.Resources.CPUPeriod = d.cpuPeriod
+		}
+		if d.cpuShares != 0 {
+			hc.Resources.CPUShares = d.cpuShares
+		}
+		if d.cpusetCpus != "" {
+			hc.Resources.CpusetCpus = d.cpusetCpus
+		}
+		if d.cpusetMems != "" {
+			hc.Resources.CpusetMems = d.cpusetMems
 		}
 		if info, err := d.DockerAPI.Info(ctx); err == nil {
 			if info.CgroupDriver == "cgroupfs" {

--- a/driver/docker-container/factory.go
+++ b/driver/docker-container/factory.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/docker/buildx/driver"
@@ -49,6 +50,36 @@ func (f *factory) New(ctx context.Context, cfg driver.InitConfig) (driver.Driver
 			}
 		case k == "image":
 			d.image = v
+		case k == "memory":
+			if err := d.memory.Set(v); err == nil {
+				return nil, err
+			}
+		case k == "memory-swap":
+			if err := d.memorySwap.Set(v); err == nil {
+				return nil, err
+			}
+		case k == "cpu-period":
+			vv, err := strconv.ParseInt(v, 10, 0)
+			if err != nil {
+				return nil, err
+			}
+			d.cpuPeriod = vv
+		case k == "cpu-quota":
+			vv, err := strconv.ParseInt(v, 10, 0)
+			if err != nil {
+				return nil, err
+			}
+			d.cpuQuota = vv
+		case k == "cpu-shares":
+			vv, err := strconv.ParseInt(v, 10, 0)
+			if err != nil {
+				return nil, err
+			}
+			d.cpuShares = vv
+		case k == "cpuset-cpus":
+			d.cpusetCpus = v
+		case k == "cpuset-mems":
+			d.cpusetMems = v
 		case k == "cgroup-parent":
 			d.cgroupParent = v
 		case strings.HasPrefix(k, "env."):


### PR DESCRIPTION
fixes #2049

limit builder container memory

use: `docker buildx create --driver docker-container --driver-opt memory=32G --name zmicro`