### PR TITLE
[v0.13 backport] ci: enable multi-platform lint only for upstream repo

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           source: ${{ github.server_url }}/${{ github.repository }}.git#${{ env.RELEASE_NAME }}
           targets: update-docs
+          provenance: false
           set: |
             *.output=/tmp/buildx-docs
         env:
@@ -54,6 +55,7 @@ jobs:
         uses: docker/bake-action@v4
         with:
           targets: vendor
+          provenance: false
           set: |
             vendor.args.MODULE=github.com/docker/buildx@${{ env.RELEASE_NAME }}
       -

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -26,7 +26,6 @@ jobs:
         name: Prepare
         run: |
           rm -rf ./data/buildx/*
-          rm -rf ./_vendor/github.com/docker/buildx
           if [ -n "${{ github.event.inputs.tag }}" ]; then
             echo "RELEASE_NAME=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
           else
@@ -52,12 +51,10 @@ jobs:
           cp /tmp/buildx-docs/out/reference/*.yaml ./data/buildx/
       -
         name: Update vendor
-        uses: docker/bake-action@v4
-        with:
-          targets: vendor
-          provenance: false
-          set: |
-            vendor.args.MODULE=github.com/docker/buildx@${{ env.RELEASE_NAME }}
+        run: |
+          make vendor
+        env:
+          VENDOR_MODULE: github.com/docker/buildx@${{ env.RELEASE_NAME }}
       -
         name: Create PR on docs repo
         uses: peter-evans/create-pull-request@a4f52f8033a6168103c2538976c07b467e8163bc

--- a/.github/workflows/docs-upstream.yml
+++ b/.github/workflows/docs-upstream.yml
@@ -37,6 +37,7 @@ jobs:
         uses: docker/bake-action@v4
         with:
           targets: update-docs
+          provenance: false
           set: |
             *.output=/tmp/buildx-docs
             *.cache-from=type=gha,scope=docs-yaml

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,8 +19,6 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-22.04
-    env:
-      GOLANGCI_LINT_MULTIPLATFORM: 1
     strategy:
       fail-fast: false
       matrix:
@@ -30,6 +28,12 @@ jobs:
           - validate-docs
           - validate-generated-files
     steps:
+      -
+        name: Prepare
+        run: |
+          if [ "$GITHUB_REPOSITORY" = "docker/buildx" ]; then
+            echo "GOLANGCI_LINT_MULTIPLATFORM=1" >> $GITHUB_ENV
+          fi
       -
         name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
* backport of https://github.com/docker/buildx/pull/2339

also backport docs changes related to https://github.com/docker/buildx/actions/runs/8254729582 (cc @dvdksn):
* https://github.com/docker/buildx/pull/2312
* https://github.com/docker/buildx/pull/2314