### PR TITLE
tests: refactor worker handling in sandbox

### DIFF
--- a/tests/bake.go
+++ b/tests/bake.go
@@ -641,8 +641,8 @@ target "default" {
 }
 
 func testBakeMultiExporters(t *testing.T, sb integration.Sandbox) {
-	if sb.Name() != "docker" {
-		t.Skip("skipping test for non-docker workers")
+	if !isDockerContainerWorker(sb) {
+		t.Skip("only testing with docker-container worker")
 	}
 
 	registry, err := sb.NewRegistry()
@@ -722,8 +722,8 @@ target "default" {
 }
 
 func testBakeLoadPush(t *testing.T, sb integration.Sandbox) {
-	if sb.Name() != "docker" {
-		t.Skip("skipping test for non-docker workers")
+	if !isDockerContainerWorker(sb) {
+		t.Skip("only testing with docker-container worker")
 	}
 
 	registry, err := sb.NewRegistry()

--- a/tests/create.go
+++ b/tests/create.go
@@ -26,8 +26,8 @@ var createTests = []func(t *testing.T, sb integration.Sandbox){
 }
 
 func testCreateMemoryLimit(t *testing.T, sb integration.Sandbox) {
-	if sb.Name() != "docker-container" {
-		t.Skip("only testing for docker-container driver")
+	if !isDockerContainerWorker(sb) {
+		t.Skip("only testing with docker-container worker")
 	}
 
 	var builderName string
@@ -45,8 +45,8 @@ func testCreateMemoryLimit(t *testing.T, sb integration.Sandbox) {
 }
 
 func testCreateRestartAlways(t *testing.T, sb integration.Sandbox) {
-	if sb.Name() != "docker-container" {
-		t.Skip("only testing for docker-container driver")
+	if !isDockerContainerWorker(sb) {
+		t.Skip("only testing with docker-container worker")
 	}
 
 	var builderName string

--- a/tests/imagetools.go
+++ b/tests/imagetools.go
@@ -22,8 +22,8 @@ var imagetoolsTests = []func(t *testing.T, sb integration.Sandbox){
 }
 
 func testImagetoolsCopyManifest(t *testing.T, sb integration.Sandbox) {
-	if sb.Name() != "docker-container" {
-		t.Skip("imagetools tests are not driver specific and only run on docker-container")
+	if !isDockerContainerWorker(sb) {
+		t.Skip("only testing with docker-container worker, imagetools only runs on docker-container")
 	}
 
 	dir := createDockerfile(t)
@@ -81,8 +81,8 @@ func testImagetoolsCopyManifest(t *testing.T, sb integration.Sandbox) {
 }
 
 func testImagetoolsCopyIndex(t *testing.T, sb integration.Sandbox) {
-	if sb.Name() != "docker-container" {
-		t.Skip("imagetools tests are not driver specific and only run on docker-container")
+	if !isDockerContainerWorker(sb) {
+		t.Skip("only testing with docker-container worker, imagetools only runs on docker-container")
 	}
 
 	dir := createDockerfile(t)
@@ -130,8 +130,8 @@ func testImagetoolsCopyIndex(t *testing.T, sb integration.Sandbox) {
 }
 
 func testImagetoolsInspectAndFilter(t *testing.T, sb integration.Sandbox) {
-	if sb.Name() != "docker-container" {
-		t.Skip("imagetools tests are not driver specific and only run on docker-container")
+	if !isDockerContainerWorker(sb) {
+		t.Skip("only testing with docker-container worker, imagetools only runs on docker-container")
 	}
 
 	dir := createDockerfile(t)
@@ -181,8 +181,8 @@ func testImagetoolsInspectAndFilter(t *testing.T, sb integration.Sandbox) {
 }
 
 func testImagetoolsAnnotation(t *testing.T, sb integration.Sandbox) {
-	if sb.Name() != "docker-container" {
-		t.Skip("imagetools tests are not driver specific and only run on docker-container")
+	if !isDockerContainerWorker(sb) {
+		t.Skip("only testing with docker-container worker, imagetools only runs on docker-container")
 	}
 
 	dir := createDockerfile(t)

--- a/tests/inspect.go
+++ b/tests/inspect.go
@@ -41,7 +41,7 @@ func testInspect(t *testing.T, sb integration.Sandbox) {
 	}
 
 	require.Equal(t, sb.Address(), name)
-	sbDriver, _, _ := strings.Cut(sb.Name(), "+")
+	sbDriver, _ := driverName(sb.Name())
 	require.Equal(t, sbDriver, driver)
 	if isDockerWorker(sb) {
 		require.NotEmpty(t, hostGatewayIP, "host-gateway-ip worker label should be set with docker driver")
@@ -51,8 +51,8 @@ func testInspect(t *testing.T, sb integration.Sandbox) {
 }
 
 func testInspectBuildkitdFlags(t *testing.T, sb integration.Sandbox) {
-	if sb.Name() != "docker-container" {
-		t.Skip("only testing for docker-container driver")
+	if !isDockerContainerWorker(sb) {
+		t.Skip("only testing with docker-container worker")
 	}
 
 	var builderName string
@@ -81,8 +81,8 @@ func testInspectBuildkitdFlags(t *testing.T, sb integration.Sandbox) {
 }
 
 func testInspectNetworkHostEntitlement(t *testing.T, sb integration.Sandbox) {
-	if sb.Name() != "docker-container" {
-		t.Skip("only testing for docker-container driver")
+	if !isDockerContainerWorker(sb) {
+		t.Skip("only testing with docker-container worker")
 	}
 
 	var builderName string

--- a/tests/integration.go
+++ b/tests/integration.go
@@ -71,7 +71,27 @@ func dockerCmd(sb integration.Sandbox, opts ...cmdOpt) *exec.Cmd {
 	return cmd
 }
 
+func isMobyWorker(sb integration.Sandbox) bool {
+	name, hasFeature := driverName(sb.Name())
+	return name == "docker" && !hasFeature
+}
+
 func isDockerWorker(sb integration.Sandbox) bool {
-	sbDriver, _, _ := strings.Cut(sb.Name(), "+")
-	return sbDriver == "docker"
+	name, _ := driverName(sb.Name())
+	return name == "docker"
+}
+
+func isDockerContainerWorker(sb integration.Sandbox) bool {
+	name, _ := driverName(sb.Name())
+	return name == "docker-container"
+}
+
+func driverName(sbName string) (string, bool) {
+	name := sbName
+	var hasFeature bool
+	if b, _, ok := strings.Cut(name, "+"); ok {
+		name = b
+		hasFeature = true
+	}
+	return name, hasFeature
 }

--- a/tests/ls.go
+++ b/tests/ls.go
@@ -34,7 +34,7 @@ func testLs(t *testing.T, sb integration.Sandbox) {
 		},
 	}
 
-	sbDriver, _, _ := strings.Cut(sb.Name(), "+")
+	sbDriver, _ := driverName(sb.Name())
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {

--- a/tests/rm.go
+++ b/tests/rm.go
@@ -21,8 +21,8 @@ var rmTests = []func(t *testing.T, sb integration.Sandbox){
 }
 
 func testRm(t *testing.T, sb integration.Sandbox) {
-	if sb.Name() != "docker-container" {
-		t.Skip("only testing for docker-container driver")
+	if !isDockerContainerWorker(sb) {
+		t.Skip("only testing with docker-container worker")
 	}
 
 	out, err := rmCmd(sb, withArgs("default"))
@@ -40,8 +40,8 @@ func testRm(t *testing.T, sb integration.Sandbox) {
 }
 
 func testRmMulti(t *testing.T, sb integration.Sandbox) {
-	if sb.Name() != "docker-container" {
-		t.Skip("only testing for docker-container driver")
+	if !isDockerContainerWorker(sb) {
+		t.Skip("only testing with docker-container worker")
 	}
 
 	var builderNames []string


### PR DESCRIPTION
carried from https://github.com/docker/buildx/pull/2322

Adds helpers to handle worker being used. This will be helpful with #2322 and #2307