### PR TITLE
build: resolve 8.3 filename format to long one on Windows

### DIFF
--- a/build/git_unix.go
+++ b/build/git_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+// +build !windows
+
+package build
+
+// getLongPathName is a no-op on non-Windows platforms.
+func getLongPathName(path string) (string, error) {
+	return path, nil
+}

--- a/build/git_windows.go
+++ b/build/git_windows.go
@@ -1,0 +1,26 @@
+package build
+
+import "golang.org/x/sys/windows"
+
+// getLongPathName converts Windows short pathnames to full pathnames.
+// For example C:\Users\ADMIN~1 --> C:\Users\Administrator.
+func getLongPathName(path string) (string, error) {
+	// See https://groups.google.com/forum/#!topic/golang-dev/1tufzkruoTg
+	p, err := windows.UTF16FromString(path)
+	if err != nil {
+		return "", err
+	}
+	b := p // GetLongPathName says we can reuse buffer
+	n, err := windows.GetLongPathName(&p[0], &b[0], uint32(len(b)))
+	if err != nil {
+		return "", err
+	}
+	if n > uint32(len(b)) {
+		b = make([]uint16, n)
+		_, err = windows.GetLongPathName(&p[0], &b[0], uint32(len(b)))
+		if err != nil {
+			return "", err
+		}
+	}
+	return windows.UTF16ToString(b), nil
+}

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.19.0
 	golang.org/x/mod v0.11.0
 	golang.org/x/sync v0.3.0
+	golang.org/x/sys v0.15.0
 	golang.org/x/term v0.15.0
 	google.golang.org/grpc v1.58.3
 	gopkg.in/yaml.v3 v3.0.1
@@ -152,7 +153,6 @@ require (
 	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/oauth2 v0.10.0 // indirect
-	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/tools v0.10.0 // indirect

--- a/util/gitutil/gitutil.go
+++ b/util/gitutil/gitutil.go
@@ -70,7 +70,7 @@ func (c *Git) RootDir() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return sanitizePath(root), nil
+	return SanitizePath(root), nil
 }
 
 func (c *Git) GitDir() (string, error) {

--- a/util/gitutil/path.go
+++ b/util/gitutil/path.go
@@ -45,7 +45,7 @@ func gitPath(wd string) (string, error) {
 
 var windowsPathRegex = regexp.MustCompile(`^[A-Za-z]:[\\/].*$`)
 
-func sanitizePath(path string) string {
+func SanitizePath(path string) string {
 	// If we're running in WSL, we need to convert Windows paths to Unix paths.
 	// This is because the git binary can be invoked through `git.exe` and
 	// therefore returns Windows paths.

--- a/util/gitutil/path_unix_test.go
+++ b/util/gitutil/path_unix_test.go
@@ -10,10 +10,10 @@ import (
 )
 
 func TestSanitizePathUnix(t *testing.T) {
-	assert.Equal(t, "/home/foobar", sanitizePath("/home/foobar"))
+	assert.Equal(t, "/home/foobar", SanitizePath("/home/foobar"))
 }
 
 func TestSanitizePathWSL(t *testing.T) {
 	t.Setenv("WSL_DISTRO_NAME", "Ubuntu")
-	assert.Equal(t, "/mnt/c/Users/foobar", sanitizePath("C:\\Users\\foobar"))
+	assert.Equal(t, "/mnt/c/Users/foobar", SanitizePath("C:\\Users\\foobar"))
 }

--- a/util/gitutil/path_windows.go
+++ b/util/gitutil/path_windows.go
@@ -9,6 +9,6 @@ func gitPath(wd string) (string, error) {
 	return exec.LookPath("git.exe")
 }
 
-func sanitizePath(path string) string {
+func SanitizePath(path string) string {
 	return filepath.ToSlash(filepath.Clean(path))
 }

--- a/util/gitutil/path_windows_test.go
+++ b/util/gitutil/path_windows_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestSanitizePathWindows(t *testing.T) {
-	assert.Equal(t, "C:\\Users\\foobar", sanitizePath("C:/Users/foobar"))
+	assert.Equal(t, "C:\\Users\\foobar", SanitizePath("C:/Users/foobar"))
 }


### PR DESCRIPTION
related to https://github.com/docker/buildx/pull/2206#issuecomment-1910309373

Converts Windows short pathnames to full pathnames (e.g. `C:\Users\ADMIN~1 --> C:\Users\Administrator`) so `vcs:localdir:*` and `com.docker.image.source.entrypoint` attrs are set in this case, otherwise: https://github.com/docker/buildx/actions/runs/7640538748/job/20815891223#step:5:419

Logic is taken from moby: https://github.com/moby/moby/blob/e8346c53d93d2cddf3d09910e166cdd8874070b3/integration-cli/utils_windows_test.go#L5-L27