### PR TITLE
build: mark information requests as internal

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -455,7 +455,7 @@ func BuildWithResultHandler(ctx context.Context, nodes []builder.Node, opt map[s
 					} else {
 						rr, err = c.Build(ctx, *so, "buildx", buildFunc, ch)
 					}
-					if desktop.BuildBackendEnabled() && node.Driver.HistoryAPISupported(ctx) {
+					if !so.Internal && desktop.BuildBackendEnabled() && node.Driver.HistoryAPISupported(ctx) {
 						if err != nil {
 							return &desktop.ErrorWithBuildRef{
 								Ref: buildRef,

--- a/build/opt.go
+++ b/build/opt.go
@@ -354,6 +354,11 @@ func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt Op
 		so.FrontendAttrs["ulimit"] = ulimits
 	}
 
+	// mark info request as internal
+	if opt.PrintFunc != nil {
+		so.Internal = true
+	}
+
 	return &so, releaseF, nil
 }
 


### PR DESCRIPTION
related to
* https://github.com/docker/buildx/pull/1100

similar to
* https://github.com/docker/buildx/pull/1954
* https://github.com/docker/buildx/pull/1961