### PR TITLE
inspect: do not display platforms field if empty

### DIFF
--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -93,7 +93,10 @@ func runInspect(dockerCli command.Cli, in inspectOptions) error {
 				if nodes[i].Version != "" {
 					fmt.Fprintf(w, "Buildkit:\t%s\n", nodes[i].Version)
 				}
-				fmt.Fprintf(w, "Platforms:\t%s\n", strings.Join(platformutil.FormatInGroups(n.Node.Platforms, n.Platforms), ", "))
+				platforms := platformutil.FormatInGroups(n.Node.Platforms, n.Platforms)
+				if len(platforms) > 0 {
+					fmt.Fprintf(w, "Platforms:\t%s\n", strings.Join(platforms, ", "))
+				}
 				if debug.IsEnabled() {
 					fmt.Fprintf(w, "Features:\n")
 					features := nodes[i].Driver.Features(ctx)


### PR DESCRIPTION
Before:

```
$ docker buildx inspect builder
Name:          builder
Driver:        docker-container
Last Activity: 2023-09-12 20:09:21 +0000 UTC

Nodes:
Name:           builder0
Endpoint:       unix:///var/run/docker.sock
Driver Options: env.BUILDKIT_STEP_LOG_MAX_SIZE="10485760" env.BUILDKIT_STEP_LOG_MAX_SPEED="10485760" env.JAEGER_TRACE="localhost:6831" image="moby/buildkit:master" network="host"
Status:         stopped
Flags:          --debug --allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host
Platforms:
```

Now:

```
$ docker buildx inspect builder
Name:          builder
Driver:        docker-container
Last Activity: 2023-09-12 20:09:21 +0000 UTC

Nodes:
Name:           builder0
Endpoint:       unix:///var/run/docker.sock
Driver Options: image="moby/buildkit:master" network="host" env.BUILDKIT_STEP_LOG_MAX_SIZE="10485760" env.BUILDKIT_STEP_LOG_MAX_SPEED="10485760" env.JAEGER_TRACE="localhost:6831"
Status:         stopped
Flags:          --debug --allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host
```