### PR TITLE
driver: add ephemeral-storage options to kuberentes-driver

### DIFF
--- a/driver/kubernetes/factory.go
+++ b/driver/kubernetes/factory.go
@@ -133,10 +133,14 @@ func (f *factory) processDriverOpts(deploymentName string, namespace string, cfg
 			deploymentOpt.RequestsCPU = v
 		case "requests.memory":
 			deploymentOpt.RequestsMemory = v
+		case "requests.ephemeral-storage":
+			deploymentOpt.RequestsEphemeralStorage = v
 		case "limits.cpu":
 			deploymentOpt.LimitsCPU = v
 		case "limits.memory":
 			deploymentOpt.LimitsMemory = v
+		case "limits.ephemeral-storage":
+			deploymentOpt.LimitsEphemeralStorage = v
 		case "rootless":
 			deploymentOpt.Rootless, err = strconv.ParseBool(v)
 			if err != nil {

--- a/driver/kubernetes/manifest/manifest.go
+++ b/driver/kubernetes/manifest/manifest.go
@@ -32,16 +32,18 @@ type DeploymentOpt struct {
 	// files mounted at /etc/buildkitd
 	ConfigFiles map[string][]byte
 
-	Rootless          bool
-	NodeSelector      map[string]string
-	CustomAnnotations map[string]string
-	CustomLabels      map[string]string
-	Tolerations       []corev1.Toleration
-	RequestsCPU       string
-	RequestsMemory    string
-	LimitsCPU         string
-	LimitsMemory      string
-	Platforms         []v1.Platform
+	Rootless                 bool
+	NodeSelector             map[string]string
+	CustomAnnotations        map[string]string
+	CustomLabels             map[string]string
+	Tolerations              []corev1.Toleration
+	RequestsCPU              string
+	RequestsMemory           string
+	RequestsEphemeralStorage string
+	LimitsCPU                string
+	LimitsMemory             string
+	LimitsEphemeralStorage   string
+	Platforms                []v1.Platform
 }
 
 const (
@@ -205,6 +207,14 @@ func NewDeployment(opt *DeploymentOpt) (d *appsv1.Deployment, c []*corev1.Config
 		d.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory] = reqMemory
 	}
 
+	if opt.RequestsEphemeralStorage != "" {
+		reqEphemeralStorage, err := resource.ParseQuantity(opt.RequestsEphemeralStorage)
+		if err != nil {
+			return nil, nil, err
+		}
+		d.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceEphemeralStorage] = reqEphemeralStorage
+	}
+
 	if opt.LimitsCPU != "" {
 		limCPU, err := resource.ParseQuantity(opt.LimitsCPU)
 		if err != nil {
@@ -219,6 +229,14 @@ func NewDeployment(opt *DeploymentOpt) (d *appsv1.Deployment, c []*corev1.Config
 			return nil, nil, err
 		}
 		d.Spec.Template.Spec.Containers[0].Resources.Limits[corev1.ResourceMemory] = limMemory
+	}
+
+	if opt.LimitsEphemeralStorage != "" {
+		limEphemeralStorage, err := resource.ParseQuantity(opt.LimitsEphemeralStorage)
+		if err != nil {
+			return nil, nil, err
+		}
+		d.Spec.Template.Spec.Containers[0].Resources.Limits[corev1.ResourceEphemeralStorage] = limEphemeralStorage
 	}
 
 	return


### PR DESCRIPTION
fixes: #2369 

Adds options to set ephemeral storage requests/limits. 

If everything is ok, I think that the documentation could be updated too