### PR TITLE
[v0.13 backport] docs: fix link to new target in dockerfile reference

### DIFF
--- a/docs/reference/buildx_build.md
+++ b/docs/reference/buildx_build.md
@@ -152,7 +152,7 @@ Allow extra privileged entitlement. List of entitlements:
 
 - `network.host` - Allows executions with host networking.
 - `security.insecure` - Allows executions without sandbox. See
-  [related Dockerfile extensions](https://docs.docker.com/reference/dockerfile/#run---securitysandbox).
+  [related Dockerfile extensions](https://docs.docker.com/reference/dockerfile/#run---security).
 
 For entitlements to be enabled, the BuildKit daemon also needs to allow them
 with `--allow-insecure-entitlement` (see [`create --buildkitd-flags`](buildx_create.md#buildkitd-flags)).


### PR DESCRIPTION
- backport of #2319
