### PR TITLE
bake: load override

### DIFF
--- a/commands/bake.go
+++ b/commands/bake.go
@@ -75,7 +75,7 @@ func runBake(ctx context.Context, dockerCli command.Cli, targets []string, in ba
 		overrides = append(overrides, "*.push=true")
 	}
 	if in.exportLoad {
-		overrides = append(overrides, "*.output=type=docker")
+		overrides = append(overrides, "*.load=true")
 	}
 	if cFlags.noCache != nil {
 		overrides = append(overrides, fmt.Sprintf("*.no-cache=%t", *cFlags.noCache))

--- a/docs/reference/buildx_bake.md
+++ b/docs/reference/buildx_bake.md
@@ -162,6 +162,7 @@ You can override the following fields:
 * `context`
 * `dockerfile`
 * `labels`
+* `load`
 * `no-cache`
 * `no-cache-filter`
 * `output`

--- a/tests/bake.go
+++ b/tests/bake.go
@@ -814,11 +814,11 @@ target "default" {
 	outb, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(outb))
 
-	// TODO: test registry when --load case fixed for bake (currently overrides --push)
-	//desc, provider, err := contentutil.ProviderFromRef(target)
-	//require.NoError(t, err)
-	//_, err = testutil.ReadImages(sb.Context(), provider, desc)
-	//require.NoError(t, err)
+	// test registry
+	desc, provider, err := contentutil.ProviderFromRef(target)
+	require.NoError(t, err)
+	_, err = testutil.ReadImages(sb.Context(), provider, desc)
+	require.NoError(t, err)
 
 	// test docker store
 	cmd = dockerCmd(sb, withArgs("image", "inspect", target))


### PR DESCRIPTION
follow-up https://github.com/docker/buildx/pull/2330

The `--load` case is not properly handled in v0.13 and previous v0.12 as it doesn't append but overrides the outputs:

```hcl
target "foo" {
  output = [ "type=local,dest=out" ]
}

target "bar" {
}
```

```
$ docker buildx bake --load --print foo bar
```
```json
{
  "group": {
    "default": {
      "targets": [
        "foo",
        "bar"
      ]
    }
  },
  "target": {
    "bar": {
      "context": ".",
      "dockerfile": "Dockerfile",
      "output": [
        "type=docker"
      ]
    },
    "foo": {
      "context": ".",
      "dockerfile": "Dockerfile",
      "output": [
        "type=docker"
      ]
    }
  }
}
```

With this change it will append only if there is a compatible output already (image, registry) or empty:

```json
{
  "group": {
    "default": {
      "targets": [
        "foo",
        "bar"
      ]
    }
  },
  "target": {
    "bar": {
      "context": ".",
      "dockerfile": "Dockerfile",
      "output": [
        "type=docker"
      ]
    },
    "foo": {
      "context": ".",
      "dockerfile": "Dockerfile",
      "output": [
        "type=local,dest=out"
      ]
    }
  }
}
```

For example with:

```hcl
target "foo" {
  output = [ "type=image" ]
}

target "bar" {
}
```

It would result in:

```json
{
  "group": {
    "default": {
      "targets": [
        "foo",
        "bar"
      ]
    }
  },
  "target": {
    "bar": {
      "context": ".",
      "dockerfile": "Dockerfile",
      "output": [
        "type=docker"
      ]
    },
    "foo": {
      "context": ".",
      "dockerfile": "Dockerfile",
      "output": [
        "type=image"
        "type=docker"
      ]
    }
  }
}
```

Same has been done for push override so we are consistent. See new tests suite for more info.