### PR TITLE
commands: handle ctrl-c on active prompt

### DIFF
--- a/commands/prune.go
+++ b/commands/prune.go
@@ -49,8 +49,12 @@ func runPrune(ctx context.Context, dockerCli command.Cli, opts pruneOptions) err
 		warning = allCacheWarning
 	}
 
-	if !opts.force && !command.PromptForConfirmation(dockerCli.In(), dockerCli.Out(), warning) {
-		return nil
+	if !opts.force {
+		if ok, err := prompt(ctx, dockerCli.In(), dockerCli.Out(), warning); err != nil {
+			return err
+		} else if !ok {
+			return nil
+		}
 	}
 
 	b, err := builder.New(dockerCli, builder.WithName(opts.builder))

--- a/commands/rm.go
+++ b/commands/rm.go
@@ -28,8 +28,12 @@ const (
 )
 
 func runRm(ctx context.Context, dockerCli command.Cli, in rmOptions) error {
-	if in.allInactive && !in.force && !command.PromptForConfirmation(dockerCli.In(), dockerCli.Out(), rmInactiveWarning) {
-		return nil
+	if in.allInactive && !in.force {
+		if ok, err := prompt(ctx, dockerCli.In(), dockerCli.Out(), rmInactiveWarning); err != nil {
+			return err
+		} else if !ok {
+			return nil
+		}
 	}
 
 	txn, release, err := storeutil.GetStore(dockerCli)

--- a/commands/util.go
+++ b/commands/util.go
@@ -1,0 +1,23 @@
+package commands
+
+import (
+	"context"
+	"io"
+
+	"github.com/docker/cli/cli/command"
+)
+
+func prompt(ctx context.Context, ins io.Reader, out io.Writer, msg string) (bool, error) {
+	done := make(chan struct{})
+	var ok bool
+	go func() {
+		ok = command.PromptForConfirmation(ins, out, msg)
+		close(done)
+	}()
+	select {
+	case <-ctx.Done():
+		return false, context.Cause(ctx)
+	case <-done:
+		return ok, nil
+	}
+}


### PR DESCRIPTION
fix #2240

With recent changes, the global cobra context is passed to all commands what usually is correct, but in this case the prompt library does not provide support for cancellation.

Note that although the new function supports cancellation, it does not leave the reader in a clean state. Internally the prompt function uses bufio reader so it is unknown how many bytes it has read and how much data it has dropped once the prompt function returns.