### PR TITLE
[v0.12 backport] update to go1.21.6

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,7 +13,7 @@ permissions:
   security-events: write
 
 env:
-  GO_VERSION: 1.21.3
+  GO_VERSION: 1.21.6
 
 jobs:
   codeql:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.21.3
+ARG GO_VERSION=1.21.6
 ARG XX_VERSION=1.2.1
 
 ARG DOCKER_VERSION=24.0.6

--- a/hack/dockerfiles/docs.Dockerfile
+++ b/hack/dockerfiles/docs.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.21.3
+ARG GO_VERSION=1.21.6
 ARG FORMATS=md,yaml
 
 FROM golang:${GO_VERSION}-alpine AS docsgen

--- a/hack/dockerfiles/generated-files.Dockerfile
+++ b/hack/dockerfiles/generated-files.Dockerfile
@@ -5,7 +5,7 @@
 # Copyright The Buildx Authors.
 # Licensed under the Apache License, Version 2.0
 
-ARG GO_VERSION="1.21.3"
+ARG GO_VERSION="1.21.6"
 ARG PROTOC_VERSION="3.11.4"
 
 # protoc is dynamically linked to glibc so can't use alpine base

--- a/hack/dockerfiles/lint.Dockerfile
+++ b/hack/dockerfiles/lint.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.21.3
+ARG GO_VERSION=1.21.6
 ARG GOLANGCI_LINT_VERSION=1.54.2
 
 FROM golang:${GO_VERSION}-alpine

--- a/hack/dockerfiles/vendor.Dockerfile
+++ b/hack/dockerfiles/vendor.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.21.3
+ARG GO_VERSION=1.21.6
 ARG MODOUTDATED_VERSION=v0.8.0
 
 FROM golang:${GO_VERSION}-alpine AS base


### PR DESCRIPTION
- backport https://github.com/docker/buildx/pull/2190

(cherry picked from commit 61dff684adbf8d0e33008994a52ebcfa7a256ff6)