### PR TITLE
build: infer platform from first node if none set

### DIFF
--- a/build/driver.go
+++ b/build/driver.go
@@ -19,6 +19,8 @@ import (
 )
 
 type resolvedNode struct {
+	SolveOpt *client.SolveOpt
+
 	resolver    *nodeResolver
 	driverIndex int
 	platforms   []specs.Platform

--- a/build/driver.go
+++ b/build/driver.go
@@ -19,8 +19,6 @@ import (
 )
 
 type resolvedNode struct {
-	SolveOpt *client.SolveOpt
-
 	resolver    *nodeResolver
 	driverIndex int
 	platforms   []specs.Platform

--- a/build/driver_test.go
+++ b/build/driver_test.go
@@ -22,6 +22,7 @@ func TestFindDriverSanity(t *testing.T) {
 	require.Len(t, res, 1)
 	require.Equal(t, 0, res[0].driverIndex)
 	require.Equal(t, "aaa", res[0].Node().Builder)
+	require.Equal(t, []specs.Platform{platforms.DefaultSpec()}, res[0].platforms)
 }
 
 func TestFindDriverEmpty(t *testing.T) {
@@ -227,6 +228,7 @@ func TestSelectNodeCurrentPlatform(t *testing.T) {
 	require.True(t, perfect)
 	require.Len(t, res, 1)
 	require.Equal(t, "bbb", res[0].Node().Builder)
+	require.Empty(t, res[0].platforms)
 }
 
 func TestSelectNodeAdditionalPlatforms(t *testing.T) {

--- a/build/driver_test.go
+++ b/build/driver_test.go
@@ -217,7 +217,7 @@ func TestSelectNodePreferExact(t *testing.T) {
 	require.Equal(t, "bbb", res[0].Node().Builder)
 }
 
-func TestSelectNodeCurrentPlatform(t *testing.T) {
+func TestSelectNodeNoPlatform(t *testing.T) {
 	r := makeTestResolver(map[string][]specs.Platform{
 		"aaa": {platforms.MustParse("linux/foobar")},
 		"bbb": {platforms.DefaultSpec()},
@@ -227,7 +227,7 @@ func TestSelectNodeCurrentPlatform(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, perfect)
 	require.Len(t, res, 1)
-	require.Equal(t, "bbb", res[0].Node().Builder)
+	require.Equal(t, "aaa", res[0].Node().Builder)
 	require.Empty(t, res[0].platforms)
 }
 


### PR DESCRIPTION
closes https://github.com/docker/buildx/pull/2124

If user doesn't specify any platform, it should be inferred from the first node instead of using the local platform. In follow-up we should also look at the rules suggested in https://github.com/docker/buildx/issues/2119#issuecomment-1815517521 to take into account the preferred platform as well.