### PR TITLE
look for stdout instead of stderr for plain output

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -309,9 +309,7 @@ func runBuild(ctx context.Context, dockerCli command.Cli, options buildOptions) 
 
 	var term bool
 	if _, err := console.ConsoleFromFile(os.Stdout); err == nil {
-		if _, exists := os.LookupEnv("NO_COLOR"); !exists {
-			term = true
-		}
+		term = true
 	}
 	attributes := buildMetricAttributes(dockerCli, b, &options)
 


### PR DESCRIPTION
make the primary decision based on 'stdout is redictected' instead of stderr; like many software.
e.g. `docker build ... | tee` should be enough to make it realize term is a nay instead of `docker build ... 2>&1 | tee`.