### PR TITLE
bake: display read definition files in build output

### DIFF
--- a/bake/bake_test.go
+++ b/bake/bake_test.go
@@ -1440,7 +1440,7 @@ func TestReadLocalFilesDefault(t *testing.T) {
 			for _, tf := range tt.filenames {
 				require.NoError(t, os.WriteFile(tf, []byte(tf), 0644))
 			}
-			files, err := ReadLocalFiles(nil, nil)
+			files, err := ReadLocalFiles(nil, nil, nil)
 			require.NoError(t, err)
 			if len(files) == 0 {
 				require.Equal(t, len(tt.expected), len(files))

--- a/commands/bake.go
+++ b/commands/bake.go
@@ -150,7 +150,10 @@ func runBake(dockerCli command.Cli, targets []string, in bakeOptions, cFlags com
 	if url != "" {
 		files, inp, err = bake.ReadRemoteFiles(ctx, nodes, url, in.files, printer)
 	} else {
-		files, err = bake.ReadLocalFiles(in.files, dockerCli.In())
+		progress.Wrap("[internal] load local bake definitions", printer.Write, func(sub progress.SubLogger) error {
+			files, err = bake.ReadLocalFiles(in.files, dockerCli.In(), sub)
+			return nil
+		})
 	}
 	if err != nil {
 		return err

--- a/tests/bake.go
+++ b/tests/bake.go
@@ -20,6 +20,7 @@ func bakeCmd(sb integration.Sandbox, opts ...cmdOpt) (string, error) {
 
 var bakeTests = []func(t *testing.T, sb integration.Sandbox){
 	testBakeLocal,
+	testBakeLocalMulti,
 	testBakeRemote,
 	testBakeRemoteCmdContext,
 	testBakeRemoteCmdContextOverride,
@@ -47,8 +48,45 @@ target "default" {
 	)
 	dirDest := t.TempDir()
 
-	out, err := bakeCmd(sb, withDir(dir), withArgs("--set", "*.output=type=local,dest="+dirDest))
+	cmd := buildxCmd(sb, withDir(dir), withArgs("bake", "--progress=plain", "--set", "*.output=type=local,dest="+dirDest))
+	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, out)
+	require.Contains(t, string(out), `#1 [internal] load local bake definitions`)
+	require.Contains(t, string(out), `#1 reading docker-bake.hcl`)
+
+	require.FileExists(t, filepath.Join(dirDest, "foo"))
+}
+
+func testBakeLocalMulti(t *testing.T, sb integration.Sandbox) {
+	dockerfile := []byte(`
+FROM scratch
+COPY foo /foo
+	`)
+	bakefile := []byte(`
+target "default" {
+}
+`)
+	composefile := []byte(`
+services:
+  app:
+    build: {}
+`)
+
+	dir := tmpdir(
+		t,
+		fstest.CreateFile("docker-bake.hcl", bakefile, 0600),
+		fstest.CreateFile("compose.yaml", composefile, 0600),
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+		fstest.CreateFile("foo", []byte("foo"), 0600),
+	)
+	dirDest := t.TempDir()
+
+	cmd := buildxCmd(sb, withDir(dir), withArgs("bake", "--progress=plain", "--set", "*.output=type=local,dest="+dirDest))
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, out)
+	require.Contains(t, string(out), `#1 [internal] load local bake definitions`)
+	require.Contains(t, string(out), `#1 reading compose.yaml`)
+	require.Contains(t, string(out), `#1 reading docker-bake.hcl`)
 
 	require.FileExists(t, filepath.Join(dirDest, "foo"))
 }

--- a/util/cobrautil/completion/completion.go
+++ b/util/cobrautil/completion/completion.go
@@ -19,7 +19,7 @@ func Disable(cmd *cobra.Command, args []string, toComplete string) ([]string, co
 
 func BakeTargets(files []string) ValidArgsFn {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		f, err := bake.ReadLocalFiles(files, nil)
+		f, err := bake.ReadLocalFiles(files, nil, nil)
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveError
 		}


### PR DESCRIPTION
If no bake definition are specified, it will currently consume the default ones in this specified order: https://github.com/docker/buildx/blob/05b88216251d20597e6a457f0d454dbbeb8d03eb/bake/bake.go#L47-L53

Following-up a discussion with @milas:

> If you have both `docker-bake.hcl` AND `docker-compose.yml` in a directory, Bake always parses the Compose file unless you pass `-f docker-bake.hcl` explicitly
> So if you have a syntax error in your compose file:
> ```
> ❯ docker buildx bake services
> [+] Building 0.0s (0/0)                                                                                                                  cloud:cloud-stage
> ERROR: parsing : yaml: line 3: mapping values are not allowed in this context
> ```
> But:
> ```
> ❯ docker buildx bake -f docker-bake.hcl services
> [+] Building 0.5s (10/10) FINISHED                                                                                                       cloud:cloud-stage
>  => [registry internal] connected to docker's cloud service                                                                                           0.0s
>  => => note: cloud builds are currently in beta                                                                                                       0.0s
> ```
> I actually noticed this because I was getting this in my bake:
> ```
> WARNING: The "BUILD_SERVICE_CLIENT_MTLS_CERT" variable is not set. Defaulting to a blank string.
> ```
> and was SO confused because that's not part of the `Dockerfile` or Bake file and I thought it was actually coming FROM the builder but that's a variable in the Compose file (that it wasn't even using) and that's `compose-go` writing out that message to stdout

So there is an issue with `compose-go` writing on stdout warnings: https://github.com/compose-spec/compose-go/blob/2d32c3f774bda0ad20e8d06eae493047b728fc54/template/template.go#L206. Didn't find an easy way to disable logging via https://github.com/compose-spec/compose-go/blob/2d32c3f774bda0ad20e8d06eae493047b728fc54/template/template.go#L114-L116 without setting `options.Interpolate.Substitute` and redefining templating on our side. @milas @glours Is it possible to have smth easier to consume through `loader.Options` instead like `options.Logging = false`?

It also appears in his case that consuming a `compose.yml` and `docker-bake.hcl` when invoking `docker buildx bake` is unexpected/confusing. Maybe we could put some effort and clearly state this behavior in our docs https://docs.docker.com/build/bake/reference/#file-format (cc @dvdksn).

On the other hand it's pretty common to have a compose file just for runtime and a bake hcl file to build on a repository so I tend to agree with him.

This PR will show what bake definitions are consumed in the build output to mitigate this issue and help user figures out what is the source of the definition:

```
$ docker buildx bake binaries
[+] Building 2.1s (10/10) FINISHED                                                                                                                                                                             docker:default
 => [internal] load local bake definitions                                                                                                                                                                               0.0s 
 => => reading compose.yaml 954B / 954B                                                                                                                                                                                  0.0s
 => => reading docker-bake.hcl 3.68kB / 3.68kB                                                                                                                                                                           0.0s 
 => [internal] load .dockerignore                                                                                                                                                                                        0.1s
 => => transferring context: 45B                                                                                                                                                                                         0.0s 
 => [internal] load build definition from Dockerfile                                                                                                                                                                     0.1s 
 => => transferring dockerfile: 4.66kB                                                                                                                                                                                   0.0s 
 => resolve image config for docker.io/docker/dockerfile:1
...
```

```
$ docker buildx bake binaries
#0 building with "default" instance using docker driver

#1 [internal] load local bake definitions
#1 reading compose.yaml 954B / 954B done
#1 reading docker-bake.hcl 3.68kB / 3.68kB done
#1 DONE 0.0s

#2 [internal] load build definition from Dockerfile
#2 transferring dockerfile: 4.66kB 0.0s done
#2 DONE 0.1s

#3 [internal] load .dockerignore
#3 transferring context: 45B 0.0s done
#3 DONE 0.1s

#4 resolve image config for docker.io/docker/dockerfile:1
#4 DONE 0.5s
...
```
