### PR TITLE
driver(container): fix conditional statement for error handling

### DIFF
--- a/driver/docker-container/factory.go
+++ b/driver/docker-container/factory.go
@@ -51,11 +51,11 @@ func (f *factory) New(ctx context.Context, cfg driver.InitConfig) (driver.Driver
 		case k == "image":
 			d.image = v
 		case k == "memory":
-			if err := d.memory.Set(v); err == nil {
+			if err := d.memory.Set(v); err != nil {
 				return nil, err
 			}
 		case k == "memory-swap":
-			if err := d.memorySwap.Set(v); err == nil {
+			if err := d.memorySwap.Set(v); err != nil {
 				return nil, err
 			}
 		case k == "cpu-period":

--- a/tests/create.go
+++ b/tests/create.go
@@ -1,0 +1,39 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/util/testutil/integration"
+	"github.com/stretchr/testify/require"
+)
+
+func createCmd(sb integration.Sandbox, opts ...cmdOpt) (string, error) {
+	opts = append([]cmdOpt{withArgs("create")}, opts...)
+	cmd := buildxCmd(sb, opts...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+var createTests = []func(t *testing.T, sb integration.Sandbox){
+	testCreateMemoryLimit,
+}
+
+func testCreateMemoryLimit(t *testing.T, sb integration.Sandbox) {
+	if sb.Name() != "docker-container" {
+		t.Skip("only testing for docker-container driver")
+	}
+
+	var builderName string
+	t.Cleanup(func() {
+		if builderName == "" {
+			return
+		}
+		out, err := rmCmd(sb, withArgs(builderName))
+		require.NoError(t, err, out)
+	})
+
+	out, err := createCmd(sb, withArgs("--driver", "docker-container", "--driver-opt", "network=host", "--driver-opt", "memory=1g"))
+	require.NoError(t, err, out)
+	builderName = strings.TrimSpace(out)
+}

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -27,6 +27,7 @@ func TestIntegration(t *testing.T) {
 	tests = append(tests, lsTests...)
 	tests = append(tests, imagetoolsTests...)
 	tests = append(tests, versionTests...)
+	tests = append(tests, createTests...)
 	testIntegration(t, tests...)
 }
 

--- a/tests/rm.go
+++ b/tests/rm.go
@@ -1,0 +1,12 @@
+package tests
+
+import (
+	"github.com/moby/buildkit/util/testutil/integration"
+)
+
+func rmCmd(sb integration.Sandbox, opts ...cmdOpt) (string, error) {
+	opts = append([]cmdOpt{withArgs("rm")}, opts...)
+	cmd := buildxCmd(sb, opts...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}


### PR DESCRIPTION
fixes #2177 

When creating a builder and setting memory limit, it panics:

```
$ docker --debug buildx create --name foo --driver-opt "memory=3g"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x120c656]

goroutine 46 [running]:
github.com/docker/buildx/builder.(*Node).loadData(0xc000429d40, {0x266fc00, 0xc00025ebd0})
        github.com/docker/buildx/builder/node.go:254 +0x56
github.com/docker/buildx/builder.(*Builder).LoadNodes.(*Builder).LoadNodes.func2.func3()
        github.com/docker/buildx/builder/node.go:154 +0x625
golang.org/x/sync/errgroup.(*Group).Go.func1()
        golang.org/x/sync@v0.3.0/errgroup/errgroup.go:75 +0x56
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 1
        golang.org/x/sync@v0.3.0/errgroup/errgroup.go:72 +0x96
```

Conditional statement for error handling was not set correctly.