### PR TITLE
driver: only initialize the client once in the docker and remote drivers

### DIFF
--- a/util/syncutil/once_value.go
+++ b/util/syncutil/once_value.go
@@ -1,0 +1,16 @@
+package syncutil
+
+import "sync"
+
+type OnceValue[T any] struct {
+	once  sync.Once
+	value T
+	err   error
+}
+
+func (o *OnceValue[T1]) Do(fn func() (T1, error)) (T1, error) {
+	o.once.Do(func() {
+		o.value, o.err = fn()
+	})
+	return o.value, o.err
+}


### PR DESCRIPTION
The docker and remote drivers both use the client internally and
therefore re-initialize the client multiple times within themselves. We
do some work to ensure the client is only initialized once through the
driver handle, but these drivers end up initializing the client multiple
times erroneously.

This updates these drivers to have their own caching code for the client
to prevent reinitialization which also has the side effect of fixing a
bug where traces were duplicated and sent multiple times.