### PR TITLE
vendor: update compose-go to v1.19.0

### DIFF
--- a/bake/compose_test.go
+++ b/bake/compose_test.go
@@ -719,6 +719,25 @@ services:
 	require.Equal(t, "buildfoo", *c.Targets[1].Target)
 }
 
+func TestDevelop(t *testing.T) {
+	var dt = []byte(`
+services:
+  scratch:
+    build:
+     context: ./webapp
+    develop:
+      watch: 
+        - path: ./webapp/html
+          action: sync
+          target: /var/www
+          ignore:
+            - node_modules/
+`)
+
+	_, err := ParseCompose([]compose.ConfigFile{{Content: dt}}, nil)
+	require.NoError(t, err)
+}
+
 // chdir changes the current working directory to the named directory,
 // and then restore the original working directory at the end of the test.
 func chdir(t *testing.T, dir string) {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/aws/aws-sdk-go-v2/config v1.18.16
-	github.com/compose-spec/compose-go v1.18.4
+	github.com/compose-spec/compose-go v1.19.0
 	github.com/containerd/console v1.0.3
 	github.com/containerd/containerd v1.7.2
 	github.com/containerd/continuity v0.4.1

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUoc7Ik9EfrFqcylYqgPZ9ANSbTAntnE=
-github.com/compose-spec/compose-go v1.18.4 h1:yLYfsc3ATAYZVAJcXyx/V847/JVBmf3pfKfR13mXU4s=
-github.com/compose-spec/compose-go v1.18.4/go.mod h1:+MdqXV4RA7wdFsahh/Kb8U0pAJqkg7mr4PM9tFKU8RM=
+github.com/compose-spec/compose-go v1.19.0 h1:t68gAcwStDg0hy2kFvqHJIksf6xkqRnlSKfL45/ETqo=
+github.com/compose-spec/compose-go v1.19.0/go.mod h1:+MdqXV4RA7wdFsahh/Kb8U0pAJqkg7mr4PM9tFKU8RM=
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
 github.com/containerd/console v1.0.3 h1:lIr7SlA5PxZyMV30bDW0MGbiOPXwc63yRuCP0ARubLw=
 github.com/containerd/console v1.0.3/go.mod h1:7LqA/THxQ86k76b8c/EMSiaJ3h1eZkMkXar0TQ1gf3U=

--- a/vendor/github.com/compose-spec/compose-go/cli/options.go
+++ b/vendor/github.com/compose-spec/compose-go/cli/options.go
@@ -328,6 +328,14 @@ func WithResourceLoader(r loader.ResourceLoader) ProjectOptionsFn {
 	}
 }
 
+// WithoutEnvironmentResolution disable environment resolution
+func WithoutEnvironmentResolution(o *ProjectOptions) error {
+	o.loadOptions = append(o.loadOptions, func(options *loader.Options) {
+		options.SkipResolveEnvironment = true
+	})
+	return nil
+}
+
 // DefaultFileNames defines the Compose file names for auto-discovery (in order of preference)
 var DefaultFileNames = []string{"compose.yaml", "compose.yml", "docker-compose.yml", "docker-compose.yaml"}
 

--- a/vendor/github.com/compose-spec/compose-go/loader/loader.go
+++ b/vendor/github.com/compose-spec/compose-go/loader/loader.go
@@ -61,6 +61,8 @@ type Options struct {
 	SkipExtends bool
 	// SkipInclude will ignore `include` and only load model from file(s) set by ConfigDetails
 	SkipInclude bool
+	// SkipResolveEnvironment will ignore computing `environment` for services
+	SkipResolveEnvironment bool
 	// Interpolation options
 	Interpolate *interp.Options
 	// Discard 'env_file' entries after resolving to 'environment' section
@@ -255,7 +257,6 @@ func load(ctx context.Context, configDetails types.ConfigDetails, opts *Options,
 	loaded = append(loaded, mainFile)
 
 	includeRefs := make(map[string][]types.IncludeConfig)
-	first := true
 	for _, file := range configDetails.ConfigFiles {
 		var postProcessor PostProcessor
 		configDict := file.Config
@@ -285,22 +286,21 @@ func load(ctx context.Context, configDetails types.ConfigDetails, opts *Options,
 				}
 			}
 
-			if first {
-				first = false
+			if model == nil {
 				model = cfg
-				return nil
-			}
-			merged, err := merge([]*types.Config{model, cfg})
-			if err != nil {
-				return err
+			} else {
+				merged, err := merge([]*types.Config{model, cfg})
+				if err != nil {
+					return err
+				}
+				model = merged
 			}
 			if postProcessor != nil {
-				err = postProcessor.Apply(merged)
+				err = postProcessor.Apply(model)
 				if err != nil {
 					return err
 				}
 			}
-			model = merged
 			return nil
 		}
 
@@ -335,6 +335,10 @@ func load(ctx context.Context, configDetails types.ConfigDetails, opts *Options,
 				return nil, err
 			}
 		}
+	}
+
+	if model == nil {
+		return nil, errors.New("empty compose file")
 	}
 
 	project := &types.Project{
@@ -385,9 +389,14 @@ func load(ctx context.Context, configDetails types.ConfigDetails, opts *Options,
 
 	project.ApplyProfiles(opts.Profiles)
 
-	err := project.ResolveServicesEnvironment(opts.discardEnvFiles)
+	if !opts.SkipResolveEnvironment {
+		err := project.ResolveServicesEnvironment(opts.discardEnvFiles)
+		if err != nil {
+			return nil, err
+		}
+	}
 
-	return project, err
+	return project, nil
 }
 
 func InvalidProjectNameErr(v string) error {

--- a/vendor/github.com/compose-spec/compose-go/loader/paths.go
+++ b/vendor/github.com/compose-spec/compose-go/loader/paths.go
@@ -115,6 +115,13 @@ func ResolveServiceRelativePaths(workingDir string, s *types.ServiceConfig) {
 		}
 		s.Volumes[i].Source = resolveMaybeUnixPath(workingDir, vol.Source)
 	}
+
+	if s.Develop != nil {
+		for i, w := range s.Develop.Watch {
+			w.Path = absPath(workingDir, w.Path)
+			s.Develop.Watch[i] = w
+		}
+	}
 }
 
 func absPath(workingDir string, filePath string) string {

--- a/vendor/github.com/compose-spec/compose-go/schema/compose-spec.json
+++ b/vendor/github.com/compose-spec/compose-go/schema/compose-spec.json
@@ -91,6 +91,7 @@
       "type": "object",
 
       "properties": {
+        "develop": {"$ref": "#/definitions/development"},
         "deploy": {"$ref": "#/definitions/deployment"},
         "annotations": {"$ref": "#/definitions/list_or_dict"},
         "attach": {"type": "boolean"},
@@ -462,6 +463,26 @@
       },
       "additionalProperties": false,
       "patternProperties": {"^x-": {}}
+    },
+    "development": {
+      "id": "#/definitions/development",
+      "type": ["object", "null"],
+      "properties": {
+        "watch": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "ignore": {"type": "array", "items": {"type": "string"}},
+              "path": {"type": "string"},
+              "action": {"type": "string", "enum": ["rebuild", "sync"]},
+              "target": {"type": "string"}
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {"^x-": {}}
+        }
+      }
     },
     "deployment": {
       "id": "#/definitions/deployment",

--- a/vendor/github.com/compose-spec/compose-go/types/develop.go
+++ b/vendor/github.com/compose-spec/compose-go/types/develop.go
@@ -1,0 +1,35 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package types
+
+type DevelopConfig struct {
+	Watch []Trigger `json:"watch,omitempty"`
+}
+
+type WatchAction string
+
+const (
+	WatchActionSync    WatchAction = "sync"
+	WatchActionRebuild WatchAction = "rebuild"
+)
+
+type Trigger struct {
+	Path   string      `json:"path,omitempty"`
+	Action WatchAction `json:"action,omitempty"`
+	Target string      `json:"target,omitempty"`
+	Ignore []string    `json:"ignore,omitempty"`
+}

--- a/vendor/github.com/compose-spec/compose-go/types/types.go
+++ b/vendor/github.com/compose-spec/compose-go/types/types.go
@@ -88,23 +88,24 @@ type ServiceConfig struct {
 	Name     string   `yaml:"-" json:"-"`
 	Profiles []string `yaml:"profiles,omitempty" json:"profiles,omitempty"`
 
-	Annotations  Mapping      `yaml:"annotations,omitempty" json:"annotations,omitempty"`
-	Attach       *bool        `yaml:"attach,omitempty" json:"attach,omitempty"`
-	Build        *BuildConfig `yaml:"build,omitempty" json:"build,omitempty"`
-	BlkioConfig  *BlkioConfig `yaml:"blkio_config,omitempty" json:"blkio_config,omitempty"`
-	CapAdd       []string     `yaml:"cap_add,omitempty" json:"cap_add,omitempty"`
-	CapDrop      []string     `yaml:"cap_drop,omitempty" json:"cap_drop,omitempty"`
-	CgroupParent string       `yaml:"cgroup_parent,omitempty" json:"cgroup_parent,omitempty"`
-	Cgroup       string       `yaml:"cgroup,omitempty" json:"cgroup,omitempty"`
-	CPUCount     int64        `yaml:"cpu_count,omitempty" json:"cpu_count,omitempty"`
-	CPUPercent   float32      `yaml:"cpu_percent,omitempty" json:"cpu_percent,omitempty"`
-	CPUPeriod    int64        `yaml:"cpu_period,omitempty" json:"cpu_period,omitempty"`
-	CPUQuota     int64        `yaml:"cpu_quota,omitempty" json:"cpu_quota,omitempty"`
-	CPURTPeriod  int64        `yaml:"cpu_rt_period,omitempty" json:"cpu_rt_period,omitempty"`
-	CPURTRuntime int64        `yaml:"cpu_rt_runtime,omitempty" json:"cpu_rt_runtime,omitempty"`
-	CPUS         float32      `yaml:"cpus,omitempty" json:"cpus,omitempty"`
-	CPUSet       string       `yaml:"cpuset,omitempty" json:"cpuset,omitempty"`
-	CPUShares    int64        `yaml:"cpu_shares,omitempty" json:"cpu_shares,omitempty"`
+	Annotations  Mapping        `yaml:"annotations,omitempty" json:"annotations,omitempty"`
+	Attach       *bool          `yaml:"attach,omitempty" json:"attach,omitempty"`
+	Build        *BuildConfig   `yaml:"build,omitempty" json:"build,omitempty"`
+	Develop      *DevelopConfig `yaml:"develop,omitempty" json:"develop,omitempty"`
+	BlkioConfig  *BlkioConfig   `yaml:"blkio_config,omitempty" json:"blkio_config,omitempty"`
+	CapAdd       []string       `yaml:"cap_add,omitempty" json:"cap_add,omitempty"`
+	CapDrop      []string       `yaml:"cap_drop,omitempty" json:"cap_drop,omitempty"`
+	CgroupParent string         `yaml:"cgroup_parent,omitempty" json:"cgroup_parent,omitempty"`
+	Cgroup       string         `yaml:"cgroup,omitempty" json:"cgroup,omitempty"`
+	CPUCount     int64          `yaml:"cpu_count,omitempty" json:"cpu_count,omitempty"`
+	CPUPercent   float32        `yaml:"cpu_percent,omitempty" json:"cpu_percent,omitempty"`
+	CPUPeriod    int64          `yaml:"cpu_period,omitempty" json:"cpu_period,omitempty"`
+	CPUQuota     int64          `yaml:"cpu_quota,omitempty" json:"cpu_quota,omitempty"`
+	CPURTPeriod  int64          `yaml:"cpu_rt_period,omitempty" json:"cpu_rt_period,omitempty"`
+	CPURTRuntime int64          `yaml:"cpu_rt_runtime,omitempty" json:"cpu_rt_runtime,omitempty"`
+	CPUS         float32        `yaml:"cpus,omitempty" json:"cpus,omitempty"`
+	CPUSet       string         `yaml:"cpuset,omitempty" json:"cpuset,omitempty"`
+	CPUShares    int64          `yaml:"cpu_shares,omitempty" json:"cpu_shares,omitempty"`
 
 	// Command for the service containers.
 	// If set, overrides COMMAND from the image.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -121,7 +121,7 @@ github.com/cenkalti/backoff/v4
 # github.com/cespare/xxhash/v2 v2.2.0
 ## explicit; go 1.11
 github.com/cespare/xxhash/v2
-# github.com/compose-spec/compose-go v1.18.4
+# github.com/compose-spec/compose-go v1.19.0
 ## explicit; go 1.19
 github.com/compose-spec/compose-go/cli
 github.com/compose-spec/compose-go/consts


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

Bake is currently broken for projects with a `compose.yaml` that implements the latest version of the compose spec (the one used by Docker Compose v1.22)
