### PR TITLE
ci(fix): remove underscore in docs data dir

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -20,7 +20,7 @@ jobs:
       -
         name: Prepare
         run: |
-          rm -rf ./_data/buildx/*
+          rm -rf ./data/buildx/*
           rm -rf ./_vendor/github.com/docker/buildx
       -
         name: Set up Docker Buildx
@@ -38,7 +38,7 @@ jobs:
       -
         name: Copy yaml
         run: |
-          cp /tmp/buildx-docs/out/reference/*.yaml ./_data/buildx/
+          cp /tmp/buildx-docs/out/reference/*.yaml ./data/buildx/
       -
         name: Update vendor
         uses: docker/bake-action@v4


### PR DESCRIPTION
Follow-up to #2295

We have no underscore in the data dirname anymore. 

https://github.com/docker/docs/tree/main/data

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>