### PR TITLE
don't print build details when progress is rawjson

### DIFF
--- a/commands/bake.go
+++ b/commands/bake.go
@@ -138,7 +138,7 @@ func runBake(ctx context.Context, dockerCli command.Cli, targets []string, in ba
 			if err == nil {
 				err = err1
 			}
-			if err == nil && progressMode != progressui.QuietMode {
+			if err == nil && progressMode != progressui.QuietMode && progressMode != progressui.RawJSONMode {
 				desktop.PrintBuildDetails(os.Stderr, printer.BuildRefs(), term)
 			}
 		}

--- a/commands/build.go
+++ b/commands/build.go
@@ -294,10 +294,13 @@ func runBuild(ctx context.Context, dockerCli command.Cli, options buildOptions) 
 		return retErr
 	}
 
-	if progressMode != progressui.QuietMode {
-		desktop.PrintBuildDetails(os.Stderr, printer.BuildRefs(), term)
-	} else {
+	switch progressMode {
+	case progressui.RawJSONMode:
+		// no additional display
+	case progressui.QuietMode:
 		fmt.Println(getImageID(resp.ExporterResponse))
+	default:
+		desktop.PrintBuildDetails(os.Stderr, printer.BuildRefs(), term)
 	}
 	if options.imageIDFile != "" {
 		if err := os.WriteFile(options.imageIDFile, []byte(getImageID(resp.ExporterResponse)), 0644); err != nil {
@@ -753,7 +756,7 @@ func dockerUlimitToControllerUlimit(u *dockeropts.UlimitOpt) *controllerapi.Ulim
 }
 
 func printWarnings(w io.Writer, warnings []client.VertexWarning, mode progressui.DisplayMode) {
-	if len(warnings) == 0 || mode == progressui.QuietMode {
+	if len(warnings) == 0 || mode == progressui.QuietMode || mode == progressui.RawJSONMode {
 		return
 	}
 	fmt.Fprintf(w, "\n ")


### PR DESCRIPTION
when a build is ran using `--progress=rawjson` output should only contain line-delimited json stream
`PrintBuildDetails` to display an additional human-readable message at the end of the build breaks parsing this stream

Another option would be to use stdout for json and stderr for such messages