### PR TITLE
debug: Following-up patches for error messages

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -418,6 +418,9 @@ func runControllerBuild(ctx context.Context, dockerCli command.Cli, opts *contro
 }
 
 func printError(err error, printer *progress.Printer) error {
+	if err == nil {
+		return nil
+	}
 	if err := printer.Pause(); err != nil {
 		return err
 	}

--- a/commands/debug/root.go
+++ b/commands/debug/root.go
@@ -66,7 +66,7 @@ func RootCmd(dockerCli command.Cli, children ...DebuggableCmd) *cobra.Command {
 				return errors.Errorf("failed to configure terminal: %v", err)
 			}
 
-			err = monitor.RunMonitor(ctx, "", nil, controllerapi.InvokeConfig{
+			_, err = monitor.RunMonitor(ctx, "", nil, controllerapi.InvokeConfig{
 				Tty: true,
 			}, c, dockerCli.In(), os.Stdout, os.Stderr, printer)
 			con.Reset()

--- a/controller/processes/processes.go
+++ b/controller/processes/processes.go
@@ -137,11 +137,7 @@ func (m *Manager) StartProcess(pid string, resultCtx *build.ResultHandle, cfg *p
 	go func() {
 		var err error
 		if err = ctr.Exec(ctx, cfg, in.Stdin, in.Stdout, in.Stderr); err != nil {
-			if errors.Is(err, context.Canceled) {
-				logrus.Debugf("process canceled: %v", err)
-			} else {
-				logrus.Errorf("failed to exec process: %v", err)
-			}
+			logrus.Debugf("process error: %v", err)
 		}
 		logrus.Debugf("finished process %s %v", pid, cfg.Entrypoint)
 		m.processes.Delete(pid)

--- a/monitor/commands/reload.go
+++ b/monitor/commands/reload.go
@@ -9,6 +9,7 @@ import (
 	controllerapi "github.com/docker/buildx/controller/pb"
 	"github.com/docker/buildx/monitor/types"
 	"github.com/docker/buildx/util/progress"
+	"github.com/moby/buildkit/solver/errdefs"
 	"github.com/pkg/errors"
 )
 
@@ -70,6 +71,11 @@ func (cm *ReloadCmd) Exec(ctx context.Context, args []string) error {
 		} else {
 			fmt.Printf("failed to reload: %v\n", err)
 		}
+		// report error
+		for _, s := range errdefs.Sources(err) {
+			s.Print(cm.stdout)
+		}
+		fmt.Fprintf(cm.stdout, "ERROR: %v\n", err)
 	} else {
 		resultUpdated = true
 	}

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -302,7 +302,11 @@ func (m *monitor) startInvoke(ctx context.Context, pid string, cfg controllerapi
 	go func() {
 		// Start a new invoke
 		if err := m.invoke(ctx, pid, cfg); err != nil {
-			logrus.Debugf("invoke error: %v", err)
+			if errors.Is(err, context.Canceled) {
+				logrus.Debugf("process canceled: %v", err)
+			} else {
+				logrus.Errorf("invoke: %v", err)
+			}
 		}
 		if pid == m.attachedPid.Load() {
 			m.attachedPid.Store("")

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -17,14 +17,20 @@ import (
 	"github.com/docker/buildx/util/ioset"
 	"github.com/docker/buildx/util/progress"
 	"github.com/google/shlex"
+	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/identity"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/term"
 )
 
+type MonitorBuildResult struct {
+	Resp *client.SolveResponse
+	Err  error
+}
+
 // RunMonitor provides an interactive session for running and managing containers via specified IO.
-func RunMonitor(ctx context.Context, curRef string, options *controllerapi.BuildOptions, invokeConfig controllerapi.InvokeConfig, c control.BuildxController, stdin io.ReadCloser, stdout io.WriteCloser, stderr console.File, progress *progress.Printer) error {
+func RunMonitor(ctx context.Context, curRef string, options *controllerapi.BuildOptions, invokeConfig controllerapi.InvokeConfig, c control.BuildxController, stdin io.ReadCloser, stdout io.WriteCloser, stderr console.File, progress *progress.Printer) (*MonitorBuildResult, error) {
 	defer func() {
 		if err := c.Disconnect(ctx, curRef); err != nil {
 			logrus.Warnf("disconnect error: %v", err)
@@ -32,7 +38,7 @@ func RunMonitor(ctx context.Context, curRef string, options *controllerapi.Build
 	}()
 
 	if err := progress.Pause(); err != nil {
-		return err
+		return nil, err
 	}
 	defer progress.Unpause()
 
@@ -169,10 +175,10 @@ func RunMonitor(ctx context.Context, curRef string, options *controllerapi.Build
 		select {
 		case <-doneCh:
 			m.close()
-			return nil
+			return m.lastBuildResult, nil
 		case err := <-errCh:
 			m.close()
-			return err
+			return m.lastBuildResult, err
 		case <-monitorDisableCh:
 		}
 		monitorForwarder.SetOut(nil)
@@ -233,6 +239,14 @@ type monitor struct {
 	invokeIO     *ioset.Forwarder
 	invokeCancel func()
 	attachedPid  atomic.Value
+
+	lastBuildResult *MonitorBuildResult
+}
+
+func (m *monitor) Build(ctx context.Context, options controllerapi.BuildOptions, in io.ReadCloser, progress progress.Writer) (ref string, resp *client.SolveResponse, err error) {
+	ref, resp, err = m.BuildxController.Build(ctx, options, in, progress)
+	m.lastBuildResult = &MonitorBuildResult{Resp: resp, Err: err} // Record build result
+	return
 }
 
 func (m *monitor) DisconnectSession(ctx context.Context, targetID string) error {


### PR DESCRIPTION
- 38137b29dd03335611fe190b4ed467e51804bd55 : fixes the following mentioned in https://github.com/docker/buildx/pull/2006#pullrequestreview-1681377351
  - > * There is an error in Dockerfile command (eg. change `RUN` to `RUN2`). I get an error. Now I run `reload`. It builds up to the Dockerfile error again but this time I don't see any error.
- b06a55cf53b0c5b34d1e1bffa058394cd673ce2d : following-up for https://github.com/docker/buildx/pull/2006/commits/0dd89f602922851a3159976972832728aafa0bd3
- 267e30a19cd5972187a6553c00e0442e8f45d150 : fixes the following mentioned in https://github.com/docker/buildx/pull/2006#pullrequestreview-1681377351
  - > * I run `debug build .` and get an error. I fix the error and issue `reload`. Now my build succeeds. I run some more interactive processes and eventually close the debugger. Now I get an error.
- 14834e6085e5227d1baface0aa057cccb34ffc29 : following-up for https://github.com/docker/buildx/pull/2006/commits/6db8569f096a89a0a2e1f637c4cd990b99c7b832
