### PR TITLE
rm: support removing multiple builders at once

### DIFF
--- a/docs/reference/buildx.md
+++ b/docs/reference/buildx.md
@@ -20,7 +20,7 @@ Extended build capabilities with BuildKit
 | [`inspect`](buildx_inspect.md)       | Inspect current builder instance       |
 | [`ls`](buildx_ls.md)                 | List builder instances                 |
 | [`prune`](buildx_prune.md)           | Remove build cache                     |
-| [`rm`](buildx_rm.md)                 | Remove a builder instance              |
+| [`rm`](buildx_rm.md)                 | Remove one or more builder instances   |
 | [`stop`](buildx_stop.md)             | Stop builder instance                  |
 | [`use`](buildx_use.md)               | Set the current builder instance       |
 | [`version`](buildx_version.md)       | Show buildx version information        |

--- a/docs/reference/buildx_rm.md
+++ b/docs/reference/buildx_rm.md
@@ -1,11 +1,11 @@
 # buildx rm
 
 ```text
-docker buildx rm [NAME]
+docker buildx rm [OPTIONS] [NAME] [NAME...]
 ```
 
 <!---MARKER_GEN_START-->
-Remove a builder instance
+Remove one or more builder instances
 
 ### Options
 

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -28,6 +28,7 @@ func TestIntegration(t *testing.T) {
 	tests = append(tests, imagetoolsTests...)
 	tests = append(tests, versionTests...)
 	tests = append(tests, createTests...)
+	tests = append(tests, rmTests...)
 	testIntegration(t, tests...)
 }
 

--- a/tests/rm.go
+++ b/tests/rm.go
@@ -1,7 +1,11 @@
 package tests
 
 import (
+	"strings"
+	"testing"
+
 	"github.com/moby/buildkit/util/testutil/integration"
+	"github.com/stretchr/testify/require"
 )
 
 func rmCmd(sb integration.Sandbox, opts ...cmdOpt) (string, error) {
@@ -9,4 +13,48 @@ func rmCmd(sb integration.Sandbox, opts ...cmdOpt) (string, error) {
 	cmd := buildxCmd(sb, opts...)
 	out, err := cmd.CombinedOutput()
 	return string(out), err
+}
+
+var rmTests = []func(t *testing.T, sb integration.Sandbox){
+	testRm,
+	testRmMulti,
+}
+
+func testRm(t *testing.T, sb integration.Sandbox) {
+	if sb.Name() != "docker-container" {
+		t.Skip("only testing for docker-container driver")
+	}
+
+	out, err := rmCmd(sb, withArgs("default"))
+	require.Error(t, err, out) // can't remove a docker builder
+
+	out, err = createCmd(sb, withArgs("--driver", "docker-container"))
+	require.NoError(t, err, out)
+	builderName := strings.TrimSpace(out)
+
+	out, err = inspectCmd(sb, withArgs(builderName, "--bootstrap"))
+	require.NoError(t, err, out)
+
+	out, err = rmCmd(sb, withArgs(builderName))
+	require.NoError(t, err, out)
+}
+
+func testRmMulti(t *testing.T, sb integration.Sandbox) {
+	if sb.Name() != "docker-container" {
+		t.Skip("only testing for docker-container driver")
+	}
+
+	var builderNames []string
+	for i := 0; i < 3; i++ {
+		out, err := createCmd(sb, withArgs("--driver", "docker-container"))
+		require.NoError(t, err, out)
+		builderName := strings.TrimSpace(out)
+
+		out, err = inspectCmd(sb, withArgs(builderName, "--bootstrap"))
+		require.NoError(t, err, out)
+		builderNames = append(builderNames, builderName)
+	}
+
+	out, err := rmCmd(sb, withArgs(builderNames...))
+	require.NoError(t, err, out)
 }


### PR DESCRIPTION
Similar to `docker rm`, it gives the possibility to remove one or more builder instances at once.