### PR TITLE
build: fix stdin handling when building with controller

### DIFF
--- a/tests/build.go
+++ b/tests/build.go
@@ -69,11 +69,6 @@ func testBuild(t *testing.T, sb integration.Sandbox) {
 }
 
 func testBuildStdin(t *testing.T, sb integration.Sandbox) {
-	if isExperimental() {
-		// FIXME: https://github.com/docker/buildx/issues/2368
-		t.Skip("build from stdin hangs in experimental mode: https://github.com/docker/buildx/issues/2368")
-	}
-
 	dockerfile := []byte(`
 FROM busybox:latest AS base
 COPY foo /etc/foo


### PR DESCRIPTION
fixes #2368

When building in experimental mode we are using the controller which handles io forwarding operations, such as copying data from a reader to a writer and therefore locks stdin from being read in https://github.com/docker/buildx/blob/5c29e6e26eab79b47220af609ab36be4beb327fe/build/opt.go#L384

To fix this we can skip forwarding if invoke is not used as it seems to be handled only for this case. We also have a clear condition making it not possible to use a Dockerfile or context from stdin if invoke is used: https://github.com/docker/buildx/blob/0a3e5e5257dbecc6da1b501c93fee248fa17d0dd/commands/build.go#L397-L400

This should mitigate this issue but might need a deeper look as follow-up