### PR TITLE
bake: discard progress on print

### DIFF
--- a/commands/bake.go
+++ b/commands/bake.go
@@ -128,6 +128,9 @@ func runBake(dockerCli command.Cli, targets []string, in bakeOptions, cFlags com
 	}
 
 	progressMode := progressui.DisplayMode(cFlags.progress)
+	if in.printOnly {
+		progressMode = progressui.QuietMode
+	}
 	printer, err := progress.NewPrinter(ctx2, os.Stderr, progressMode,
 		progress.WithDesc(progressTextDesc, progressConsoleDesc),
 	)


### PR DESCRIPTION
follow-up https://github.com/docker/buildx/pull/2076#issuecomment-1763056196

There are cases when using the canonical representation through `--print` can be useful but when using a remote bake definition, the output can be used effectively:

```
$ docker buildx bake https://github.com/docker/buildx.git --print
#0 building with "default" instance using docker driver

#1 [internal] load remote bake definitions
#1 reading docker-bake.hcl done
#1 DONE 1.0s

#2 [internal] load git source https://github.com/docker/buildx.git
#2 0.553 ref: refs/heads/master HEAD
#2 0.553 05b88216251d20597e6a457f0d454dbbeb8d03eb       HEAD
#2 1.014 05b88216251d20597e6a457f0d454dbbeb8d03eb       refs/heads/master
#2 CACHED
{
  "group": {
    "default": {
      "targets": [
        "binaries"
      ]
    }
  },
  "target": {
    "binaries": {
      "context": "https://github.com/docker/buildx.git",
      "dockerfile": "Dockerfile",
      "args": {
        "BUILDKIT_CONTEXT_KEEP_GIT_DIR": "1"
      },
      "target": "binaries",
      "platforms": [
        "local"
      ],
      "output": [
        "./bin/build"
      ]
    }
  }
}
```

The progress output is still useful here so user knows what ref is being fetched. User could set `--progress=quiet` to solve this issue.

Tbf I'm not really sure that enforcing `quiet` is the right solution. Maybe it's just a matter of documenting this use case (cc @dvdksn)? Let me know what you think.