### PR TITLE
handle json formatting for print

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -855,7 +855,9 @@ func printResult(f *controllerapi.PrintFunc, res map[string]string) error {
 	case "subrequests.describe":
 		return printValue(subrequests.PrintDescribe, subrequests.SubrequestsDescribeDefinition.Version, f.Format, res)
 	default:
-		if dt, ok := res["result.txt"]; ok {
+		if dt, ok := res["result.json"]; ok && f.Format == "json" {
+			fmt.Println(dt)
+		} else if dt, ok := res["result.txt"]; ok {
 			fmt.Print(dt)
 		} else {
 			log.Printf("%s %+v", f, res)


### PR DESCRIPTION
JSON formatting was handled by the known print names, but unclear why the default case was not handled as well if user requested JSON output.

@daghack 