### PR TITLE
driver: make buildkitd "config" and "flags" names consistent

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -255,7 +255,7 @@ func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt Op
 	supportsAttestations := bopts.LLBCaps.Contains(apicaps.CapID("exporter.image.attestations")) && nodeDriver.Features(ctx)[driver.MultiPlatform]
 	if len(attests) > 0 {
 		if !supportsAttestations {
-			return nil, nil, errors.Errorf("attestations are not supported by the current buildkitd")
+			return nil, nil, errors.Errorf("attestations are not supported by the current BuildKit daemon")
 		}
 		for k, v := range attests {
 			so.FrontendAttrs["attest:"+k] = v

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -332,16 +332,16 @@ func GetBuilders(dockerCli command.Cli, txn *store.Txn) ([]*Builder, error) {
 }
 
 type CreateOpts struct {
-	Name       string
-	Driver     string
-	NodeName   string
-	Platforms  []string
-	Flags      string
-	ConfigFile string
-	DriverOpts []string
-	Use        bool
-	Endpoint   string
-	Append     bool
+	Name                string
+	Driver              string
+	NodeName            string
+	Platforms           []string
+	BuildkitdFlags      string
+	BuildkitdConfigFile string
+	DriverOpts          []string
+	Use                 bool
+	Endpoint            string
+	Append              bool
 }
 
 func Create(ctx context.Context, txn *store.Txn, dockerCli command.Cli, opts CreateOpts) (*Builder, error) {
@@ -429,11 +429,11 @@ func Create(ctx context.Context, txn *store.Txn, dockerCli command.Cli, opts Cre
 		}
 	}
 
-	var flags []string
-	if opts.Flags != "" {
-		flags, err = shlex.Split(opts.Flags)
+	var buildkitdFlags []string
+	if opts.BuildkitdFlags != "" {
+		buildkitdFlags, err = shlex.Split(opts.BuildkitdFlags)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to parse buildkit flags")
+			return nil, errors.Wrap(err, "failed to parse BuildKit daemon flags")
 		}
 	}
 
@@ -493,21 +493,21 @@ func Create(ctx context.Context, txn *store.Txn, dockerCli command.Cli, opts Cre
 		setEp = false
 	}
 
-	m, err := csvToMap(opts.DriverOpts)
+	driverOpts, err := csvToMap(opts.DriverOpts)
 	if err != nil {
 		return nil, err
 	}
 
-	configFile := opts.ConfigFile
-	if configFile == "" {
-		// if buildkit config is not provided, check if the default one is
-		// available and use it
+	buildkitdConfigFile := opts.BuildkitdConfigFile
+	if buildkitdConfigFile == "" {
+		// if buildkit daemon config is not provided, check if the default one
+		// is available and use it
 		if f, ok := confutil.DefaultConfigFile(dockerCli); ok {
-			configFile = f
+			buildkitdConfigFile = f
 		}
 	}
 
-	if err := ng.Update(opts.NodeName, ep, opts.Platforms, setEp, opts.Append, flags, configFile, m); err != nil {
+	if err := ng.Update(opts.NodeName, ep, opts.Platforms, setEp, opts.Append, buildkitdFlags, buildkitdConfigFile, driverOpts); err != nil {
 		return nil, err
 	}
 

--- a/builder/node.go
+++ b/builder/node.go
@@ -142,7 +142,7 @@ func (b *Builder) LoadNodes(ctx context.Context, opts ...LoadNodesOption) (_ []N
 					}
 				}
 
-				d, err := driver.GetDriver(ctx, "buildx_buildkit_"+n.Name, factory, n.Endpoint, dockerapi, imageopt.Auth, kcc, n.Flags, n.Files, n.DriverOpts, n.Platforms, b.opts.contextPathHash, lno.dialMeta)
+				d, err := driver.GetDriver(ctx, "buildx_buildkit_"+n.Name, factory, n.Endpoint, dockerapi, imageopt.Auth, kcc, n.BuildkitdFlags, n.Files, n.DriverOpts, n.Platforms, b.opts.contextPathHash, lno.dialMeta)
 				if err != nil {
 					node.Err = err
 					return nil
@@ -217,33 +217,33 @@ func (n *Node) MarshalJSON() ([]byte, error) {
 		pp = append(pp, platforms.Format(p))
 	}
 	return json.Marshal(struct {
-		Name        string
-		Endpoint    string
-		Flags       []string           `json:",omitempty"`
-		DriverOpts  map[string]string  `json:",omitempty"`
-		Files       map[string][]byte  `json:",omitempty"`
-		Status      string             `json:",omitempty"`
-		ProxyConfig map[string]string  `json:",omitempty"`
-		Version     string             `json:",omitempty"`
-		Err         string             `json:",omitempty"`
-		IDs         []string           `json:",omitempty"`
-		Platforms   []string           `json:",omitempty"`
-		GCPolicy    []client.PruneInfo `json:",omitempty"`
-		Labels      map[string]string  `json:",omitempty"`
+		Name           string
+		Endpoint       string
+		BuildkitdFlags []string           `json:"Flags,omitempty"`
+		DriverOpts     map[string]string  `json:",omitempty"`
+		Files          map[string][]byte  `json:",omitempty"`
+		Status         string             `json:",omitempty"`
+		ProxyConfig    map[string]string  `json:",omitempty"`
+		Version        string             `json:",omitempty"`
+		Err            string             `json:",omitempty"`
+		IDs            []string           `json:",omitempty"`
+		Platforms      []string           `json:",omitempty"`
+		GCPolicy       []client.PruneInfo `json:",omitempty"`
+		Labels         map[string]string  `json:",omitempty"`
 	}{
-		Name:        n.Name,
-		Endpoint:    n.Endpoint,
-		Flags:       n.Flags,
-		DriverOpts:  n.DriverOpts,
-		Files:       n.Files,
-		Status:      status,
-		ProxyConfig: n.ProxyConfig,
-		Version:     n.Version,
-		Err:         nerr,
-		IDs:         n.IDs,
-		Platforms:   pp,
-		GCPolicy:    n.GCPolicy,
-		Labels:      n.Labels,
+		Name:           n.Name,
+		Endpoint:       n.Endpoint,
+		BuildkitdFlags: n.BuildkitdFlags,
+		DriverOpts:     n.DriverOpts,
+		Files:          n.Files,
+		Status:         status,
+		ProxyConfig:    n.ProxyConfig,
+		Version:        n.Version,
+		Err:            nerr,
+		IDs:            n.IDs,
+		Platforms:      pp,
+		GCPolicy:       n.GCPolicy,
+		Labels:         n.Labels,
 	})
 }
 

--- a/commands/create.go
+++ b/commands/create.go
@@ -16,17 +16,17 @@ import (
 )
 
 type createOptions struct {
-	name         string
-	driver       string
-	nodeName     string
-	platform     []string
-	actionAppend bool
-	actionLeave  bool
-	use          bool
-	flags        string
-	configFile   string
-	driverOpts   []string
-	bootstrap    bool
+	name                string
+	driver              string
+	nodeName            string
+	platform            []string
+	actionAppend        bool
+	actionLeave         bool
+	use                 bool
+	driverOpts          []string
+	buildkitdFlags      string
+	buildkitdConfigFile string
+	bootstrap           bool
 	// upgrade      bool // perform upgrade of the driver
 }
 
@@ -51,16 +51,16 @@ func runCreate(ctx context.Context, dockerCli command.Cli, in createOptions, arg
 	}
 
 	b, err := builder.Create(ctx, txn, dockerCli, builder.CreateOpts{
-		Name:       in.name,
-		Driver:     in.driver,
-		NodeName:   in.nodeName,
-		Platforms:  in.platform,
-		Flags:      in.flags,
-		ConfigFile: in.configFile,
-		DriverOpts: in.driverOpts,
-		Use:        in.use,
-		Endpoint:   ep,
-		Append:     in.actionAppend,
+		Name:                in.name,
+		Driver:              in.driver,
+		NodeName:            in.nodeName,
+		Platforms:           in.platform,
+		DriverOpts:          in.driverOpts,
+		BuildkitdFlags:      in.buildkitdFlags,
+		BuildkitdConfigFile: in.buildkitdConfigFile,
+		Use:                 in.use,
+		Endpoint:            ep,
+		Append:              in.actionAppend,
 	})
 	if err != nil {
 		return err
@@ -106,12 +106,16 @@ func createCmd(dockerCli command.Cli) *cobra.Command {
 	flags.StringVar(&options.name, "name", "", "Builder instance name")
 	flags.StringVar(&options.driver, "driver", "", fmt.Sprintf("Driver to use (available: %s)", drivers.String()))
 	flags.StringVar(&options.nodeName, "node", "", "Create/modify node with given name")
-	flags.StringVar(&options.flags, "buildkitd-flags", "", "Flags for buildkitd daemon")
-	flags.StringVar(&options.configFile, "config", "", "BuildKit config file")
 	flags.StringArrayVar(&options.platform, "platform", []string{}, "Fixed platforms for current node")
 	flags.StringArrayVar(&options.driverOpts, "driver-opt", []string{}, "Options for the driver")
-	flags.BoolVar(&options.bootstrap, "bootstrap", false, "Boot builder after creation")
+	flags.StringVar(&options.buildkitdFlags, "buildkitd-flags", "", "BuildKit daemon flags")
 
+	// we allow for both "--config" and "--buildkitd-config", although the latter is the recommended way to avoid ambiguity.
+	flags.StringVar(&options.buildkitdConfigFile, "buildkitd-config", "", "BuildKit daemon config file")
+	flags.StringVar(&options.buildkitdConfigFile, "config", "", "BuildKit daemon config file")
+	flags.MarkHidden("config")
+
+	flags.BoolVar(&options.bootstrap, "bootstrap", false, "Boot builder after creation")
 	flags.BoolVar(&options.actionAppend, "append", false, "Append a node to builder instead of changing it")
 	flags.BoolVar(&options.actionLeave, "leave", false, "Remove a node from builder instead of changing it")
 	flags.BoolVar(&options.use, "use", false, "Set the current builder instance")

--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -84,11 +84,11 @@ func runInspect(ctx context.Context, dockerCli command.Cli, in inspectOptions) e
 				fmt.Fprintf(w, "Error:\t%s\n", err.Error())
 			} else {
 				fmt.Fprintf(w, "Status:\t%s\n", nodes[i].DriverInfo.Status)
-				if len(n.Flags) > 0 {
-					fmt.Fprintf(w, "Flags:\t%s\n", strings.Join(n.Flags, " "))
+				if len(n.BuildkitdFlags) > 0 {
+					fmt.Fprintf(w, "BuildKit daemon flags:\t%s\n", strings.Join(n.BuildkitdFlags, " "))
 				}
 				if nodes[i].Version != "" {
-					fmt.Fprintf(w, "Buildkit:\t%s\n", nodes[i].Version)
+					fmt.Fprintf(w, "BuildKit version:\t%s\n", nodes[i].Version)
 				}
 				platforms := platformutil.FormatInGroups(n.Node.Platforms, n.Platforms)
 				if len(platforms) > 0 {

--- a/commands/rm.go
+++ b/commands/rm.go
@@ -112,7 +112,7 @@ func rmCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 
 	flags := cmd.Flags()
 	flags.BoolVar(&options.keepState, "keep-state", false, "Keep BuildKit state")
-	flags.BoolVar(&options.keepDaemon, "keep-daemon", false, "Keep the buildkitd daemon running")
+	flags.BoolVar(&options.keepDaemon, "keep-daemon", false, "Keep the BuildKit daemon running")
 	flags.BoolVar(&options.allInactive, "all-inactive", false, "Remove all inactive builders")
 	flags.BoolVarP(&options.force, "force", "f", false, "Do not prompt for confirmation")
 

--- a/docs/reference/buildx_build.md
+++ b/docs/reference/buildx_build.md
@@ -154,7 +154,7 @@ Allow extra privileged entitlement. List of entitlements:
 - `security.insecure` - Allows executions without sandbox. See
   [related Dockerfile extensions](https://docs.docker.com/reference/dockerfile/#run---securitysandbox).
 
-For entitlements to be enabled, the `buildkitd` daemon also needs to allow them
+For entitlements to be enabled, the BuildKit daemon also needs to allow them
 with `--allow-insecure-entitlement` (see [`create --buildkitd-flags`](buildx_create.md#buildkitd-flags)).
 
 ```console

--- a/docs/reference/buildx_create.md
+++ b/docs/reference/buildx_create.md
@@ -9,19 +9,19 @@ Create a new builder instance
 
 ### Options
 
-| Name                                    | Type          | Default | Description                                                           |
-|:----------------------------------------|:--------------|:--------|:----------------------------------------------------------------------|
-| [`--append`](#append)                   |               |         | Append a node to builder instead of changing it                       |
-| `--bootstrap`                           |               |         | Boot builder after creation                                           |
-| [`--buildkitd-flags`](#buildkitd-flags) | `string`      |         | Flags for buildkitd daemon                                            |
-| [`--config`](#config)                   | `string`      |         | BuildKit config file                                                  |
-| [`--driver`](#driver)                   | `string`      |         | Driver to use (available: `docker-container`, `kubernetes`, `remote`) |
-| [`--driver-opt`](#driver-opt)           | `stringArray` |         | Options for the driver                                                |
-| [`--leave`](#leave)                     |               |         | Remove a node from builder instead of changing it                     |
-| [`--name`](#name)                       | `string`      |         | Builder instance name                                                 |
-| [`--node`](#node)                       | `string`      |         | Create/modify node with given name                                    |
-| [`--platform`](#platform)               | `stringArray` |         | Fixed platforms for current node                                      |
-| [`--use`](#use)                         |               |         | Set the current builder instance                                      |
+| Name                                      | Type          | Default | Description                                                           |
+|:------------------------------------------|:--------------|:--------|:----------------------------------------------------------------------|
+| [`--append`](#append)                     |               |         | Append a node to builder instead of changing it                       |
+| `--bootstrap`                             |               |         | Boot builder after creation                                           |
+| [`--buildkitd-config`](#buildkitd-config) | `string`      |         | BuildKit daemon config file                                           |
+| [`--buildkitd-flags`](#buildkitd-flags)   | `string`      |         | BuildKit daemon flags                                                 |
+| [`--driver`](#driver)                     | `string`      |         | Driver to use (available: `docker-container`, `kubernetes`, `remote`) |
+| [`--driver-opt`](#driver-opt)             | `stringArray` |         | Options for the driver                                                |
+| [`--leave`](#leave)                       |               |         | Remove a node from builder instead of changing it                     |
+| [`--name`](#name)                         | `string`      |         | Builder instance name                                                 |
+| [`--node`](#node)                         | `string`      |         | Create/modify node with given name                                    |
+| [`--platform`](#platform)                 | `stringArray` |         | Fixed platforms for current node                                      |
+| [`--use`](#use)                           |               |         | Set the current builder instance                                      |
 
 
 <!---MARKER_GEN_END-->
@@ -55,29 +55,15 @@ $ docker buildx create --name eager_beaver --append mycontext2
 eager_beaver
 ```
 
-### <a name="buildkitd-flags"></a> Specify options for the buildkitd daemon (--buildkitd-flags)
+### <a name="buildkitd-config"></a> Specify a configuration file for the BuildKit daemon (--buildkitd-config)
 
 ```text
---buildkitd-flags FLAGS
+--buildkitd-config FILE
 ```
 
-Adds flags when starting the buildkitd daemon. They take precedence over the
-configuration file specified by [`--config`](#config). See `buildkitd --help`
-for the available flags.
-
-```text
---buildkitd-flags '--debug --debugaddr 0.0.0.0:6666'
-```
-
-### <a name="config"></a> Specify a configuration file for the buildkitd daemon (--config)
-
-```text
---config FILE
-```
-
-Specifies the configuration file for the buildkitd daemon to use. The configuration
-can be overridden by [`--buildkitd-flags`](#buildkitd-flags).
-See an [example buildkitd configuration file](https://github.com/moby/buildkit/blob/master/docs/buildkitd.toml.md).
+Specifies the configuration file for the BuildKit daemon to use. The
+configuration can be overridden by [`--buildkitd-flags`](#buildkitd-flags).
+See an [example BuildKit daemon configuration file](https://github.com/moby/buildkit/blob/master/docs/buildkitd.toml.md).
 
 If you don't specify a configuration file, Buildx looks for one by default in:
 
@@ -89,6 +75,20 @@ Note that if you create a `docker-container` builder and have specified
 certificates for registries in the `buildkitd.toml` configuration, the files
 will be copied into the container under `/etc/buildkit/certs` and configuration
 will be updated to reflect that.
+
+### <a name="buildkitd-flags"></a> Specify options for the BuildKit daemon (--buildkitd-flags)
+
+```text
+--buildkitd-flags FLAGS
+```
+
+Adds flags when starting the BuildKit daemon. They take precedence over the
+configuration file specified by [`--buildkitd-config`](#buildkitd-config). See
+`buildkitd --help` for the available flags.
+
+```text
+--buildkitd-flags '--debug --debugaddr 0.0.0.0:6666'
+```
 
 ### <a name="driver"></a> Set the builder driver to use (--driver)
 
@@ -133,8 +133,8 @@ to achieve that.
 
 #### `remote` driver
 
-Uses a remote instance of buildkitd over an arbitrary connection. With this
-driver, you manually create and manage instances of buildkit yourself, and
+Uses a remote instance of BuildKit daemon over an arbitrary connection. With
+this driver, you manually create and manage instances of buildkit yourself, and
 configure buildx to point at it.
 
 Unlike `docker` driver, built images will not automatically appear in

--- a/docs/reference/buildx_rm.md
+++ b/docs/reference/buildx_rm.md
@@ -14,7 +14,7 @@ Remove one or more builder instances
 | [`--all-inactive`](#all-inactive)   |          |         | Remove all inactive builders             |
 | [`--builder`](#builder)             | `string` |         | Override the configured builder instance |
 | [`-f`](#force), [`--force`](#force) |          |         | Do not prompt for confirmation           |
-| [`--keep-daemon`](#keep-daemon)     |          |         | Keep the buildkitd daemon running        |
+| [`--keep-daemon`](#keep-daemon)     |          |         | Keep the BuildKit daemon running         |
 | [`--keep-state`](#keep-state)       |          |         | Keep BuildKit state                      |
 
 
@@ -48,10 +48,10 @@ Do not prompt for confirmation before removing inactive builders.
 $ docker buildx rm --all-inactive --force
 ```
 
-### <a name="keep-daemon"></a> Keep the buildkitd daemon running (--keep-daemon)
+### <a name="keep-daemon"></a> Keep the BuildKit daemon running (--keep-daemon)
 
 Keep the BuildKit daemon running after the buildx context is removed. This is
-useful when you manage buildkitd daemons and buildx contexts independently.
+useful when you manage BuildKit daemons and buildx contexts independently.
 Only supported by the
 [`docker-container`](https://docs.docker.com/build/drivers/docker-container/)
 and [`kubernetes`](https://docs.docker.com/build/drivers/kubernetes/) drivers.

--- a/driver/docker-container/driver.go
+++ b/driver/docker-container/driver.go
@@ -494,7 +494,7 @@ func writeConfigFiles(m map[string][]byte) (_ string, err error) {
 }
 
 func getBuildkitFlags(initConfig driver.InitConfig) []string {
-	flags := initConfig.BuildkitFlags
+	flags := initConfig.BuildkitdFlags
 	if _, ok := initConfig.Files[buildkitdConfigFile]; ok {
 		// There's no way for us to determine the appropriate default configuration
 		// path and the default path can vary depending on if the image is normal

--- a/driver/docker-container/factory.go
+++ b/driver/docker-container/factory.go
@@ -56,7 +56,7 @@ func (f *factory) New(ctx context.Context, cfg driver.InitConfig) (driver.Driver
 		case k == "network":
 			d.netMode = v
 			if v == "host" {
-				d.InitConfig.BuildkitFlags = append(d.InitConfig.BuildkitFlags, "--allow-insecure-entitlement=network.host")
+				d.InitConfig.BuildkitdFlags = append(d.InitConfig.BuildkitdFlags, "--allow-insecure-entitlement=network.host")
 			}
 		case k == "image":
 			d.image = v

--- a/driver/kubernetes/factory.go
+++ b/driver/kubernetes/factory.go
@@ -105,7 +105,7 @@ func (f *factory) processDriverOpts(deploymentName string, namespace string, cfg
 		Name:          deploymentName,
 		Image:         bkimage.DefaultImage,
 		Replicas:      1,
-		BuildkitFlags: cfg.BuildkitFlags,
+		BuildkitFlags: cfg.BuildkitdFlags,
 		Rootless:      false,
 		Platforms:     cfg.Platforms,
 		ConfigFiles:   cfg.Files,

--- a/driver/manager.go
+++ b/driver/manager.go
@@ -52,7 +52,7 @@ type InitConfig struct {
 	EndpointAddr     string
 	DockerAPI        dockerclient.APIClient
 	KubeClientConfig KubeClientConfig
-	BuildkitFlags    []string
+	BuildkitdFlags   []string
 	Files            map[string][]byte
 	DriverOpts       map[string]string
 	Auth             Auth
@@ -103,13 +103,13 @@ func GetFactory(name string, instanceRequired bool) (Factory, error) {
 	return nil, errors.Errorf("failed to find driver %q", name)
 }
 
-func GetDriver(ctx context.Context, name string, f Factory, endpointAddr string, api dockerclient.APIClient, auth Auth, kcc KubeClientConfig, flags []string, files map[string][]byte, do map[string]string, platforms []specs.Platform, contextPathHash string, dialMeta map[string][]string) (*DriverHandle, error) {
+func GetDriver(ctx context.Context, name string, f Factory, endpointAddr string, api dockerclient.APIClient, auth Auth, kcc KubeClientConfig, buildkitdFlags []string, files map[string][]byte, do map[string]string, platforms []specs.Platform, contextPathHash string, dialMeta map[string][]string) (*DriverHandle, error) {
 	ic := InitConfig{
 		EndpointAddr:     endpointAddr,
 		DockerAPI:        api,
 		KubeClientConfig: kcc,
 		Name:             name,
-		BuildkitFlags:    flags,
+		BuildkitdFlags:   buildkitdFlags,
 		DriverOpts:       do,
 		Auth:             auth,
 		Platforms:        platforms,

--- a/driver/remote/factory.go
+++ b/driver/remote/factory.go
@@ -46,7 +46,7 @@ func (f *factory) New(ctx context.Context, cfg driver.InitConfig) (driver.Driver
 	if len(cfg.Files) > 0 {
 		return nil, errors.Errorf("setting config file is not supported for remote driver")
 	}
-	if len(cfg.BuildkitFlags) > 0 {
+	if len(cfg.BuildkitdFlags) > 0 {
 		return nil, errors.Errorf("setting buildkit flags is not supported for remote driver")
 	}
 

--- a/hack/test-driver
+++ b/hack/test-driver
@@ -49,7 +49,7 @@ if [ "$DRIVER" != "docker" ]; then
     for platform in ${PLATFORMS//,/ }; do
       createFlags=""
       if [ -f "$BUILDKIT_CFG" ]; then
-        createFlags="$createFlags --config=${BUILDKIT_CFG}"
+        createFlags="$createFlags --buildkitd-config=${BUILDKIT_CFG}"
       fi
       if [ "$firstNode" = "0" ]; then
         createFlags="$createFlags --append"
@@ -71,7 +71,7 @@ if [ "$DRIVER" != "docker" ]; then
   else
     createFlags=""
     if [ -f "$BUILDKIT_CFG" ]; then
-      createFlags="$createFlags --config=${BUILDKIT_CFG}"
+      createFlags="$createFlags --buildkitd-config=${BUILDKIT_CFG}"
     fi
     buildxCmd create ${createFlags} \
       --bootstrap \

--- a/store/nodegroup.go
+++ b/store/nodegroup.go
@@ -24,11 +24,11 @@ type NodeGroup struct {
 }
 
 type Node struct {
-	Name       string
-	Endpoint   string
-	Platforms  []specs.Platform
-	Flags      []string
-	DriverOpts map[string]string
+	Name           string
+	Endpoint       string
+	Platforms      []specs.Platform
+	DriverOpts     map[string]string
+	BuildkitdFlags []string `json:"Flags"` // keep the field name for backward compatibility
 
 	Files map[string][]byte
 }
@@ -48,7 +48,7 @@ func (ng *NodeGroup) Leave(name string) error {
 	return nil
 }
 
-func (ng *NodeGroup) Update(name, endpoint string, platforms []string, endpointsSet bool, actionAppend bool, flags []string, configFile string, do map[string]string) error {
+func (ng *NodeGroup) Update(name, endpoint string, platforms []string, endpointsSet bool, actionAppend bool, buildkitdFlags []string, buildkitdConfigFile string, do map[string]string) error {
 	if ng.Dynamic {
 		return errors.New("dynamic node group does not support Update")
 	}
@@ -66,8 +66,8 @@ func (ng *NodeGroup) Update(name, endpoint string, platforms []string, endpoints
 	}
 
 	var files map[string][]byte
-	if configFile != "" {
-		files, err = confutil.LoadConfigFiles(configFile)
+	if buildkitdConfigFile != "" {
+		files, err = confutil.LoadConfigFiles(buildkitdConfigFile)
 		if err != nil {
 			return err
 		}
@@ -83,15 +83,15 @@ func (ng *NodeGroup) Update(name, endpoint string, platforms []string, endpoints
 		if len(platforms) > 0 {
 			n.Platforms = pp
 		}
-		if flags != nil {
-			n.Flags = flags
+		if buildkitdFlags != nil {
+			n.BuildkitdFlags = buildkitdFlags
 			needsRestart = true
 		}
 		if do != nil {
 			n.DriverOpts = do
 			needsRestart = true
 		}
-		if configFile != "" {
+		if buildkitdConfigFile != "" {
 			for k, v := range files {
 				n.Files[k] = v
 			}
@@ -115,12 +115,12 @@ func (ng *NodeGroup) Update(name, endpoint string, platforms []string, endpoints
 	}
 
 	n := Node{
-		Name:       name,
-		Endpoint:   endpoint,
-		Platforms:  pp,
-		Flags:      flags,
-		DriverOpts: do,
-		Files:      files,
+		Name:           name,
+		Endpoint:       endpoint,
+		Platforms:      pp,
+		DriverOpts:     do,
+		BuildkitdFlags: buildkitdFlags,
+		Files:          files,
 	}
 
 	ng.Nodes = append(ng.Nodes, n)
@@ -143,8 +143,8 @@ func (ng *NodeGroup) Copy() *NodeGroup {
 func (n *Node) Copy() *Node {
 	platforms := []specs.Platform{}
 	copy(platforms, n.Platforms)
-	flags := []string{}
-	copy(flags, n.Flags)
+	buildkitdFlags := []string{}
+	copy(buildkitdFlags, n.BuildkitdFlags)
 	driverOpts := map[string]string{}
 	for k, v := range n.DriverOpts {
 		driverOpts[k] = v
@@ -156,12 +156,12 @@ func (n *Node) Copy() *Node {
 		files[k] = vv
 	}
 	return &Node{
-		Name:       n.Name,
-		Endpoint:   n.Endpoint,
-		Platforms:  platforms,
-		Flags:      flags,
-		DriverOpts: driverOpts,
-		Files:      files,
+		Name:           n.Name,
+		Endpoint:       n.Endpoint,
+		Platforms:      platforms,
+		BuildkitdFlags: buildkitdFlags,
+		DriverOpts:     driverOpts,
+		Files:          files,
 	}
 }
 

--- a/store/nodegroup_test.go
+++ b/store/nodegroup_test.go
@@ -28,8 +28,8 @@ func TestNodeGroupUpdate(t *testing.T) {
 	require.Equal(t, []string{"linux/arm64"}, platformutil.Format(ng.Nodes[1].Platforms))
 
 	require.Equal(t, "foo2", ng.Nodes[0].Endpoint)
-	require.Equal(t, []string{"--debug"}, ng.Nodes[0].Flags)
-	require.Equal(t, []string(nil), ng.Nodes[1].Flags)
+	require.Equal(t, []string{"--debug"}, ng.Nodes[0].BuildkitdFlags)
+	require.Equal(t, []string(nil), ng.Nodes[1].BuildkitdFlags)
 
 	// duplicate endpoint
 	err = ng.Update("foo1", "foo2", nil, true, false, nil, "", nil)

--- a/tests/build.go
+++ b/tests/build.go
@@ -118,7 +118,7 @@ func testBuildRegistryExportAttestations(t *testing.T, sb integration.Sandbox) {
 	out, err := buildCmd(sb, withArgs(fmt.Sprintf("--output=type=image,name=%s,push=true", target), "--provenance=true", dir))
 	if sb.Name() == "docker" {
 		require.Error(t, err)
-		require.Contains(t, out, "attestations are not supported")
+		require.Contains(t, out, "Attestation is not supported")
 		return
 	}
 	require.NoError(t, err, string(out))

--- a/tests/workers/docker-container.go
+++ b/tests/workers/docker-container.go
@@ -58,7 +58,7 @@ func (w *containerWorker) New(ctx context.Context, cfg *integration.BackendConfi
 	cmd := exec.Command("buildx", "create",
 		"--bootstrap",
 		"--name="+name,
-		"--config="+cfgfile,
+		"--buildkitd-config="+cfgfile,
 		"--driver=docker-container",
 		"--driver-opt=network=host",
 	)


### PR DESCRIPTION
I found it confusing to have `config` as driver opt instead of `buildkitd-config` so we are consistent with `buildkitd-flags`. Same for variables not aligned across our code base.

This is also relevant for #2270 