### PR TITLE
bump actions/upload-artifact and actions/download-artifact to 4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,10 @@ jobs:
           - ./tests
     steps:
       -
+        name: Prepare
+        run: |
+          echo "TESTREPORTS_NAME=${{ github.job }}-$(echo "${{ matrix.pkg }}-${{ matrix.worker }}" | tr -dc '[:alnum:]-\n\r' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+      -
         name: Checkout
         uses: actions/checkout@v4
         with:
@@ -100,9 +104,9 @@ jobs:
       -
         name: Test
         run: |
-          export TEST_REPORT_SUFFIX=-${{ github.job }}-$(echo "${{ matrix.pkg }}-${{ matrix.worker }}" | tr -dc '[:alnum:]-\n\r' | tr '[:upper:]' '[:lower:]')
           ./hack/test
         env:
+          TEST_REPORT_SUFFIX: "-${{ env.TESTREPORTS_NAME }}"
           TEST_DOCKERD: "${{ startsWith(matrix.worker, 'docker') && '1' || '0' }}"
           TESTFLAGS: "${{ (matrix.worker == 'docker' || matrix.worker == 'docker\\+containerd') && env.TESTFLAGS_DOCKER || env.TESTFLAGS }} --run=//worker=${{ matrix.worker }}$"
           TESTPKGS: "${{ matrix.pkg }}"
@@ -122,9 +126,9 @@ jobs:
       -
         name: Upload test reports
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: test-reports
+          name: test-reports-${{ env.TESTREPORTS_NAME }}
           path: ./bin/testreports
 
   test-unit:
@@ -150,8 +154,10 @@ jobs:
       -
         name: Prepare
         run: |
+          testreportsName=${{ github.job }}--${{ matrix.os }}
           testreportsBaseDir=./bin/testreports
-          testreportsDir=$testreportsBaseDir/unit-${{ matrix.os }}
+          testreportsDir=$testreportsBaseDir/$testreportsName
+          echo "TESTREPORTS_NAME=$testreportsName" >> $GITHUB_ENV
           echo "TESTREPORTS_BASEDIR=$testreportsBaseDir" >> $GITHUB_ENV
           echo "TESTREPORTS_DIR=$testreportsDir" >> $GITHUB_ENV
           mkdir -p $testreportsDir
@@ -191,9 +197,9 @@ jobs:
       -
         name: Upload test reports
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: test-reports
+          name: test-reports-${{ env.TESTREPORTS_NAME }}
           path: ${{ env.TESTREPORTS_BASEDIR }}
 
   prepare-binaries:
@@ -251,9 +257,9 @@ jobs:
           CACHE_TO: type=gha,scope=binaries-${{ env.PLATFORM_PAIR }},mode=max
       -
         name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: buildx
+          name: buildx-${{ env.PLATFORM_PAIR }}
           path: ${{ env.DESTDIR }}/*
           if-no-files-found: error
 
@@ -322,10 +328,11 @@ jobs:
         uses: actions/checkout@v4
       -
         name: Download binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: buildx
           path: ${{ env.DESTDIR }}
+          pattern: buildx-*
+          merge-multiple: true
       -
         name: Create checksums
         run: ./hack/hash-files

--- a/.github/workflows/docs-upstream.yml
+++ b/.github/workflows/docs-upstream.yml
@@ -45,7 +45,7 @@ jobs:
           DOCS_FORMATS: yaml
       -
         name: Upload reference YAML docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docs-yaml
           path: /tmp/buildx-docs/out/reference

--- a/.github/workflows/docs-upstream.yml
+++ b/.github/workflows/docs-upstream.yml
@@ -52,7 +52,7 @@ jobs:
           retention-days: 1
 
   validate:
-    uses: docker/docs/.github/workflows/validate-upstream.yml@main
+    uses: docker/docs/.github/workflows/validate-upstream.yml@919a9b9104a34a40b30d116529bcce589a544d1c  # pin for artifact v4 support: https://github.com/docker/docs/pull/19220
     needs:
       - docs-yaml
     with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -46,7 +46,7 @@ jobs:
           mv ${{ env.DESTDIR }}/build/buildx ${{ env.DESTDIR }}/build/docker-buildx
       -
         name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: binary
           path: ${{ env.DESTDIR }}/build
@@ -103,7 +103,7 @@ jobs:
         if: matrix.driver == 'docker' || matrix.driver == 'docker-container'
       -
         name: Install buildx
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: binary
           path: /home/runner/.docker/cli-plugins


### PR DESCRIPTION
Related to:

![image](https://github.com/docker/buildx/assets/1951866/7e8bf06d-d1da-41b8-9b46-1a5dbb9ebd79)

Previous PRs to bump to v4 were closed (https://github.com/docker/buildx/pull/2163) because there was no support for merging multiple files from a matrix but this has been fixed since then: https://github.com/actions/upload-artifact/issues/472#issuecomment-1861571655