### PR TITLE
commands: release the file lock before attempting to boot during create

### DIFF
--- a/commands/create.go
+++ b/commands/create.go
@@ -72,6 +72,7 @@ func runCreate(dockerCli command.Cli, in createOptions, args []string) error {
 	if err != nil {
 		return err
 	}
+	// Ensure the file lock gets released no matter what happens.
 	defer release()
 
 	name := in.name
@@ -299,6 +300,10 @@ func runCreate(dockerCli command.Cli, in createOptions, args []string) error {
 			return err
 		}
 	}
+
+	// The store is no longer used from this point.
+	// Release it so we aren't holding the file lock during the boot.
+	release()
 
 	if in.bootstrap {
 		if _, err = b.Boot(ctx); err != nil {


### PR DESCRIPTION
If the boot command hung or took a long time, it blocked any read
operations (such as `buildx ls`).

When the boot happens, we no longer need to hold the file lock so we can
release it. Releasing multiple times is legal and causes whichever
release that is second to be a no-op so the defer is kept to ensure the
lock is released even when an error condition happens.

Fixes #2062.