### PR TITLE
ci: bump codecov/codecov-action to 4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,7 @@ jobs:
       -
         name: Send to Codecov
         if: always()
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           directory: ./bin/testreports
           flags: integration
@@ -183,7 +183,7 @@ jobs:
       -
         name: Send to Codecov
         if: always()
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           directory: ${{ env.TESTREPORTS_DIR }}
           env_vars: RUNNER_OS


### PR DESCRIPTION
related to https://github.com/docker/buildx/actions/runs/7784740901

![image](https://github.com/docker/buildx/assets/1951866/ee90f856-5b52-433e-ae08-ed820041ce50)

Not sure why this one was left behind by dependabot :thinking: