### PR TITLE
docs: update link to Docker container driver

### DIFF
--- a/docs/manuals/drivers/docker-container.md
+++ b/docs/manuals/drivers/docker-container.md
@@ -1,3 +1,3 @@
 # Docker container driver
 
-This page has moved to [Docker Docs website](https://docs.docker.com/build/building/drivers/docker-container)
+This page has moved to [Docker Docs website](https://docs.docker.com/build/drivers/docker-container)


### PR DESCRIPTION
The manual for the Docker container build driver has moved permanently:
* from https://docs.docker.com/build/building/drivers/docker-container
* to https://docs.docker.com/build/drivers/docker-container/