### PR TITLE
build: set build ref in response

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -786,6 +786,7 @@ func BuildWithResultHandler(ctx context.Context, nodes []builder.Node, opt map[s
 
 						return res, nil
 					}
+					buildRef := fmt.Sprintf("%s/%s/%s", node.Builder, node.Name, so.Ref)
 					var rr *client.SolveResponse
 					if resultHandleFunc != nil {
 						var resultHandle *ResultHandle
@@ -795,7 +796,6 @@ func BuildWithResultHandler(ctx context.Context, nodes []builder.Node, opt map[s
 						rr, err = c.Build(ctx, *so, "buildx", buildFunc, ch)
 					}
 					if desktop.BuildBackendEnabled() && node.Driver.HistoryAPISupported(ctx) {
-						buildRef := fmt.Sprintf("%s/%s/%s", node.Builder, node.Name, so.Ref)
 						if err != nil {
 							return &desktop.ErrorWithBuildRef{
 								Ref: buildRef,
@@ -815,6 +815,7 @@ func BuildWithResultHandler(ctx context.Context, nodes []builder.Node, opt map[s
 					for k, v := range printRes {
 						rr.ExporterResponse[k] = string(v)
 					}
+					rr.ExporterResponse["buildx.build.ref"] = buildRef
 
 					node := dp.Node().Driver
 					if node.IsMobyDriver() {

--- a/docs/reference/buildx_build.md
+++ b/docs/reference/buildx_build.md
@@ -327,6 +327,7 @@ $ cat metadata.json
 
 ```json
 {
+  "buildx.build.ref": "mybuilder/mybuilder0/0fjb6ubs52xx3vygf6fgdl611",
   "containerimage.config.digest": "sha256:2937f66a9722f7f4a2df583de2f8cb97fc9196059a410e7f00072fc918930e66",
   "containerimage.descriptor": {
     "annotations": {


### PR DESCRIPTION
Sets `buildx.build.ref` in the metadata file.

```
$ docker buildx build . --metadata-file md.json
...
$ cat md.json
{
  "buildx.build.ref": "default/default/0fjb6ubs52xx3vygf6fgdl611",
  "containerimage.config.digest": "sha256:9651cc2b3c508f697c9c43b67b64c8359c2865c019e680aac1c11f4b875b67e0",
  "containerimage.digest": "sha256:9651cc2b3c508f697c9c43b67b64c8359c2865c019e680aac1c11f4b875b67e0"
}
```

```
$ docker buildx bake validate --metadata-file md.json
...
$ cat md.json
{
  "lint": {
    "buildx.build.ref": "default/default/kamngmcgyzebqxwu98b4lfv3n"
  },
  "validate-docs": {
    "buildx.build.ref": "default/default/w1spi3ss9vnatnkznc4fw0btd"
  },
  "validate-vendor": {
    "buildx.build.ref": "default/default/lc2ohlly0xkvop06y81fzyiag"
  }
}
```