### PR TITLE
remote: use winio DialPipeContext for named pipes

### DIFF
--- a/driver/remote/driver.go
+++ b/driver/remote/driver.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/docker/buildx/driver"
+	util "github.com/docker/buildx/driver/remote/util"
 	"github.com/docker/buildx/util/progress"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/util/tracing/detect"
@@ -99,9 +100,8 @@ func (d *Driver) Dial(ctx context.Context) (net.Conn, error) {
 		return nil, errors.Errorf("invalid endpoint address: %s", d.InitConfig.EndpointAddr)
 	}
 
-	dialer := &net.Dialer{}
+	conn, err := util.DialContext(ctx, network, addr)
 
-	conn, err := dialer.DialContext(ctx, network, addr)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/driver/remote/util/dialer_unix.go
+++ b/driver/remote/util/dialer_unix.go
@@ -1,0 +1,17 @@
+//go:build !windows
+// +build !windows
+
+package remote
+
+import (
+	"context"
+	"net"
+)
+
+func DialContext(ctx context.Context, network string, addr string) (net.Conn, error) {
+	dialer := &net.Dialer{}
+
+	conn, err := dialer.DialContext(ctx, network, addr)
+
+	return conn, err
+}

--- a/driver/remote/util/dialer_windows.go
+++ b/driver/remote/util/dialer_windows.go
@@ -1,0 +1,23 @@
+package remote
+
+import (
+	"context"
+	"net"
+
+	"github.com/Microsoft/go-winio"
+)
+
+func DialContext(ctx context.Context, network string, addr string) (net.Conn, error) {
+	var conn net.Conn
+	var err error
+
+	// dial context doesn't support named pipes
+	if network == "npipe" {
+		conn, err = winio.DialPipeContext(ctx, addr)
+	} else {
+		dialer := &net.Dialer{}
+		conn, err = dialer.DialContext(ctx, network, addr)
+	}
+
+	return conn, err
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1
+	github.com/Microsoft/go-winio v0.6.1
 	github.com/aws/aws-sdk-go-v2/config v1.26.6
 	github.com/compose-spec/compose-go/v2 v2.0.0-rc.8
 	github.com/containerd/console v1.0.4
@@ -60,7 +61,6 @@ require (
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
-	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/Microsoft/hcsshim v0.11.4 // indirect
 	github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect


### PR DESCRIPTION
This PR fixes an issue where the [Dialer ](https://pkg.go.dev/net?GOOS=windows#Dialer.DialContextl) in go does not support named pipes which the buildkit daemon on Windows uses. I've added a utility DialContext function that uses  [DialPipeContext](https://github.com/microsoft/go-winio/blob/008bc6ea439f15884bef0b52f2772190c382bf46/pipe.go#L255C6-L255C21) for npipe connections on windows.

