### PR TITLE
update to go 1.21.3

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,12 +26,13 @@ linters:
 
 linters-settings:
   depguard:
-    list-type: blacklist
-    include-go-root: true
-    packages:
-      # The io/ioutil package has been deprecated.
-      # https://go.dev/doc/go1.16#ioutil
-      - io/ioutil
+    rules:
+      main:
+        deny:
+          # The io/ioutil package has been deprecated.
+          # https://go.dev/doc/go1.16#ioutil
+          - pkg: "io/ioutil"
+            desc: The io/ioutil package has been deprecated.
   forbidigo:
     forbid:
       - '^fmt\.Errorf(# use errors\.Errorf instead)?$'
@@ -47,3 +48,22 @@ issues:
     - linters:
         - revive
       text: "stutters"
+    - linters:
+        - revive
+      text: "empty-block"
+    - linters:
+        - revive
+      text: "superfluous-else"
+    - linters:
+        - revive
+      text: "unused-parameter"
+    - linters:
+        - revive
+      text: "redefines-builtin-id"
+    - linters:
+        - revive
+      text: "if-return"
+
+# show all
+max-issues-per-linter: 0
+max-same-issues: 0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.20.8
+ARG GO_VERSION=1.21.3
 ARG XX_VERSION=1.2.1
 
 ARG DOCKER_VERSION=24.0.6

--- a/bake/compose.go
+++ b/bake/compose.go
@@ -51,6 +51,7 @@ func ParseCompose(cfgs []compose.ConfigFile, envs map[string]string) (*Config, e
 		g := &Group{Name: "default"}
 
 		for _, s := range cfg.Services {
+			s := s
 			if s.Build == nil {
 				continue
 			}

--- a/bake/hclparser/hclparser.go
+++ b/bake/hclparser/hclparser.go
@@ -631,13 +631,14 @@ func Parse(b hcl.Body, opt Opt, val interface{}) (map[string]map[string][]string
 	}
 
 	for _, a := range content.Attributes {
+		a := a
 		return nil, hcl.Diagnostics{
 			&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Invalid attribute",
 				Detail:   "global attributes currently not supported",
-				Subject:  &a.Range,
-				Context:  &a.Range,
+				Subject:  a.Range.Ptr(),
+				Context:  a.Range.Ptr(),
 			},
 		}
 	}
@@ -660,13 +661,14 @@ func Parse(b hcl.Body, opt Opt, val interface{}) (map[string]map[string][]string
 			var subject *hcl.Range
 			var context *hcl.Range
 			if p.funcs[k].Params != nil {
-				subject = &p.funcs[k].Params.Range
+				subject = p.funcs[k].Params.Range.Ptr()
 				context = subject
 			} else {
 				for _, block := range blocks.Blocks {
+					block := block
 					if block.Type == "function" && len(block.Labels) == 1 && block.Labels[0] == k {
-						subject = &block.LabelRanges[0]
-						context = &block.DefRange
+						subject = block.LabelRanges[0].Ptr()
+						context = block.DefRange.Ptr()
 						break
 					}
 				}
@@ -732,6 +734,7 @@ func Parse(b hcl.Body, opt Opt, val interface{}) (map[string]map[string][]string
 
 	diags = hcl.Diagnostics{}
 	for _, b := range content.Blocks {
+		b := b
 		v := reflect.ValueOf(val)
 
 		err := p.resolveBlock(b, nil)
@@ -742,7 +745,7 @@ func Parse(b hcl.Body, opt Opt, val interface{}) (map[string]map[string][]string
 					continue
 				}
 			} else {
-				return nil, wrapErrorDiagnostic("Invalid block", err, &b.LabelRanges[0], &b.DefRange)
+				return nil, wrapErrorDiagnostic("Invalid block", err, b.LabelRanges[0].Ptr(), b.DefRange.Ptr())
 			}
 		}
 

--- a/build/build.go
+++ b/build/build.go
@@ -65,6 +65,7 @@ var (
 )
 
 const (
+	//nolint:gosec // G101: false-positive
 	printFallbackImage = "docker/dockerfile:1.5.2-labs@sha256:f2e91734a84c0922ff47aa4098ab775f1dfa932430d2888dd5cad5251fafdac4"
 )
 

--- a/commands/use.go
+++ b/commands/use.go
@@ -35,10 +35,7 @@ func runUse(dockerCli command.Cli, in useOptions) error {
 				if err != nil {
 					return err
 				}
-				if err := txn.SetCurrent(ep, "", false, false); err != nil {
-					return err
-				}
-				return nil
+				return txn.SetCurrent(ep, "", false, false)
 			}
 			list, err := dockerCli.ContextStore().List()
 			if err != nil {
@@ -58,11 +55,7 @@ func runUse(dockerCli command.Cli, in useOptions) error {
 	if err != nil {
 		return err
 	}
-	if err := txn.SetCurrent(ep, in.builder, in.isGlobal, in.isDefault); err != nil {
-		return err
-	}
-
-	return nil
+	return txn.SetCurrent(ep, in.builder, in.isGlobal, in.isDefault)
 }
 
 func useCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {

--- a/controller/pb/path_test.go
+++ b/controller/pb/path_test.go
@@ -236,6 +236,7 @@ func TestResolvePaths(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := ResolveOptionPaths(&tt.options)
 			require.NoError(t, err)

--- a/driver/docker-container/driver.go
+++ b/driver/docker-container/driver.go
@@ -73,10 +73,7 @@ func (d *Driver) Bootstrap(ctx context.Context, l progress.Logger) error {
 			if err := d.start(ctx, sub); err != nil {
 				return err
 			}
-			if err := d.wait(ctx, sub); err != nil {
-				return err
-			}
-			return nil
+			return d.wait(ctx, sub)
 		})
 	})
 }
@@ -119,7 +116,7 @@ func (d *Driver) create(ctx context.Context, l progress.SubLogger) error {
 	}
 
 	useInit := true // let it cleanup exited processes created by BuildKit's container API
-	if err := l.Wrap("creating container "+d.Name, func() error {
+	return l.Wrap("creating container "+d.Name, func() error {
 		hc := &container.HostConfig{
 			Privileged: true,
 			Mounts: []mount.Mount{
@@ -189,14 +186,8 @@ func (d *Driver) create(ctx context.Context, l progress.SubLogger) error {
 				return err
 			}
 		}
-		if err := d.wait(ctx, l); err != nil {
-			return err
-		}
-		return nil
-	}); err != nil {
-		return err
-	}
-	return nil
+		return d.wait(ctx, l)
+	})
 }
 
 func (d *Driver) wait(ctx context.Context, l progress.SubLogger) error {

--- a/driver/kubernetes/driver.go
+++ b/driver/kubernetes/driver.go
@@ -87,10 +87,7 @@ func (d *Driver) Bootstrap(ctx context.Context, l progress.Logger) error {
 		return sub.Wrap(
 			fmt.Sprintf("waiting for %d pods to be ready", d.minReplicas),
 			func() error {
-				if err := d.wait(ctx); err != nil {
-					return err
-				}
-				return nil
+				return d.wait(ctx)
 			})
 	})
 }
@@ -228,7 +225,7 @@ func (d *Driver) Factory() driver.Factory {
 	return d.factory
 }
 
-func (d *Driver) Features(ctx context.Context) map[driver.Feature]bool {
+func (d *Driver) Features(_ context.Context) map[driver.Feature]bool {
 	return map[driver.Feature]bool{
 		driver.OCIExporter:    true,
 		driver.DockerExporter: d.DockerAPI != nil,
@@ -237,6 +234,6 @@ func (d *Driver) Features(ctx context.Context) map[driver.Feature]bool {
 	}
 }
 
-func (d *Driver) HostGatewayIP(ctx context.Context) (net.IP, error) {
+func (d *Driver) HostGatewayIP(_ context.Context) (net.IP, error) {
 	return nil, errors.New("host-gateway is not supported by the kubernetes driver")
 }

--- a/hack/dockerfiles/docs.Dockerfile
+++ b/hack/dockerfiles/docs.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.20.8
+ARG GO_VERSION=1.21.3
 ARG FORMATS=md,yaml
 
 FROM golang:${GO_VERSION}-alpine AS docsgen

--- a/hack/dockerfiles/generated-files.Dockerfile
+++ b/hack/dockerfiles/generated-files.Dockerfile
@@ -5,7 +5,7 @@
 # Copyright The Buildx Authors.
 # Licensed under the Apache License, Version 2.0
 
-ARG GO_VERSION="1.20.8"
+ARG GO_VERSION="1.21.3"
 ARG PROTOC_VERSION="3.11.4"
 
 # protoc is dynamically linked to glibc so can't use alpine base

--- a/hack/dockerfiles/lint.Dockerfile
+++ b/hack/dockerfiles/lint.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.20.8
+ARG GO_VERSION=1.21.3
 
 FROM golang:${GO_VERSION}-alpine
 RUN apk add --no-cache git gcc musl-dev

--- a/hack/dockerfiles/lint.Dockerfile
+++ b/hack/dockerfiles/lint.Dockerfile
@@ -1,10 +1,14 @@
 # syntax=docker/dockerfile:1
 
 ARG GO_VERSION=1.21.3
+ARG GOLANGCI_LINT_VERSION=1.54.2
 
 FROM golang:${GO_VERSION}-alpine
 RUN apk add --no-cache git gcc musl-dev
-RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.51.1
+ENV GOFLAGS="-buildvcs=false"
+ARG GOLANGCI_LINT_VERSION
+RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v${GOLANGCI_LINT_VERSION}
 WORKDIR /go/src/github.com/docker/buildx
-RUN --mount=target=/go/src/github.com/docker/buildx --mount=target=/root/.cache,type=cache \
-  golangci-lint run
+RUN --mount=target=/go/src/github.com/docker/buildx \
+    --mount=target=/root/.cache,type=cache \
+    golangci-lint run

--- a/hack/dockerfiles/vendor.Dockerfile
+++ b/hack/dockerfiles/vendor.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.20.8
+ARG GO_VERSION=1.21.3
 ARG MODOUTDATED_VERSION=v0.8.0
 
 FROM golang:${GO_VERSION}-alpine AS base

--- a/store/nodegroup.go
+++ b/store/nodegroup.go
@@ -102,10 +102,7 @@ func (ng *NodeGroup) Update(name, endpoint string, platforms []string, endpoints
 		}
 
 		ng.Nodes[i] = n
-		if err := ng.validateDuplicates(endpoint, i); err != nil {
-			return err
-		}
-		return nil
+		return ng.validateDuplicates(endpoint, i)
 	}
 
 	if name == "" {
@@ -127,11 +124,7 @@ func (ng *NodeGroup) Update(name, endpoint string, platforms []string, endpoints
 	}
 
 	ng.Nodes = append(ng.Nodes, n)
-
-	if err := ng.validateDuplicates(endpoint, len(ng.Nodes)-1); err != nil {
-		return err
-	}
-	return nil
+	return ng.validateDuplicates(endpoint, len(ng.Nodes)-1)
 }
 
 func (ng *NodeGroup) Copy() *NodeGroup {

--- a/store/store.go
+++ b/store/store.go
@@ -185,10 +185,7 @@ func (t *Txn) reset(key string) error {
 	if err != nil {
 		return err
 	}
-	if err := ioutils.AtomicWriteFile(filepath.Join(t.s.root, "current"), dt, 0600); err != nil {
-		return err
-	}
-	return nil
+	return ioutils.AtomicWriteFile(filepath.Join(t.s.root, "current"), dt, 0600)
 }
 
 func (t *Txn) Current(key string) (*NodeGroup, error) {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -18,9 +18,9 @@ func TestEmptyStartup(t *testing.T) {
 	s, err := New(tmpdir)
 	require.NoError(t, err)
 
-	txn, close, err := s.Txn()
+	txn, release, err := s.Txn()
 	require.NoError(t, err)
-	defer close()
+	defer release()
 
 	ng, err := txn.Current("foo")
 	require.NoError(t, err)

--- a/tests/workers/docker-container.go
+++ b/tests/workers/docker-container.go
@@ -80,8 +80,8 @@ func (w *containerWorker) New(ctx context.Context, cfg *integration.BackendConfi
 }
 
 func (w *containerWorker) Close() error {
-	if close := w.dockerClose; close != nil {
-		return close()
+	if c := w.dockerClose; c != nil {
+		return c()
 	}
 
 	// reset the worker to be ready to go again


### PR DESCRIPTION
https://tip.golang.org/doc/go1.21

Updates golangci-lint to 1.54.2 and its configuration to show all lint issues and align exclude rules with buildkit ones as well: https://github.com/golangci/golangci-lint/releases/tag/v1.54.2