### PR TITLE
metrics: add build duration metric

### DIFF
--- a/commands/debug/root.go
+++ b/commands/debug/root.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"go.opentelemetry.io/otel/metric/noop"
 )
 
 // DebugConfig is a user-specified configuration for the debugger.
@@ -50,7 +51,7 @@ func RootCmd(dockerCli command.Cli, children ...DebuggableCmd) *cobra.Command {
 			}
 
 			ctx := context.TODO()
-			c, err := controller.NewController(ctx, controlOptions, dockerCli, printer)
+			c, err := controller.NewController(ctx, controlOptions, dockerCli, printer, noop.NewMeterProvider())
 			if err != nil {
 				return err
 			}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -10,9 +10,10 @@ import (
 	"github.com/docker/buildx/util/progress"
 	"github.com/docker/cli/cli/command"
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel/metric"
 )
 
-func NewController(ctx context.Context, opts control.ControlOptions, dockerCli command.Cli, pw progress.Writer) (control.BuildxController, error) {
+func NewController(ctx context.Context, opts control.ControlOptions, dockerCli command.Cli, pw progress.Writer, mp metric.MeterProvider) (control.BuildxController, error) {
 	var name string
 	if opts.Detach {
 		name = "remote"
@@ -23,9 +24,9 @@ func NewController(ctx context.Context, opts control.ControlOptions, dockerCli c
 	var c control.BuildxController
 	err := progress.Wrap(fmt.Sprintf("[internal] connecting to %s controller", name), pw.Write, func(l progress.SubLogger) (err error) {
 		if opts.Detach {
-			c, err = remote.NewRemoteBuildxController(ctx, dockerCli, opts, l)
+			c, err = remote.NewRemoteBuildxController(ctx, dockerCli, opts, l, mp)
 		} else {
-			c = local.NewLocalBuildxController(ctx, dockerCli, l)
+			c = local.NewLocalBuildxController(ctx, dockerCli, l, mp)
 		}
 		return err
 	})

--- a/controller/remote/controller_nolinux.go
+++ b/controller/remote/controller_nolinux.go
@@ -10,9 +10,10 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"go.opentelemetry.io/otel/metric"
 )
 
-func NewRemoteBuildxController(ctx context.Context, dockerCli command.Cli, opts control.ControlOptions, logger progress.SubLogger) (control.BuildxController, error) {
+func NewRemoteBuildxController(ctx context.Context, dockerCli command.Cli, opts control.ControlOptions, logger progress.SubLogger, mp metric.MeterProvider) (control.BuildxController, error) {
 	return nil, errors.New("remote buildx unsupported")
 }
 

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v0.42.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v0.42.0
 	go.opentelemetry.io/otel/metric v1.19.0
+	go.opentelemetry.io/otel/sdk v1.19.0
 	go.opentelemetry.io/otel/sdk/metric v1.19.0
 	go.opentelemetry.io/otel/trace v1.19.0
 	golang.org/x/mod v0.13.0
@@ -147,7 +148,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.19.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.19.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.42.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.19.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	golang.org/x/crypto v0.17.0 // indirect
 	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1 // indirect

--- a/otel/sdk/metric/otlp.go
+++ b/otel/sdk/metric/otlp.go
@@ -1,4 +1,4 @@
-package metrics
+package metric
 
 import (
 	"context"
@@ -35,13 +35,9 @@ func detectOtlpExporter(ctx context.Context) (sdkmetric.Exporter, error) {
 
 	switch proto {
 	case "grpc":
-		return otlpmetricgrpc.New(ctx,
-			otlpmetricgrpc.WithTemporalitySelector(deltaTemporality),
-		)
+		return otlpmetricgrpc.New(ctx)
 	case "http/protobuf":
-		return otlpmetrichttp.New(ctx,
-			otlpmetrichttp.WithTemporalitySelector(deltaTemporality),
-		)
+		return otlpmetrichttp.New(ctx)
 	// case "http/json": // unsupported by library
 	default:
 		return nil, errors.Errorf("unsupported otlp protocol %v", proto)

--- a/otel/sdk/metric/resource.go
+++ b/otel/sdk/metric/resource.go
@@ -1,0 +1,50 @@
+package metric
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
+)
+
+var (
+	res     *resource.Resource
+	resOnce sync.Once
+)
+
+// Resource retrieves the OTEL resource for the buildx CLI.
+func Resource() *resource.Resource {
+	resOnce.Do(func() {
+		var err error
+		res, err = resource.New(context.Background(),
+			resource.WithDetectors(serviceNameDetector{}),
+			resource.WithAttributes(
+				attribute.Stringer("service.instance.id", uuid.New()),
+			),
+			resource.WithFromEnv(),
+			resource.WithTelemetrySDK(),
+		)
+		if err != nil {
+			otel.Handle(err)
+		}
+	})
+	return res
+}
+
+type serviceNameDetector struct{}
+
+func (serviceNameDetector) Detect(ctx context.Context) (*resource.Resource, error) {
+	return resource.StringDetector(
+		semconv.SchemaURL,
+		semconv.ServiceNameKey,
+		func() (string, error) {
+			return filepath.Base(os.Args[0]), nil
+		},
+	).Detect(ctx)
+}

--- a/util/confutil/exp.go
+++ b/util/confutil/exp.go
@@ -1,0 +1,15 @@
+package confutil
+
+import (
+	"os"
+	"strconv"
+)
+
+// IsExperimental checks if the experimental flag has been configured.
+func IsExperimental() bool {
+	if v, ok := os.LookupEnv("BUILDX_EXPERIMENTAL"); ok {
+		vv, _ := strconv.ParseBool(v)
+		return vv
+	}
+	return false
+}

--- a/util/progress/metricwriter.go
+++ b/util/progress/metricwriter.go
@@ -1,0 +1,101 @@
+package progress
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	sdkmetric "github.com/docker/buildx/otel/sdk/metric"
+	"github.com/moby/buildkit/client"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+type (
+	buildStatus int
+)
+
+const (
+	buildStatusComplete buildStatus = iota
+	buildStatusCanceled
+	buildStatusError
+)
+
+type RecordFunc func(ctx context.Context)
+
+type metricWriter struct {
+	Writer
+	meter  metric.Meter
+	opts   []metric.MeasurementOption
+	status buildStatus
+	start  time.Time
+}
+
+func Metrics(mp metric.MeterProvider, pw Writer, opts ...metric.MeasurementOption) (Writer, RecordFunc) {
+	mw := &metricWriter{
+		Writer: pw,
+		meter:  sdkmetric.Meter(mp),
+		opts:   opts,
+		status: buildStatusComplete,
+		start:  time.Now(),
+	}
+	return mw, mw.Record
+}
+
+func (mw *metricWriter) Write(ss *client.SolveStatus) {
+	mw.write(ss)
+	mw.Writer.Write(ss)
+}
+
+func (mw *metricWriter) write(ss *client.SolveStatus) {
+	for _, v := range ss.Vertexes {
+		if v.Error != "" {
+			newBuildStatus := buildStatusError
+			if strings.HasSuffix(v.Error, context.Canceled.Error()) {
+				newBuildStatus = buildStatusCanceled
+			}
+
+			if mw.status < newBuildStatus {
+				mw.status = newBuildStatus
+			}
+		}
+	}
+}
+
+func (mw *metricWriter) Record(ctx context.Context) {
+	mw.record(ctx)
+}
+
+func (mw *metricWriter) record(ctx context.Context) {
+	buildDuration, _ := mw.meter.Int64Counter("build.duration",
+		metric.WithDescription("Measures the total build duration."),
+		metric.WithUnit("ms"))
+
+	totalDur := time.Since(mw.start)
+	opts := toAddOptions(mw.opts,
+		metric.WithAttributes(mw.statusAttribute()),
+	)
+	buildDuration.Add(ctx, int64(totalDur/time.Millisecond), opts...)
+}
+
+func (mw *metricWriter) statusAttribute() attribute.KeyValue {
+	status := "unknown"
+	switch mw.status {
+	case buildStatusComplete:
+		status = "completed"
+	case buildStatusCanceled:
+		status = "canceled"
+	case buildStatusError:
+		status = "error"
+	}
+	return attribute.String("status", status)
+}
+
+func toAddOptions(opts []metric.MeasurementOption, extraOpts ...metric.AddOption) []metric.AddOption {
+	newOpts := make([]metric.AddOption, 0, len(opts)+len(extraOpts))
+	for _, opt := range opts {
+		newOpts = append(newOpts, opt)
+	}
+	newOpts = append(newOpts, extraOpts...)
+	return newOpts
+}


### PR DESCRIPTION
This adds a build duration metric with attributes related to the build
id, build ref, driver name, and the resulting status of the build.

This also modifies some aspects of how the resource is configured by
including `service.instance.id`. This id is used to uniquely identify
the CLI invocation for use in downstream aggregators. This allows
downstream aggregators to know that the metric for an instance has not
reset and that it is a unique invocation for future aggregation. Some
work will have to be done in the aggregator to prevent the storage of
this instance id as it can cause issues with cardinality limitations,
but it's necessary for the initial reporter to include this.

The temporality selector is still the same, but has been removed from
the otlp exporter options since that one doesn't seem to do anything.  I
also recently learned the temporality didn't do what I thought it did.
I thought it would allow for multiple different invocations to be
treated as the same instance for the purposes of aggregation. It does
not work this way as the metric sdk considers each of these a gap reset.
That's the reason the instance id was added. This makes the difference
between cumulative and delta mostly cosmetic, but delta temporality has
some benefits for downstream consumers for aggregation so it's likely
good to keep.

The cli count has been removed as it doesn't contain anything new and
wasn't a useful metric. The naming of metrics has also been changed from
using `docker` as a prefix and instead relying on the instrumentation
name.