### PR TITLE
[v0.12] ci(docs-upstream): pin reusable workflow

### DIFF
--- a/.github/workflows/docs-upstream.yml
+++ b/.github/workflows/docs-upstream.yml
@@ -52,7 +52,7 @@ jobs:
           retention-days: 1
 
   validate:
-    uses: docker/docs/.github/workflows/validate-upstream.yml@main
+    uses: docker/docs/.github/workflows/validate-upstream.yml@e864c797e391fa35aecf1ddcecdbdeb683546424  # pin for artifact v3 support
     needs:
       - docs-yaml
     with:


### PR DESCRIPTION
follow-up https://github.com/docker/buildx/pull/2210#issuecomment-1911663381
related to https://github.com/docker/docs/pull/19220

need to pin docs validate upstream workflow to a commit with artifact v3 support as this is not backward compat with v4 from main.