### PR TITLE
driver: allow non-cached client

### DIFF
--- a/commands/bake.go
+++ b/commands/bake.go
@@ -114,7 +114,7 @@ func runBake(dockerCli command.Cli, targets []string, in bakeOptions, cFlags com
 		if err = updateLastActivity(dockerCli, b.NodeGroup); err != nil {
 			return errors.Wrapf(err, "failed to update builder last activity time")
 		}
-		nodes, err = b.LoadNodes(ctx, false)
+		nodes, err = b.LoadNodes(ctx)
 		if err != nil {
 			return err
 		}

--- a/commands/build.go
+++ b/commands/build.go
@@ -252,7 +252,7 @@ func runBuild(dockerCli command.Cli, options buildOptions) (err error) {
 	if err != nil {
 		return err
 	}
-	_, err = b.LoadNodes(ctx, false)
+	_, err = b.LoadNodes(ctx)
 	if err != nil {
 		return err
 	}

--- a/commands/create.go
+++ b/commands/create.go
@@ -270,7 +270,7 @@ func runCreate(dockerCli command.Cli, in createOptions, args []string) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
 
-	nodes, err := b.LoadNodes(timeoutCtx, true)
+	nodes, err := b.LoadNodes(timeoutCtx, builder.WithData())
 	if err != nil {
 		return err
 	}

--- a/commands/diskusage.go
+++ b/commands/diskusage.go
@@ -39,7 +39,7 @@ func runDiskUsage(dockerCli command.Cli, opts duOptions) error {
 		return err
 	}
 
-	nodes, err := b.LoadNodes(ctx, false)
+	nodes, err := b.LoadNodes(ctx)
 	if err != nil {
 		return err
 	}

--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -40,7 +40,7 @@ func runInspect(dockerCli command.Cli, in inspectOptions) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
 
-	nodes, err := b.LoadNodes(timeoutCtx, true)
+	nodes, err := b.LoadNodes(timeoutCtx, builder.WithData())
 	if in.bootstrap {
 		var ok bool
 		ok, err = b.Boot(ctx)
@@ -48,7 +48,7 @@ func runInspect(dockerCli command.Cli, in inspectOptions) error {
 			return err
 		}
 		if ok {
-			nodes, err = b.LoadNodes(timeoutCtx, true)
+			nodes, err = b.LoadNodes(timeoutCtx, builder.WithData())
 		}
 	}
 

--- a/commands/ls.go
+++ b/commands/ls.go
@@ -49,7 +49,7 @@ func runLs(dockerCli command.Cli, in lsOptions) error {
 	for _, b := range builders {
 		func(b *builder.Builder) {
 			eg.Go(func() error {
-				_, _ = b.LoadNodes(timeoutCtx, true)
+				_, _ = b.LoadNodes(timeoutCtx, builder.WithData())
 				return nil
 			})
 		}(b)

--- a/commands/prune.go
+++ b/commands/prune.go
@@ -60,7 +60,7 @@ func runPrune(dockerCli command.Cli, opts pruneOptions) error {
 		return err
 	}
 
-	nodes, err := b.LoadNodes(ctx, false)
+	nodes, err := b.LoadNodes(ctx)
 	if err != nil {
 		return err
 	}

--- a/commands/rm.go
+++ b/commands/rm.go
@@ -55,7 +55,7 @@ func runRm(dockerCli command.Cli, in rmOptions) error {
 		return err
 	}
 
-	nodes, err := b.LoadNodes(ctx, false)
+	nodes, err := b.LoadNodes(ctx)
 	if err != nil {
 		return err
 	}
@@ -139,7 +139,7 @@ func rmAllInactive(ctx context.Context, txn *store.Txn, dockerCli command.Cli, i
 	for _, b := range builders {
 		func(b *builder.Builder) {
 			eg.Go(func() error {
-				nodes, err := b.LoadNodes(timeoutCtx, true)
+				nodes, err := b.LoadNodes(timeoutCtx, builder.WithData())
 				if err != nil {
 					return errors.Wrapf(err, "cannot load %s", b.Name)
 				}

--- a/commands/stop.go
+++ b/commands/stop.go
@@ -25,7 +25,7 @@ func runStop(dockerCli command.Cli, in stopOptions) error {
 	if err != nil {
 		return err
 	}
-	nodes, err := b.LoadNodes(ctx, false)
+	nodes, err := b.LoadNodes(ctx)
 	if err != nil {
 		return err
 	}

--- a/controller/build/build.go
+++ b/controller/build/build.go
@@ -171,7 +171,7 @@ func RunBuild(ctx context.Context, dockerCli command.Cli, in controllerapi.Build
 	if err = updateLastActivity(dockerCli, b.NodeGroup); err != nil {
 		return nil, nil, errors.Wrapf(err, "failed to update builder last activity time")
 	}
-	nodes, err := b.LoadNodes(ctx, false)
+	nodes, err := b.LoadNodes(ctx)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/driver/docker-container/driver.go
+++ b/driver/docker-container/driver.go
@@ -399,6 +399,10 @@ func (d *Driver) Features(ctx context.Context) map[driver.Feature]bool {
 	}
 }
 
+func (d *Driver) HostGatewayIP(ctx context.Context) (net.IP, error) {
+	return nil, errors.New("host-gateway is not supported by the docker-container driver")
+}
+
 func demuxConn(c net.Conn) net.Conn {
 	pr, pw := io.Pipe()
 	// TODO: rewrite parser with Reader() to avoid goroutine switch

--- a/driver/docker-container/driver.go
+++ b/driver/docker-container/driver.go
@@ -359,7 +359,7 @@ func (d *Driver) Rm(ctx context.Context, force, rmVolume, rmDaemon bool) error {
 	return nil
 }
 
-func (d *Driver) Client(ctx context.Context) (*client.Client, error) {
+func (d *Driver) Client(ctx context.Context, copts ...driver.ClientOption) (*client.Client, error) {
 	_, conn, err := d.exec(ctx, []string{"buildctl", "dial-stdio"})
 	if err != nil {
 		return nil, err

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -3,6 +3,7 @@ package driver
 import (
 	"context"
 	"io"
+	"net"
 
 	"github.com/docker/buildx/store"
 	"github.com/docker/buildx/util/progress"
@@ -60,6 +61,7 @@ type Driver interface {
 	Rm(ctx context.Context, force, rmVolume, rmDaemon bool) error
 	Client(ctx context.Context) (*client.Client, error)
 	Features(ctx context.Context) map[Feature]bool
+	HostGatewayIP(ctx context.Context) (net.IP, error)
 	IsMobyDriver() bool
 	Config() InitConfig
 }

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -59,14 +59,14 @@ type Driver interface {
 	Version(context.Context) (string, error)
 	Stop(ctx context.Context, force bool) error
 	Rm(ctx context.Context, force, rmVolume, rmDaemon bool) error
-	Client(ctx context.Context) (*client.Client, error)
+	Client(ctx context.Context, copts ...ClientOption) (*client.Client, error)
 	Features(ctx context.Context) map[Feature]bool
 	HostGatewayIP(ctx context.Context) (net.IP, error)
 	IsMobyDriver() bool
 	Config() InitConfig
 }
 
-func Boot(ctx, clientContext context.Context, d *DriverHandle, pw progress.Writer) (*client.Client, error) {
+func Boot(ctx, clientContext context.Context, d *DriverHandle, pw progress.Writer, copts ...ClientOption) (*client.Client, error) {
 	try := 0
 	for {
 		info, err := d.Info(ctx)
@@ -83,7 +83,7 @@ func Boot(ctx, clientContext context.Context, d *DriverHandle, pw progress.Write
 			}
 		}
 
-		c, err := d.Client(clientContext)
+		c, err := d.Client(clientContext, copts...)
 		if err != nil {
 			if errors.Cause(err) == ErrNotRunning && try <= 2 {
 				continue

--- a/driver/kubernetes/driver.go
+++ b/driver/kubernetes/driver.go
@@ -236,3 +236,7 @@ func (d *Driver) Features(ctx context.Context) map[driver.Feature]bool {
 		driver.MultiPlatform:  true, // Untested (needs multiple Driver instances)
 	}
 }
+
+func (d *Driver) HostGatewayIP(ctx context.Context) (net.IP, error) {
+	return nil, errors.New("host-gateway is not supported by the kubernetes driver")
+}

--- a/driver/kubernetes/driver.go
+++ b/driver/kubernetes/driver.go
@@ -189,7 +189,7 @@ func (d *Driver) Rm(ctx context.Context, force, rmVolume, rmDaemon bool) error {
 	return nil
 }
 
-func (d *Driver) Client(ctx context.Context) (*client.Client, error) {
+func (d *Driver) Client(ctx context.Context, copts ...driver.ClientOption) (*client.Client, error) {
 	restClient := d.clientset.CoreV1().RESTClient()
 	restClientConfig, err := d.KubeClientConfig.ClientConfig()
 	if err != nil {

--- a/driver/remote/driver.go
+++ b/driver/remote/driver.go
@@ -63,7 +63,7 @@ func (d *Driver) Rm(ctx context.Context, force, rmVolume, rmDaemon bool) error {
 	return nil
 }
 
-func (d *Driver) Client(ctx context.Context) (*client.Client, error) {
+func (d *Driver) Client(ctx context.Context, copts ...driver.ClientOption) (*client.Client, error) {
 	opts := []client.ClientOpt{}
 
 	exp, err := detect.Exporter()

--- a/driver/remote/driver.go
+++ b/driver/remote/driver.go
@@ -2,6 +2,8 @@ package remote
 
 import (
 	"context"
+	"errors"
+	"net"
 
 	"github.com/docker/buildx/driver"
 	"github.com/docker/buildx/util/progress"
@@ -89,6 +91,10 @@ func (d *Driver) Features(ctx context.Context) map[driver.Feature]bool {
 		driver.CacheExport:    true,
 		driver.MultiPlatform:  true,
 	}
+}
+
+func (d *Driver) HostGatewayIP(ctx context.Context) (net.IP, error) {
+	return nil, errors.New("host-gateway is not supported by the remote driver")
 }
 
 func (d *Driver) Factory() driver.Factory {


### PR DESCRIPTION
Carry cached driver client changes #2018 that are not directly related to dial meta addition.
Needs #2074

This adds ability to opt-out usage of the cached client in `DriverHandler` (see last 2 commits).