### PR TITLE
Add support for DSSE envelope for attestation in imagetools

### DIFF
--- a/util/imagetools/loader.go
+++ b/util/imagetools/loader.go
@@ -23,7 +23,11 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-const inTotoGenericMime = "application/vnd.in-toto+json"
+const (
+	inTotoGenericMime        = "application/vnd.in-toto+json"
+	inTotoSPDXDSSEMime       = "application/vnd.in-toto.spdx+dsse"
+	inTotoProvenanceDSSEMime = "application/vnd.in-toto.provenance+dsse"
+)
 
 var (
 	annotationReferences = []string{
@@ -278,7 +282,7 @@ type sbomStub struct {
 }
 
 func (l *loader) scanSBOM(ctx context.Context, fetcher remotes.Fetcher, r *result, refs []digest.Digest, as *asset) error {
-	ctx = remotes.WithMediaTypeKeyPrefix(ctx, inTotoGenericMime, "intoto")
+	ctx = withIntotoMediaTypes(ctx)
 	as.deferredSbom = func() (*sbomStub, error) {
 		var sbom *sbomStub
 		for _, dgst := range refs {
@@ -329,7 +333,7 @@ type provenanceStub struct {
 }
 
 func (l *loader) scanProvenance(ctx context.Context, fetcher remotes.Fetcher, r *result, refs []digest.Digest, as *asset) error {
-	ctx = remotes.WithMediaTypeKeyPrefix(ctx, inTotoGenericMime, "intoto")
+	ctx = withIntotoMediaTypes(ctx)
 	as.deferredProvenance = func() (*provenanceStub, error) {
 		var provenance *provenanceStub
 		for _, dgst := range refs {
@@ -458,4 +462,11 @@ func decodeDSSE(dt []byte, mime string) ([]byte, error) {
 	}
 
 	return dt, nil
+}
+
+func withIntotoMediaTypes(ctx context.Context) context.Context {
+	for _, mime := range []string{inTotoGenericMime, inTotoSPDXDSSEMime, inTotoProvenanceDSSEMime} {
+		ctx = remotes.WithMediaTypeKeyPrefix(ctx, mime, "intoto")
+	}
+	return ctx
 }


### PR DESCRIPTION
When running `docker buildx imagetools inspect --format '{{ JSON .SBOM }}` and the attestations use the `application/vnd.in-toto+json` mime type, the In-TOTO predicate is returned. However, then the attestation are wrapped in a DSSE envelope using the `application/vnd.in-toto.spdx+dsse` mime type, the same command returns and empty object (`{}`).

The changes add support for the DSSE mime type and base64 decode the envelope and returnb the payload object to stay consistent with images that do not use a wraper.