### PR TITLE
build: handle push/load shorthands for multi exporters

### DIFF
--- a/commands/bake.go
+++ b/commands/bake.go
@@ -72,11 +72,9 @@ func runBake(ctx context.Context, dockerCli command.Cli, targets []string, in ba
 
 	overrides := in.overrides
 	if in.exportPush {
-		if in.exportLoad {
-			return errors.Errorf("push and load may not be set together at the moment")
-		}
-		overrides = append(overrides, "*.push=true")
-	} else if in.exportLoad {
+		overrides = append(overrides, "*.output=type=registry")
+	}
+	if in.exportLoad {
 		overrides = append(overrides, "*.output=type=docker")
 	}
 	if cFlags.noCache != nil {


### PR DESCRIPTION
fixes https://github.com/docker/build-push-action/issues/727

We forgot to handle `push` and `load` shorthands in https://github.com/docker/buildx/pull/2290.

~Keeping this one in draft while I'm working on integration tests.~

~EDIT: Argh GitHub is broken https://www.githubstatus.com/incidents/wcl1sw4mzg60~