### PR TITLE
driver: add npipe url scheme support

### DIFF
--- a/driver/remote/util/endpoint.go
+++ b/driver/remote/util/endpoint.go
@@ -12,6 +12,7 @@ var schemes = map[string]struct{}{
 	"ssh":              {},
 	"docker-container": {},
 	"kube-pod":         {},
+	"npipe":            {},
 }
 
 func IsValidEndpoint(ep string) error {


### PR DESCRIPTION
Buildkit on windows exposes an npipe endpoint (`npipe:////./pipe/buildkitd`) which can be used to create a remote builder for WCOW.

Testing this with a simple docker file gives the result below:

![image](https://github.com/docker/buildx/assets/50120072/b6bf7f70-94fb-4291-abee-d22c94ceea51)


