### PR TITLE
ci(validate): fix GOLANGCI_LINT_MULTIPLATFORM type for multiplatform lint

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -8,7 +8,7 @@ variable "DESTDIR" {
   default = "./bin"
 }
 variable "GOLANGCI_LINT_MULTIPLATFORM" {
-  default = null
+  default = ""
 }
 
 # Special target: https://github.com/docker/metadata-action#bake-definition
@@ -35,7 +35,7 @@ target "lint" {
   inherits = ["_common"]
   dockerfile = "./hack/dockerfiles/lint.Dockerfile"
   output = ["type=cacheonly"]
-  platforms = GOLANGCI_LINT_MULTIPLATFORM != null ? [
+  platforms = GOLANGCI_LINT_MULTIPLATFORM != "" ? [
     "darwin/amd64",
     "darwin/arm64",
     "linux/amd64",


### PR DESCRIPTION
related to
* https://github.com/docker/buildx/pull/2439
* https://github.com/docker/buildx/pull/2166
* https://github.com/docker/buildx/pull/2339

`GOLANGCI_LINT_MULTIPLATFORM != null` will always be true in our bake definition as we set it to "1" or an empty string in https://github.com/docker/buildx/blob/1d88c4b169a298c3d0f9eb41393582f25dace456/.github/workflows/validate.yml#L37