### PR TITLE
build: fix racy localstate group removal

### DIFF
--- a/localstate/localstate.go
+++ b/localstate/localstate.go
@@ -127,22 +127,17 @@ func (ls *LocalState) RemoveBuilder(builderName string) error {
 	if err != nil {
 		return err
 	}
-
-	eg, _ := errgroup.WithContext(context.TODO())
 	for _, fi := range fis {
-		func(fi os.DirEntry) {
-			eg.Go(func() error {
-				return ls.RemoveBuilderNode(builderName, fi.Name())
-			})
-		}(fi)
-	}
-	if err := eg.Wait(); err != nil {
-		return err
+		if err := ls.RemoveBuilderNode(builderName, fi.Name()); err != nil {
+			return err
+		}
 	}
 
 	return os.RemoveAll(dir)
 }
 
+// RemoveBuilderNode removes all refs for a builder node.
+// This func is not safe for concurrent use from multiple goroutines.
 func (ls *LocalState) RemoveBuilderNode(builderName string, nodeName string) error {
 	if builderName == "" {
 		return errors.Errorf("builder name empty")


### PR DESCRIPTION
related to https://github.com/docker/buildx/actions/runs/6515548684/job/17698128684#step:10:410

```
+ docker buildx rm buildx-test-c52e7aa2a683a0d852229cc602f172c4
ERROR: remove /home/runner/.docker/buildx/refs/__group__/johhgzt9x9jlb16iw392e5bni: no such file or directory
```

Local state group removal can be racy because of the go routine removing each builder node. This removes the go routine that doesn't seem necessary here. Maybe instead we could add a mutex on group removal.