### PR TITLE
ci: use org-wide var as username

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,7 +225,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERPUBLICBOT_USERNAME }}
+          username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
           password: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
       -
         name: Build and push image


### PR DESCRIPTION
follow-up https://github.com/docker/buildx/pull/2157

We now have org-wide vars to get the username. Let's us it.