### PR TITLE
bake: git auth support for remote definitions

### DIFF
--- a/bake/remote.go
+++ b/bake/remote.go
@@ -4,6 +4,8 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"os"
+	"strings"
 
 	"github.com/docker/buildx/builder"
 	controllerapi "github.com/docker/buildx/controller/pb"
@@ -23,13 +25,34 @@ type Input struct {
 }
 
 func ReadRemoteFiles(ctx context.Context, nodes []builder.Node, url string, names []string, pw progress.Writer) ([]File, *Input, error) {
-	var session []session.Attachable
+	var sessions []session.Attachable
 	var filename string
+
 	st, ok := dockerui.DetectGitContext(url, false)
 	if ok {
-		ssh, err := controllerapi.CreateSSH([]*controllerapi.SSH{{ID: "default"}})
-		if err == nil {
-			session = append(session, ssh)
+		if ssh, err := controllerapi.CreateSSH([]*controllerapi.SSH{{
+			ID:    "default",
+			Paths: strings.Split(os.Getenv("BUILDX_BAKE_GIT_SSH"), ","),
+		}}); err == nil {
+			sessions = append(sessions, ssh)
+		}
+		var gitAuthSecrets []*controllerapi.Secret
+		if _, ok := os.LookupEnv("BUILDX_BAKE_GIT_AUTH_TOKEN"); ok {
+			gitAuthSecrets = append(gitAuthSecrets, &controllerapi.Secret{
+				ID:  llb.GitAuthTokenKey,
+				Env: "BUILDX_BAKE_GIT_AUTH_TOKEN",
+			})
+		}
+		if _, ok := os.LookupEnv("BUILDX_BAKE_GIT_AUTH_HEADER"); ok {
+			gitAuthSecrets = append(gitAuthSecrets, &controllerapi.Secret{
+				ID:  llb.GitAuthHeaderKey,
+				Env: "BUILDX_BAKE_GIT_AUTH_HEADER",
+			})
+		}
+		if len(gitAuthSecrets) > 0 {
+			if secrets, err := controllerapi.CreateSecrets(gitAuthSecrets); err == nil {
+				sessions = append(sessions, secrets)
+			}
 		}
 	} else {
 		st, filename, ok = dockerui.DetectHTTPContext(url)
@@ -59,7 +82,7 @@ func ReadRemoteFiles(ctx context.Context, nodes []builder.Node, url string, name
 
 	ch, done := progress.NewChannel(pw)
 	defer func() { <-done }()
-	_, err = c.Build(ctx, client.SolveOpt{Session: session, Internal: true}, "buildx", func(ctx context.Context, c gwclient.Client) (*gwclient.Result, error) {
+	_, err = c.Build(ctx, client.SolveOpt{Session: sessions, Internal: true}, "buildx", func(ctx context.Context, c gwclient.Client) (*gwclient.Result, error) {
 		def, err := st.Marshal(ctx)
 		if err != nil {
 			return nil, err

--- a/util/gitutil/testutilserve.go
+++ b/util/gitutil/testutilserve.go
@@ -10,10 +10,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func GitServeHTTP(c *Git, t testing.TB) (url string) {
+type gitServe struct {
+	token string
+}
+
+type GitServeOpt func(*gitServe)
+
+func WithAccessToken(token string) GitServeOpt {
+	return func(s *gitServe) {
+		s.token = token
+	}
+}
+
+func GitServeHTTP(c *Git, t testing.TB, opts ...GitServeOpt) (url string) {
 	t.Helper()
 	gitUpdateServerInfo(c, t)
 	ctx, cancel := context.WithCancel(context.TODO())
+
+	gs := &gitServe{}
+	for _, opt := range opts {
+		opt(gs)
+	}
 
 	ready := make(chan struct{})
 	done := make(chan struct{})
@@ -28,7 +45,25 @@ func GitServeHTTP(c *Git, t testing.TB) (url string) {
 	go func() {
 		mux := http.NewServeMux()
 		prefix := fmt.Sprintf("/%s/", name)
-		mux.Handle(prefix, http.StripPrefix(prefix, http.FileServer(http.Dir(dir))))
+
+		handler := func(next http.Handler) http.Handler {
+			var tokenChecked bool
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if gs.token != "" && !tokenChecked {
+					t.Logf("git access token to check: %q", gs.token)
+					user, pass, _ := r.BasicAuth()
+					t.Logf("basic auth: user=%q pass=%q", user, pass)
+					if pass != gs.token {
+						http.Error(w, "Unauthorized", http.StatusUnauthorized)
+						return
+					}
+					tokenChecked = true
+				}
+				next.ServeHTTP(w, r)
+			})
+		}
+
+		mux.Handle(prefix, handler(http.StripPrefix(prefix, http.FileServer(http.Dir(dir)))))
 		l, err := net.Listen("tcp", "localhost:0")
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
fixes #2360 

Adds support for Git auth when using remote bake definitions through `BUILDX_BAKE_GIT_AUTH_TOKEN` and `BUILDX_BAKE_GIT_AUTH_HEADER` envs var that will set `GIT_AUTH_TOKEN` and `GIT_AUTH_HEADER` secrets respectively, matching https://github.com/moby/buildkit/blob/ad5a64c68f20435c52a51db73ef9246d6a3feba6/client/llb/source.go#L270-L271

Also adds `BUILDX_BAKE_GIT_SSH` to be consistent so user can provide SSH sock paths.