### PR TITLE
bump gotest-annotations to fa6141aedf23596fb8bdcceab9cce8dadaa31bd9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
       -
         name: Generate annotations
         if: always()
-        uses: crazy-max/.github/.github/actions/gotest-annotations@1a64ea6d01db9a48aa61954cb20e265782c167d9
+        uses: crazy-max/.github/.github/actions/gotest-annotations@fa6141aedf23596fb8bdcceab9cce8dadaa31bd9
         with:
           directory: ./bin/testreports
       -
@@ -191,7 +191,7 @@ jobs:
       -
         name: Generate annotations
         if: always()
-        uses: crazy-max/.github/.github/actions/gotest-annotations@1a64ea6d01db9a48aa61954cb20e265782c167d9
+        uses: crazy-max/.github/.github/actions/gotest-annotations@fa6141aedf23596fb8bdcceab9cce8dadaa31bd9
         with:
           directory: ${{ env.TESTREPORTS_DIR }}
       -


### PR DESCRIPTION
related to:

![image](https://github.com/docker/buildx/assets/1951866/7a6361b1-2ef2-428e-9979-b8ea462c19d5)

full diff: https://github.com/crazy-max/.github/compare/1a64ea6d01db9a48aa61954cb20e265782c167d9...fa6141aedf23596fb8bdcceab9cce8dadaa31bd9