### PR TITLE
driver: initialize tracer delegate in driver handle instead of individual plugins

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -158,7 +158,7 @@ func BuildWithResultHandler(ctx context.Context, nodes []builder.Node, opt map[s
 		return nil, errors.Wrapf(err, "no valid drivers found")
 	}
 
-	var noMobyDriver driver.Driver
+	var noMobyDriver *driver.DriverHandle
 	for _, n := range nodes {
 		if !n.Driver.IsMobyDriver() {
 			noMobyDriver = n.Driver
@@ -658,7 +658,7 @@ func BuildWithResultHandler(ctx context.Context, nodes []builder.Node, opt map[s
 	return resp, nil
 }
 
-func pushWithMoby(ctx context.Context, d driver.Driver, name string, l progress.SubLogger) error {
+func pushWithMoby(ctx context.Context, d *driver.DriverHandle, name string, l progress.SubLogger) error {
 	api := d.Config().DockerAPI
 	if api == nil {
 		return errors.Errorf("invalid empty Docker API reference") // should never happen
@@ -738,7 +738,7 @@ func pushWithMoby(ctx context.Context, d driver.Driver, name string, l progress.
 	return nil
 }
 
-func remoteDigestWithMoby(ctx context.Context, d driver.Driver, name string) (string, error) {
+func remoteDigestWithMoby(ctx context.Context, d *driver.DriverHandle, name string) (string, error) {
 	api := d.Config().DockerAPI
 	if api == nil {
 		return "", errors.Errorf("invalid empty Docker API reference") // should never happen

--- a/build/utils.go
+++ b/build/utils.go
@@ -105,7 +105,7 @@ func toBuildkitUlimits(inp *opts.UlimitOpt) (string, error) {
 	return strings.Join(ulimits, ","), nil
 }
 
-func notSupported(f driver.Feature, d driver.Driver, docs string) error {
+func notSupported(f driver.Feature, d *driver.DriverHandle, docs string) error {
 	return errors.Errorf(`%s is not supported for the %s driver.
 Switch to a different driver, or turn on the containerd image store, and try again.
 Learn more at %s`, f, d.Factory().Name(), docs)

--- a/driver/docker/driver.go
+++ b/driver/docker/driver.go
@@ -9,7 +9,6 @@ import (
 	"github.com/docker/buildx/driver"
 	"github.com/docker/buildx/util/progress"
 	"github.com/moby/buildkit/client"
-	"github.com/moby/buildkit/util/tracing/detect"
 	"github.com/pkg/errors"
 )
 
@@ -61,22 +60,14 @@ func (d *Driver) Dial(ctx context.Context) (net.Conn, error) {
 	return d.DockerAPI.DialHijack(ctx, "/grpc", "h2c", d.DialMeta)
 }
 
-func (d *Driver) Client(ctx context.Context) (*client.Client, error) {
-	opts := []client.ClientOpt{
+func (d *Driver) Client(ctx context.Context, opts ...client.ClientOpt) (*client.Client, error) {
+	opts = append([]client.ClientOpt{
 		client.WithContextDialer(func(context.Context, string) (net.Conn, error) {
 			return d.Dial(ctx)
 		}), client.WithSessionDialer(func(ctx context.Context, proto string, meta map[string][]string) (net.Conn, error) {
 			return d.DockerAPI.DialHijack(ctx, "/session", proto, meta)
 		}),
-	}
-
-	exp, _, err := detect.Exporter()
-	if err != nil {
-		return nil, err
-	}
-	if td, ok := exp.(client.TracerDelegate); ok {
-		opts = append(opts, client.WithTracerDelegate(td))
-	}
+	}, opts...)
 	return client.New(ctx, "", opts...)
 }
 

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -61,7 +61,7 @@ type Driver interface {
 	Stop(ctx context.Context, force bool) error
 	Rm(ctx context.Context, force, rmVolume, rmDaemon bool) error
 	Dial(ctx context.Context) (net.Conn, error)
-	Client(ctx context.Context) (*client.Client, error)
+	Client(ctx context.Context, opts ...client.ClientOpt) (*client.Client, error)
 	Features(ctx context.Context) map[Feature]bool
 	HostGatewayIP(ctx context.Context) (net.IP, error)
 	IsMobyDriver() bool

--- a/driver/manager.go
+++ b/driver/manager.go
@@ -9,6 +9,7 @@ import (
 
 	dockerclient "github.com/docker/docker/client"
 	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/util/tracing/detect"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"k8s.io/client-go/rest"
@@ -156,9 +157,26 @@ type DriverHandle struct {
 
 func (d *DriverHandle) Client(ctx context.Context) (*client.Client, error) {
 	d.once.Do(func() {
-		d.client, d.err = d.Driver.Client(ctx)
+		opts, err := d.getClientOptions()
+		if err != nil {
+			d.err = err
+			return
+		}
+		d.client, d.err = d.Driver.Client(ctx, opts...)
 	})
 	return d.client, d.err
+}
+
+func (d *DriverHandle) getClientOptions() ([]client.ClientOpt, error) {
+	exp, _, err := detect.Exporter()
+	if err != nil {
+		return nil, err
+	} else if td, ok := exp.(client.TracerDelegate); ok {
+		return []client.ClientOpt{
+			client.WithTracerDelegate(td),
+		}, nil
+	}
+	return nil, nil
 }
 
 func (d *DriverHandle) HistoryAPISupported(ctx context.Context) bool {


### PR DESCRIPTION
This refactors the driver handle to initialize the tracer delegate inside of the driver handle instead of the individual plugins.

This provides more uniformity to how the tracer delegate is created by allowing the driver handle to pass additional client options to the drivers when they create the client. It also avoids creating the tracer delegate client multiple times because the driver handle will only initialize the client once. This prevents some drivers, like the remote driver, from accidentally registering multiple clients as tracer delegates.

This is an alternative to https://github.com/docker/buildx/pull/2187 for fixing the multiple trace spans sent by the remote driver problem.