### PR TITLE
driver: add status reporting and a timeout to the remote driver bootstrap

### DIFF
--- a/driver/remote/driver.go
+++ b/driver/remote/driver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"time"
 
 	"github.com/docker/buildx/driver"
 	"github.com/docker/buildx/util/progress"
@@ -29,7 +30,11 @@ func (d *Driver) Bootstrap(ctx context.Context, l progress.Logger) error {
 	if err != nil {
 		return err
 	}
-	return c.Wait(ctx)
+	return progress.Wrap("[internal] waiting for connection", l, func(_ progress.SubLogger) error {
+		ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+		defer cancel()
+		return c.Wait(ctx)
+	})
 }
 
 func (d *Driver) Info(ctx context.Context) (*driver.Info, error) {


### PR DESCRIPTION
This adds status reporting for the remote driver so it shows the length
of time it is spending waiting for the connection. If the service is
already present, this logger isn't shown but it should help provide a
message to show the user why the build is stalled.

A timeout of 20 seconds has been added to the bootstrap.

Fixes #2120.