### PR TITLE
bake: avoid evaluating parent targets before child LLB loaded

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -759,6 +759,11 @@ func BuildWithResultHandler(ctx context.Context, nodes []builder.Node, opt map[s
 						results.Set(rKey, res)
 
 						if children, ok := childTargets[rKey]; ok && len(children) > 0 {
+							// wait for the child targets to register their LLB before evaluating
+							_, err := results.Get(ctx, children...)
+							if err != nil {
+								return nil, err
+							}
 							// we need to wait until the child targets have completed before we can release
 							eg, ctx := errgroup.WithContext(ctx)
 							eg.Go(func() error {


### PR DESCRIPTION
Because of the way buildkit cache works if you have request with external cache, if some vertices from the request have already been evaluated and are available in the shared graph BuildKit will not load cache keys from external source for such vertices. This may mean that children of such vertices will not load cache because there isn't a cache path through the parent.

To work around it, wait before child definition is loaded before evaluating the parent.

fix #2144