### PR TITLE
Permit '=' separator and '[ipv6]' in --add-host

### DIFF
--- a/build/utils_test.go
+++ b/build/utils_test.go
@@ -1,0 +1,148 @@
+package build
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestToBuildkitExtraHosts(t *testing.T) {
+	tests := []struct {
+		doc         string
+		input       []string
+		expectedOut string // Expect output==input if not set.
+		expectedErr string // Expect success if not set.
+	}{
+		{
+			doc:         "IPv4, colon sep",
+			input:       []string{`myhost:192.168.0.1`},
+			expectedOut: `myhost=192.168.0.1`,
+		},
+		{
+			doc:   "IPv4, eq sep",
+			input: []string{`myhost=192.168.0.1`},
+		},
+		{
+			doc:         "Weird but permitted, IPv4 with brackets",
+			input:       []string{`myhost=[192.168.0.1]`},
+			expectedOut: `myhost=192.168.0.1`,
+		},
+		{
+			doc:         "Host and domain",
+			input:       []string{`host.and.domain.invalid:10.0.2.1`},
+			expectedOut: `host.and.domain.invalid=10.0.2.1`,
+		},
+		{
+			doc:         "IPv6, colon sep",
+			input:       []string{`anipv6host:2003:ab34:e::1`},
+			expectedOut: `anipv6host=2003:ab34:e::1`,
+		},
+		{
+			doc:         "IPv6, colon sep, brackets",
+			input:       []string{`anipv6host:[2003:ab34:e::1]`},
+			expectedOut: `anipv6host=2003:ab34:e::1`,
+		},
+		{
+			doc:         "IPv6, eq sep, brackets",
+			input:       []string{`anipv6host=[2003:ab34:e::1]`},
+			expectedOut: `anipv6host=2003:ab34:e::1`,
+		},
+		{
+			doc:         "IPv6 localhost, colon sep",
+			input:       []string{`ipv6local:::1`},
+			expectedOut: `ipv6local=::1`,
+		},
+		{
+			doc:   "IPv6 localhost, eq sep",
+			input: []string{`ipv6local=::1`},
+		},
+		{
+			doc:         "IPv6 localhost, eq sep, brackets",
+			input:       []string{`ipv6local=[::1]`},
+			expectedOut: `ipv6local=::1`,
+		},
+		{
+			doc:         "IPv6 localhost, non-canonical, colon sep",
+			input:       []string{`ipv6local:0:0:0:0:0:0:0:1`},
+			expectedOut: `ipv6local=0:0:0:0:0:0:0:1`,
+		},
+		{
+			doc:   "IPv6 localhost, non-canonical, eq sep",
+			input: []string{`ipv6local=0:0:0:0:0:0:0:1`},
+		},
+		{
+			doc:         "IPv6 localhost, non-canonical, eq sep, brackets",
+			input:       []string{`ipv6local=[0:0:0:0:0:0:0:1]`},
+			expectedOut: `ipv6local=0:0:0:0:0:0:0:1`,
+		},
+		{
+			doc:         "Bad address, colon sep",
+			input:       []string{`myhost:192.notanipaddress.1`},
+			expectedErr: `invalid IP address in add-host: "192.notanipaddress.1"`,
+		},
+		{
+			doc:         "Bad address, eq sep",
+			input:       []string{`myhost=192.notanipaddress.1`},
+			expectedErr: `invalid IP address in add-host: "192.notanipaddress.1"`,
+		},
+		{
+			doc:         "No sep",
+			input:       []string{`thathost-nosemicolon10.0.0.1`},
+			expectedErr: `bad format for add-host: "thathost-nosemicolon10.0.0.1"`,
+		},
+		{
+			doc:         "Bad IPv6",
+			input:       []string{`anipv6host:::::1`},
+			expectedErr: `invalid IP address in add-host: "::::1"`,
+		},
+		{
+			doc:         "Bad IPv6, trailing colons",
+			input:       []string{`ipv6local:::0::`},
+			expectedErr: `invalid IP address in add-host: "::0::"`,
+		},
+		{
+			doc:         "Bad IPv6, missing close bracket",
+			input:       []string{`ipv6addr=[::1`},
+			expectedErr: `invalid IP address in add-host: "[::1"`,
+		},
+		{
+			doc:         "Bad IPv6, missing open bracket",
+			input:       []string{`ipv6addr=::1]`},
+			expectedErr: `invalid IP address in add-host: "::1]"`,
+		},
+		{
+			doc:         "Missing address, colon sep",
+			input:       []string{`myhost.invalid:`},
+			expectedErr: `invalid IP address in add-host: ""`,
+		},
+		{
+			doc:         "Missing address, eq sep",
+			input:       []string{`myhost.invalid=`},
+			expectedErr: `invalid IP address in add-host: ""`,
+		},
+		{
+			doc:         "No input",
+			input:       []string{``},
+			expectedErr: `bad format for add-host: ""`,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		if tc.expectedOut == "" {
+			tc.expectedOut = strings.Join(tc.input, ",")
+		}
+		t.Run(tc.doc, func(t *testing.T) {
+			actualOut, actualErr := toBuildkitExtraHosts(context.TODO(), tc.input, nil)
+			if tc.expectedErr == "" {
+				require.Equal(t, tc.expectedOut, actualOut)
+				require.Nil(t, actualErr)
+			} else {
+				require.Zero(t, actualOut)
+				require.Error(t, actualErr, tc.expectedErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Fixes docker/cli#4648
- See https://github.com/docker/cli/issues/4648#issuecomment-1807992740
- related: https://github.com/docker/cli/pull/4663

**- What I did**

Make it easier to specify IPv6 addresses in the '--add-host' option by permitting 'host=ip' in addition to 'host:ip', and allowing square brackets around the address.

For example:

    --add-host=hostname:127.0.0.1
    --add-host=hostname:::1
    --add-host=hostname=::1
    --add-host=hostname:[::1]

**- How I did it**

Updated the function that converts from `--add-host` format to buildx's csv format, stripping brackets from the address.

This pull request is equivalent to one in `docker/cli`, for `docker run` and legacy builds.

**- How to verify it**

New unit tests pass. And ...

```
/work # cat Dockerfile
FROM alpine:latest
RUN ping -c1 something
RUN ping -c1 somethingv6

/work # docker build --add-host something=8.8.8.8 --add-host somethingv6=[::1] . 2>&1 | cat
#0 building with "default" instance using docker driver

#1 [internal] load .dockerignore
#1 transferring context: 2B done
#1 DONE 0.0s

#2 [internal] load build definition from Dockerfile
#2 transferring dockerfile: 104B done
#2 DONE 0.0s

#3 [internal] load metadata for docker.io/library/alpine:latest
#3 DONE 0.9s

#4 [1/3] FROM docker.io/library/alpine:latest@sha256:eece025e432126ce23f223450a0326fbebde39cdf496a85d8c016293fc851978
#4 CACHED

#5 [2/3] RUN ping -c1 something
#5 0.116 PING something (8.8.8.8): 56 data bytes
#5 0.190 64 bytes from 8.8.8.8: seq=0 ttl=62 time=73.792 ms
#5 0.190
#5 0.190 --- something ping statistics ---
#5 0.190 1 packets transmitted, 1 packets received, 0% packet loss
#5 0.190 round-trip min/avg/max = 73.792/73.792/73.792 ms
#5 DONE 0.2s

#6 [3/3] RUN ping -c1 somethingv6
#6 0.205 PING somethingv6 (::1): 56 data bytes
#6 0.205 64 bytes from ::1: seq=0 ttl=64 time=0.028 ms
#6 0.205
#6 0.205 --- somethingv6 ping statistics ---
#6 0.205 1 packets transmitted, 1 packets received, 0% packet loss
#6 0.205 round-trip min/avg/max = 0.028/0.028/0.028 ms
#6 DONE 0.2s

#7 exporting to image
#7 exporting layers done
#7 writing image sha256:ea192cc9965b812a66562225e85b437af3af1d8347daca9d65eff8a6498b679e done
#7 DONE 0.0s
```

**- Description for the changelog**

Permit '=' separator and '[ipv6]' in --add-host