### PR TITLE
remote: fix connhelpers with custom dialer

### DIFF
--- a/builder/node.go
+++ b/builder/node.go
@@ -142,7 +142,7 @@ func (b *Builder) LoadNodes(ctx context.Context, opts ...LoadNodesOption) (_ []N
 					}
 				}
 
-				d, err := driver.GetDriver(ctx, "buildx_buildkit_"+n.Name, factory, n.Endpoint, dockerapi, imageopt.Auth, kcc, n.BuildkitdFlags, n.Files, n.DriverOpts, n.Platforms, b.opts.contextPathHash, lno.dialMeta)
+				d, err := driver.GetDriver(ctx, driver.BuilderName(n.Name), factory, n.Endpoint, dockerapi, imageopt.Auth, kcc, n.BuildkitdFlags, n.Files, n.DriverOpts, n.Platforms, b.opts.contextPathHash, lno.dialMeta)
 				if err != nil {
 					node.Err = err
 					return nil

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"net"
+	"strings"
 
 	"github.com/docker/buildx/store"
 	"github.com/docker/buildx/util/progress"
@@ -65,6 +66,19 @@ type Driver interface {
 	HostGatewayIP(ctx context.Context) (net.IP, error)
 	IsMobyDriver() bool
 	Config() InitConfig
+}
+
+const builderNamePrefix = "buildx_buildkit_"
+
+func BuilderName(name string) string {
+	return builderNamePrefix + name
+}
+
+func ParseBuilderName(name string) (string, error) {
+	if !strings.HasPrefix(name, builderNamePrefix) {
+		return "", errors.Errorf("invalid builder name %q, must have %q prefix", name, builderNamePrefix)
+	}
+	return strings.TrimPrefix(name, builderNamePrefix), nil
 }
 
 func Boot(ctx, clientContext context.Context, d *DriverHandle, pw progress.Writer) (*client.Client, error) {

--- a/driver/kubernetes/factory.go
+++ b/driver/kubernetes/factory.go
@@ -244,10 +244,10 @@ func (f *factory) AllowsInstances() bool {
 // eg. "buildx_buildkit_loving_mendeleev0" -> "loving-mendeleev0"
 func buildxNameToDeploymentName(bx string) (string, error) {
 	// TODO: commands.util.go should not pass "buildx_buildkit_" prefix to drivers
-	if !strings.HasPrefix(bx, "buildx_buildkit_") {
-		return "", errors.Errorf("expected a string with \"buildx_buildkit_\", got %q", bx)
+	s, err := driver.ParseBuilderName(bx)
+	if err != nil {
+		return "", err
 	}
-	s := strings.TrimPrefix(bx, "buildx_buildkit_")
 	s = strings.ReplaceAll(s, "_", "-")
 	return s, nil
 }

--- a/driver/kubernetes/factory_test.go
+++ b/driver/kubernetes/factory_test.go
@@ -29,7 +29,7 @@ func TestFactory_processDriverOpts(t *testing.T) {
 	}
 
 	cfg := driver.InitConfig{
-		Name:             "buildx_buildkit_test",
+		Name:             driver.BuilderName("test"),
 		KubeClientConfig: &kcc,
 	}
 	f := factory{}

--- a/tests/create.go
+++ b/tests/create.go
@@ -1,9 +1,13 @@
 package tests
 
 import (
+	"fmt"
+	"os"
 	"strings"
 	"testing"
 
+	"github.com/docker/buildx/driver"
+	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/util/testutil/integration"
 	"github.com/stretchr/testify/require"
 )
@@ -18,6 +22,7 @@ func createCmd(sb integration.Sandbox, opts ...cmdOpt) (string, error) {
 var createTests = []func(t *testing.T, sb integration.Sandbox){
 	testCreateMemoryLimit,
 	testCreateRestartAlways,
+	testCreateRemoteContainer,
 }
 
 func testCreateMemoryLimit(t *testing.T, sb integration.Sandbox) {
@@ -56,4 +61,50 @@ func testCreateRestartAlways(t *testing.T, sb integration.Sandbox) {
 	out, err := createCmd(sb, withArgs("--driver", "docker-container", "--driver-opt", "restart-policy=always"))
 	require.NoError(t, err, out)
 	builderName = strings.TrimSpace(out)
+}
+
+func testCreateRemoteContainer(t *testing.T, sb integration.Sandbox) {
+	if sb.Name() != "docker" {
+		t.Skip("skipping test for non-docker workers")
+	}
+
+	ctnBuilderName := "ctn-builder-" + identity.NewID()
+	remoteBuilderName := "remote-builder-" + identity.NewID()
+	var hasCtnBuilder, hasRemoteBuilder bool
+	t.Cleanup(func() {
+		if hasCtnBuilder {
+			out, err := rmCmd(sb, withArgs(ctnBuilderName))
+			require.NoError(t, err, out)
+		}
+		if hasRemoteBuilder {
+			out, err := rmCmd(sb, withArgs(remoteBuilderName))
+			require.NoError(t, err, out)
+		}
+	})
+
+	out, err := createCmd(sb, withArgs("--driver", "docker-container", "--name", ctnBuilderName))
+	require.NoError(t, err, out)
+	hasCtnBuilder = true
+
+	out, err = inspectCmd(sb, withArgs("--bootstrap", ctnBuilderName))
+	require.NoError(t, err, out)
+
+	cmd := dockerCmd(sb, withArgs("container", "inspect", fmt.Sprintf("%s0", driver.BuilderName(ctnBuilderName))))
+	cmd.Stderr = os.Stderr
+	require.NoError(t, cmd.Run())
+
+	out, err = createCmd(sb, withArgs("--driver", "remote", "--name", remoteBuilderName, fmt.Sprintf("docker-container://%s0", driver.BuilderName(ctnBuilderName))))
+	require.NoError(t, err, out)
+	hasRemoteBuilder = true
+
+	out, err = inspectCmd(sb, withArgs(remoteBuilderName))
+	require.NoError(t, err, out)
+
+	for _, line := range strings.Split(out, "\n") {
+		if v, ok := strings.CutPrefix(line, "Status:"); ok {
+			require.Equal(t, strings.TrimSpace(v), "running")
+			return
+		}
+	}
+	require.Fail(t, "remote builder is not running")
 }


### PR DESCRIPTION
fix #2324
closes #2329

With the new dial-stdio command the dialer is split from `Client` function in order to access it directly.

This breaks the custom connhelpers functionality
as support for connhelpers is a feature of the default dialer. If client defines a custom dialer then only it is used without extra modifications. This means that remote driver dialer needs to detect the
connhelpers on its own.

The relevant default dialer addition is in https://github.com/moby/buildkit/blob/a38011b9f57db4b805e6bb0322d7d923b341bc6e/client/client.go#L109-L115 .

@cpuguy83 @jsternberg 

@crazy-max For test, should we have one custom test just for connhelpers or maybe just add extra config in the matrix that runs remote driver with a `docker-container://` endpoint address?