### PR TITLE
(drivers): Introduce a client interface

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -164,8 +164,8 @@ func allIndexes(l int) []int {
 	return out
 }
 
-func ensureBooted(ctx context.Context, nodes []builder.Node, idxs []int, pw progress.Writer) ([]*client.Client, error) {
-	clients := make([]*client.Client, len(nodes))
+func ensureBooted(ctx context.Context, nodes []builder.Node, idxs []int, pw progress.Writer) ([]driver.Client, error) {
+	clients := make([]driver.Client, len(nodes))
 
 	baseCtx := ctx
 	eg, ctx := errgroup.WithContext(ctx)
@@ -214,7 +214,7 @@ func splitToDriverPairs(availablePlatforms map[string]int, opt map[string]Option
 	return m
 }
 
-func resolveDrivers(ctx context.Context, nodes []builder.Node, opt map[string]Options, pw progress.Writer) (map[string][]driverPair, []*client.Client, error) {
+func resolveDrivers(ctx context.Context, nodes []builder.Node, opt map[string]Options, pw progress.Writer) (map[string][]driverPair, []driver.Client, error) {
 	dps, clients, err := resolveDriversBase(ctx, nodes, opt, pw)
 	if err != nil {
 		return nil, nil, err
@@ -230,7 +230,7 @@ func resolveDrivers(ctx context.Context, nodes []builder.Node, opt map[string]Op
 			continue
 		}
 
-		func(i int, c *client.Client) {
+		func(i int, c driver.Client) {
 			eg.Go(func() error {
 				clients[i].Build(ctx, client.SolveOpt{
 					Internal: true,
@@ -257,7 +257,7 @@ func resolveDrivers(ctx context.Context, nodes []builder.Node, opt map[string]Op
 	return dps, clients, nil
 }
 
-func resolveDriversBase(ctx context.Context, nodes []builder.Node, opt map[string]Options, pw progress.Writer) (map[string][]driverPair, []*client.Client, error) {
+func resolveDriversBase(ctx context.Context, nodes []builder.Node, opt map[string]Options, pw progress.Writer) (map[string][]driverPair, []driver.Client, error) {
 	availablePlatforms := map[string]int{}
 	for i, node := range nodes {
 		for _, p := range node.Platforms {

--- a/build/result.go
+++ b/build/result.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	controllerapi "github.com/docker/buildx/controller/pb"
+	"github.com/docker/buildx/driver"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	gateway "github.com/moby/buildkit/frontend/gateway/client"
@@ -28,7 +29,7 @@ import (
 // failures and successes.
 //
 // If the returned ResultHandle is not nil, the caller must call Done() on it.
-func NewResultHandle(ctx context.Context, cc *client.Client, opt client.SolveOpt, product string, buildFunc gateway.BuildFunc, ch chan *client.SolveStatus) (*ResultHandle, *client.SolveResponse, error) {
+func NewResultHandle(ctx context.Context, cc driver.Client, opt client.SolveOpt, product string, buildFunc gateway.BuildFunc, ch chan *client.SolveStatus) (*ResultHandle, *client.SolveResponse, error) {
 	// Create a new context to wrap the original, and cancel it when the
 	// caller-provided context is cancelled.
 	//

--- a/driver/client.go
+++ b/driver/client.go
@@ -1,0 +1,20 @@
+package driver
+
+import (
+	"context"
+
+	controlapi "github.com/moby/buildkit/api/services/control"
+	"github.com/moby/buildkit/client"
+	gateway "github.com/moby/buildkit/frontend/gateway/client"
+)
+
+type Client interface {
+	Build(ctx context.Context, opt client.SolveOpt, product string, buildFunc gateway.BuildFunc, statusChan chan *client.SolveStatus) (*client.SolveResponse, error)
+	ListWorkers(ctx context.Context, opts ...client.ListWorkersOption) ([]*client.WorkerInfo, error)
+	Info(ctx context.Context) (*client.Info, error)
+	DiskUsage(ctx context.Context, opts ...client.DiskUsageOption) ([]*client.UsageInfo, error)
+	Prune(ctx context.Context, ch chan client.UsageInfo, opts ...client.PruneOption) error
+	ControlClient() controlapi.ControlClient
+	Close() error
+	Wait(ctx context.Context) error
+}

--- a/driver/docker-container/driver.go
+++ b/driver/docker-container/driver.go
@@ -359,7 +359,7 @@ func (d *Driver) Rm(ctx context.Context, force, rmVolume, rmDaemon bool) error {
 	return nil
 }
 
-func (d *Driver) Client(ctx context.Context) (*client.Client, error) {
+func (d *Driver) Client(ctx context.Context) (driver.Client, error) {
 	_, conn, err := d.exec(ctx, []string{"buildctl", "dial-stdio"})
 	if err != nil {
 		return nil, err

--- a/driver/docker/driver.go
+++ b/driver/docker/driver.go
@@ -51,7 +51,7 @@ func (d *Driver) Rm(ctx context.Context, force, rmVolume, rmDaemon bool) error {
 	return nil
 }
 
-func (d *Driver) Client(ctx context.Context) (*client.Client, error) {
+func (d *Driver) Client(ctx context.Context) (driver.Client, error) {
 	opts := []client.ClientOpt{
 		client.WithContextDialer(func(context.Context, string) (net.Conn, error) {
 			return d.DockerAPI.DialHijack(ctx, "/grpc", "h2c", nil)

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -8,7 +8,6 @@ import (
 	"github.com/docker/buildx/util/progress"
 	clitypes "github.com/docker/cli/cli/config/types"
 	controlapi "github.com/moby/buildkit/api/services/control"
-	"github.com/moby/buildkit/client"
 	"github.com/pkg/errors"
 )
 
@@ -58,13 +57,13 @@ type Driver interface {
 	Version(context.Context) (string, error)
 	Stop(ctx context.Context, force bool) error
 	Rm(ctx context.Context, force, rmVolume, rmDaemon bool) error
-	Client(ctx context.Context) (*client.Client, error)
+	Client(ctx context.Context) (Client, error)
 	Features(ctx context.Context) map[Feature]bool
 	IsMobyDriver() bool
 	Config() InitConfig
 }
 
-func Boot(ctx, clientContext context.Context, d *DriverHandle, pw progress.Writer) (*client.Client, error) {
+func Boot(ctx, clientContext context.Context, d *DriverHandle, pw progress.Writer) (Client, error) {
 	try := 0
 	for {
 		info, err := d.Info(ctx)
@@ -92,7 +91,7 @@ func Boot(ctx, clientContext context.Context, d *DriverHandle, pw progress.Write
 	}
 }
 
-func historyAPISupported(ctx context.Context, c *client.Client) bool {
+func historyAPISupported(ctx context.Context, c Client) bool {
 	cl, err := c.ControlClient().ListenBuildHistory(ctx, &controlapi.BuildHistoryRequest{
 		ActiveOnly: true,
 		Ref:        "buildx-test-history-api-feature", // dummy ref to check if the server supports the API

--- a/driver/kubernetes/driver.go
+++ b/driver/kubernetes/driver.go
@@ -189,7 +189,7 @@ func (d *Driver) Rm(ctx context.Context, force, rmVolume, rmDaemon bool) error {
 	return nil
 }
 
-func (d *Driver) Client(ctx context.Context) (*client.Client, error) {
+func (d *Driver) Client(ctx context.Context) (driver.Client, error) {
 	restClient := d.clientset.CoreV1().RESTClient()
 	restClientConfig, err := d.KubeClientConfig.ClientConfig()
 	if err != nil {

--- a/driver/manager.go
+++ b/driver/manager.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 
 	dockerclient "github.com/docker/docker/client"
-	"github.com/moby/buildkit/client"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"k8s.io/client-go/rest"
@@ -147,7 +146,7 @@ func GetFactories(instanceRequired bool) []Factory {
 
 type DriverHandle struct {
 	Driver
-	client                  *client.Client
+	client                  Client
 	err                     error
 	once                    sync.Once
 	featuresOnce            sync.Once
@@ -159,7 +158,7 @@ type DriverHandle struct {
 	hostGatewayIPErr        error
 }
 
-func (d *DriverHandle) Client(ctx context.Context) (*client.Client, error) {
+func (d *DriverHandle) Client(ctx context.Context) (Client, error) {
 	d.once.Do(func() {
 		d.client, d.err = d.Driver.Client(ctx)
 	})

--- a/driver/remote/driver.go
+++ b/driver/remote/driver.go
@@ -61,7 +61,7 @@ func (d *Driver) Rm(ctx context.Context, force, rmVolume, rmDaemon bool) error {
 	return nil
 }
 
-func (d *Driver) Client(ctx context.Context) (*client.Client, error) {
+func (d *Driver) Client(ctx context.Context) (driver.Client, error) {
 	opts := []client.ClientOpt{}
 
 	exp, err := detect.Exporter()


### PR DESCRIPTION
This client abstracts from buildkit client. This will allow further enhancement like caching remote driver responses.