### PR TITLE
driver: docs to set buildkitd network mode and add tests

### DIFF
--- a/docs/reference/buildx_create.md
+++ b/docs/reference/buildx_create.md
@@ -90,6 +90,22 @@ configuration file specified by [`--buildkitd-config`](#buildkitd-config). See
 --buildkitd-flags '--debug --debugaddr 0.0.0.0:6666'
 ```
 
+#### BuildKit daemon network mode
+
+You can specify the network mode for the BuildKit daemon with either the
+configuration file specified by [`--buildkitd-config`](#buildkitd-config) using the
+`worker.oci.networkMode` option or `--oci-worker-net` flag here. The default
+value is `auto` and can be one of `bridge`, `cni`, `host`:
+
+```text
+--buildkitd-flags '--oci-worker-net bridge'
+```
+
+> **Note**
+>
+> Network mode "bridge" is supported since BuildKit v0.13 and will become the
+> default in next v0.14.
+
 ### <a name="driver"></a> Set the builder driver to use (--driver)
 
 ```text

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/google/uuid v1.5.0
 	github.com/hashicorp/go-cty-funcs v0.0.0-20230405223818-a090f58aa992
 	github.com/hashicorp/hcl/v2 v2.19.1
-	github.com/moby/buildkit v0.13.0-rc1.0.20240221065707-db304eb93126 // master (v0.13.0-dev)
+	github.com/moby/buildkit v0.13.0-rc1.0.20240222164755-8e3fe35738c2 // master (v0.13.0-dev)
 	github.com/moby/sys/mountinfo v0.7.1
 	github.com/moby/sys/signal v0.7.0
 	github.com/morikuni/aec v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -320,8 +320,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/moby/buildkit v0.13.0-rc1.0.20240221065707-db304eb93126 h1:aXdgP8jLyDnKEOXis4Aydp4VlXYpg2loUJarhygTOuU=
-github.com/moby/buildkit v0.13.0-rc1.0.20240221065707-db304eb93126/go.mod h1:XaLDo1L55QqXS/04FE91+mAbwjkr0vZu9g6zZlzvXL8=
+github.com/moby/buildkit v0.13.0-rc1.0.20240222164755-8e3fe35738c2 h1:e3FYb+yyx1SM1w4Mjn8L9WP5h/6u23P/xCAPZXx4m2Y=
+github.com/moby/buildkit v0.13.0-rc1.0.20240222164755-8e3fe35738c2/go.mod h1:XaLDo1L55QqXS/04FE91+mAbwjkr0vZu9g6zZlzvXL8=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/locker v1.0.1 h1:fOXqR41zeveg4fFODix+1Ch4mj/gT0NE1XJbp/epuBg=

--- a/tests/inspect.go
+++ b/tests/inspect.go
@@ -17,6 +17,7 @@ func inspectCmd(sb integration.Sandbox, opts ...cmdOpt) (string, error) {
 
 var inspectTests = []func(t *testing.T, sb integration.Sandbox){
 	testInspect,
+	testInspectBuildkitdFlags,
 }
 
 func testInspect(t *testing.T, sb integration.Sandbox) {
@@ -46,4 +47,34 @@ func testInspect(t *testing.T, sb integration.Sandbox) {
 	} else {
 		require.Empty(t, hostGatewayIP, "host-gateway-ip worker label should not be set with non-docker driver")
 	}
+}
+
+func testInspectBuildkitdFlags(t *testing.T, sb integration.Sandbox) {
+	if sb.Name() != "docker-container" {
+		t.Skip("only testing for docker-container driver")
+	}
+
+	var builderName string
+	t.Cleanup(func() {
+		if builderName == "" {
+			return
+		}
+		out, err := rmCmd(sb, withArgs(builderName))
+		require.NoError(t, err, out)
+	})
+
+	out, err := createCmd(sb, withArgs("--driver", "docker-container", "--buildkitd-flags=--oci-worker-net=bridge"))
+	require.NoError(t, err, out)
+	builderName = strings.TrimSpace(out)
+
+	out, err = inspectCmd(sb, withArgs(builderName))
+	require.NoError(t, err, out)
+
+	for _, line := range strings.Split(out, "\n") {
+		if v, ok := strings.CutPrefix(line, "BuildKit daemon flags:"); ok {
+			require.Contains(t, v, "--oci-worker-net=bridge")
+			return
+		}
+	}
+	require.Fail(t, "--oci-worker-net=bridge not found in inspect output")
 }

--- a/tests/integration.go
+++ b/tests/integration.go
@@ -47,8 +47,10 @@ func buildxCmd(sb integration.Sandbox, opts ...cmdOpt) *exec.Cmd {
 	}
 
 	if builder := sb.Address(); builder != "" {
-		cmd.Args = append(cmd.Args, "--builder="+builder)
-		cmd.Env = append(cmd.Env, "BUILDX_CONFIG=/tmp/buildx-"+builder)
+		cmd.Env = append(cmd.Env,
+			"BUILDX_CONFIG=/tmp/buildx-"+builder,
+			"BUILDX_BUILDER="+builder,
+		)
 	}
 	if context := sb.DockerAddress(); context != "" {
 		cmd.Env = append(cmd.Env, "DOCKER_CONTEXT="+context)

--- a/vendor/github.com/moby/buildkit/util/appdefaults/appdefaults.go
+++ b/vendor/github.com/moby/buildkit/util/appdefaults/appdefaults.go
@@ -1,0 +1,6 @@
+package appdefaults
+
+const (
+	BridgeName   = "buildkit0"
+	BridgeSubnet = "10.10.0.0/16"
+)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -509,7 +509,7 @@ github.com/mitchellh/mapstructure
 # github.com/mitchellh/reflectwalk v1.0.2
 ## explicit
 github.com/mitchellh/reflectwalk
-# github.com/moby/buildkit v0.13.0-rc1.0.20240221065707-db304eb93126
+# github.com/moby/buildkit v0.13.0-rc1.0.20240222164755-8e3fe35738c2
 ## explicit; go 1.21
 github.com/moby/buildkit/api/services/control
 github.com/moby/buildkit/api/types


### PR DESCRIPTION
fixes https://github.com/docker/buildx/issues/2256
follow-up https://github.com/docker/buildx/pull/2270#discussion_r1498446323 and closes #2270
needs #2268

This is an alternative to #2270 to document how to set BuildKit daemon network mode using `--buildkitd-flags` instead of introducing a new flag.