### PR TITLE
metricutil: remove BUILDX_EXPERIMENTAL from internal docker reporting

### DIFF
--- a/util/metricutil/metric.go
+++ b/util/metricutil/metric.go
@@ -37,14 +37,14 @@ type MeterProvider struct {
 func NewMeterProvider(ctx context.Context, cli command.Cli) (*MeterProvider, error) {
 	var exps []sdkmetric.Exporter
 
-	// Only metric exporters if the experimental flag is set.
-	if confutil.IsExperimental() {
-		if exp, err := dockerOtelExporter(cli); err != nil {
-			return nil, err
-		} else if exp != nil {
-			exps = append(exps, exp)
-		}
+	if exp, err := dockerOtelExporter(cli); err != nil {
+		return nil, err
+	} else if exp != nil {
+		exps = append(exps, exp)
+	}
 
+	if confutil.IsExperimental() {
+		// Expose the user-facing metric exporter only if the experimental flag is set.
 		if exp, err := detectOtlpExporter(ctx); err != nil {
 			return nil, err
 		} else if exp != nil {


### PR DESCRIPTION
The `BUILDX_EXPERIMENTAL` check is removed from the docker otel
collector. We'll send metrics to the OTLP endpoint for docker desktop if
it is present and enabled regardless of experimental status.

The user-facing `OTEL` endpoints for enabling the metric reporting for
external use is still hidden behind the experimental flag. We'll likely
remove the experimental flag for this feature for v0.14.