### PR TITLE
otel: create utility for storing common attributes for build options

### DIFF
--- a/build/git.go
+++ b/build/git.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/docker/buildx/util/gitutil"
+	"github.com/docker/buildx/util/osutil"
 	"github.com/moby/buildkit/client"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -46,7 +47,7 @@ func getGitAttributes(ctx context.Context, contextPath string, dockerfilePath st
 	if filepath.IsAbs(contextPath) {
 		wd = contextPath
 	} else {
-		wd, _ = filepath.Abs(filepath.Join(getWd(), contextPath))
+		wd, _ = filepath.Abs(filepath.Join(osutil.GetWd(), contextPath))
 	}
 	wd = gitutil.SanitizePath(wd)
 
@@ -104,7 +105,7 @@ func getGitAttributes(ctx context.Context, contextPath string, dockerfilePath st
 			dockerfilePath = filepath.Join(wd, "Dockerfile")
 		}
 		if !filepath.IsAbs(dockerfilePath) {
-			dockerfilePath = filepath.Join(getWd(), dockerfilePath)
+			dockerfilePath = filepath.Join(osutil.GetWd(), dockerfilePath)
 		}
 		if r, err := filepath.Rel(root, dockerfilePath); err == nil && !strings.HasPrefix(r, "..") {
 			res["label:"+DockerfileLabel] = r
@@ -124,7 +125,7 @@ func getGitAttributes(ctx context.Context, contextPath string, dockerfilePath st
 			if err != nil {
 				continue
 			}
-			if lp, err := getLongPathName(dir); err == nil {
+			if lp, err := osutil.GetLongPathName(dir); err == nil {
 				dir = lp
 			}
 			dir = gitutil.SanitizePath(dir)
@@ -133,12 +134,4 @@ func getGitAttributes(ctx context.Context, contextPath string, dockerfilePath st
 			}
 		}
 	}, nil
-}
-
-func getWd() string {
-	wd, _ := os.Getwd()
-	if lp, err := getLongPathName(wd); err == nil {
-		return lp
-	}
-	return wd
 }

--- a/build/git_unix.go
+++ b/build/git_unix.go
@@ -1,9 +1,0 @@
-//go:build !windows
-// +build !windows
-
-package build
-
-// getLongPathName is a no-op on non-Windows platforms.
-func getLongPathName(path string) (string, error) {
-	return path, nil
-}

--- a/util/metricutil/resource_test.go
+++ b/util/metricutil/resource_test.go
@@ -1,0 +1,33 @@
+package metricutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel"
+)
+
+func TestResource(t *testing.T) {
+	setErrorHandler(t)
+
+	// Ensure resource creation doesn't result in an error.
+	// This is because the schema urls for the various attributes need to be
+	// the same, but it's really easy to import the wrong package when upgrading
+	// otel to anew version and the buildx CLI swallows any visible errors.
+	res := Resource()
+
+	// Ensure an attribute is present.
+	assert.True(t, res.Set().HasValue("telemetry.sdk.version"), "resource attribute missing")
+}
+
+func setErrorHandler(tb testing.TB) {
+	tb.Helper()
+
+	errorHandler := otel.GetErrorHandler()
+	otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
+		tb.Errorf("otel error: %s", err)
+	}))
+	tb.Cleanup(func() {
+		otel.SetErrorHandler(errorHandler)
+	})
+}

--- a/util/osutil/path.go
+++ b/util/osutil/path.go
@@ -1,0 +1,15 @@
+package osutil
+
+import "os"
+
+// GetWd retrieves the current working directory.
+//
+// On Windows, this function will return the long path name
+// version of the path.
+func GetWd() string {
+	wd, _ := os.Getwd()
+	if lp, err := GetLongPathName(wd); err == nil {
+		return lp
+	}
+	return wd
+}

--- a/util/osutil/path_unix.go
+++ b/util/osutil/path_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+// +build !windows
+
+package osutil
+
+// GetLongPathName is a no-op on non-Windows platforms.
+func GetLongPathName(path string) (string, error) {
+	return path, nil
+}

--- a/util/osutil/path_windows.go
+++ b/util/osutil/path_windows.go
@@ -1,10 +1,10 @@
-package build
+package osutil
 
 import "golang.org/x/sys/windows"
 
-// getLongPathName converts Windows short pathnames to full pathnames.
+// GetLongPathName converts Windows short pathnames to full pathnames.
 // For example C:\Users\ADMIN~1 --> C:\Users\Administrator.
-func getLongPathName(path string) (string, error) {
+func GetLongPathName(path string) (string, error) {
 	// See https://groups.google.com/forum/#!topic/golang-dev/1tufzkruoTg
 	p, err := windows.UTF16FromString(path)
 	if err != nil {


### PR DESCRIPTION
Adds a method to include common attributes for build related options
when tracking build invocations. These attributes use certain parameters
to the build command.

This also refactors some of the utility methods used by the git tool to
determine filepaths into its own separate package so they can be reused
in another place.

Also adds a test to ensure the resource is initialized correctly and
doesn't error. The otel handler logging message is suppressed on buildx
invocations so we never see the error if there's a problem with the
schema url. It's so easy to mess up the schema url when upgrading OTEL
that we need a proper test to make sure we haven't broken the
functionality.