### PR TITLE
[v0.12 backport] ci: use public bot account to push bin image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,8 +225,8 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERPUBLICBOT_USERNAME }}
+          password: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
       -
         name: Build and push image
         uses: docker/bake-action@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,7 +225,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERPUBLICBOT_USERNAME }}
+          username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
           password: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
       -
         name: Build and push image


### PR DESCRIPTION
backport of
* https://github.com/docker/buildx/pull/2157
* https://github.com/docker/buildx/pull/2162

related to https://github.com/docker/buildx/actions/runs/7497002480/job/20410354310#step:6:36

![image](https://github.com/docker/buildx/assets/1951866/f50891e4-80e7-4a70-a79d-7fface655774)

bin-image was not published for 0.12.1, we forgot to backport these changes to v0.12 branch :see_no_evil: