### PR TITLE
Add stale issue and label actions workflows

### DIFF
--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -1,0 +1,91 @@
+# Configuration for Label Actions - https://github.com/dessant/label-actions
+
+# When a discussion is resolved, lock the discussion
+'status/resolved':
+  discussions:
+    close: true
+    close-reason: 'resolved'
+    lock: true
+
+# Request more information from the author
+'auto/needs-more-info':
+  comment: >
+    :wave: @{issue-author}, please provide the requested information.
+  issues:
+    label: 
+      - 'status/needs-more-info' 
+  prs:
+    label: 
+      - 'status/needs-more-info' 
+
+# Thank the author for their response, remove auto-labels
+'auto/got-info':
+  comment: >
+    :wave: @{issue-author}, thank you for your response!
+  issues:
+    unlabel: 
+      - 'auto/needs-more-info'
+      - 'status/needs-more-info'
+  prs:
+    unlabel: 
+      - 'auto/needs-more-info'
+      - 'status/needs-more-info'
+
+# Comment that the issue will be transferred to another repository
+'auto/transfer':
+  comment: >
+    :wave: @{issue-author}, this issue will be transferred to another repository.
+  lock: true
+  lock-reason: 'off-topic'
+  issues:
+    label: 
+      - 'needs/transfer'
+      - 'status/wontfix'
+
+# Thank the author for their contribution
+'auto/thank-you':
+  comment: >
+    :wave: @{issue-author}, thank you for your contribution!
+
+# Mark issue for conversion to discussion
+'auto/make-discussion':
+  comment: >
+    :wave: @{issue-author}, this issue will be converted to a discussion. If you think this was a mistake, please let us know.
+  issues:
+    label: 
+      - 'needs/convert-to-discussion'
+
+# Label as duplicate, prompt author to search
+'auto/duplicate':
+  comment: >
+    :wave: @{issue-author}, this item appears to be a duplicate of a previous one. Please check if it already exists and add any additional information as a comment.
+  issues:
+    label: 'kind/duplicate'
+  prs:
+    label: 'kind/duplicate'
+
+# Prompt author to provide a minimal reproduction
+'auto/needs-reproduction':
+  comment: >
+    :wave: @{issue-author}, please provide a minimal reproduction of the issue.
+  issues:
+    label: 
+      - 'needs/reproduction'
+      - 'status/blocked'
+  prs:
+    label: 
+      - 'needs/reproduction'
+      - 'status/blocked'
+
+# Use template
+'auto/use-template':
+  comment: >
+    :wave: @{issue-author}, please use one the provided templates.
+  issues:
+    label: 
+      - 'needs/template'
+      - 'status/blocked'
+  prs:
+    label: 
+      - 'needs/template'
+      - 'status/blocked'

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,0 +1,30 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 14
+          days-before-issue-close: 7
+          stale-issue-label: 'stale'
+          exempt-issue-labels: 'not-stale'
+          stale-issue-message: 'This issue is stale because it has been open 14 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 21 days with no activity.'
+          days-before-pr-stale: 14
+          days-before-pr-close: 7
+          stale-pr-message: 'This PR is stale because it has been open 14 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          close-pr-message: 'This PR was closed because it has been stalled for 21 days with no activity.'
+          stale-pr-label: 'stale'
+          exempt-pr-labels: 'not-stale'
+          exempt-all-pr-milestones: true
+          exempt-pr-assignees: true
+          start-date: '2024-05-01T00:00:00+0000'

--- a/.github/workflows/label-actions.yml
+++ b/.github/workflows/label-actions.yml
@@ -1,0 +1,21 @@
+name: 'Label Actions'
+
+on:
+  issues:
+    types: [labeled, unlabeled]
+  pull_request_target:
+    types: [labeled, unlabeled]
+  discussion:
+    types: [labeled, unlabeled]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  discussions: write
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/label-actions@v4


### PR DESCRIPTION
This PR adds in a couple of GitHub Actions to support common triage/support activities and help ensure stale issues are dealt with in a timely manner.

## Label actions

Use [label actions](https://github.com/marketplace/actions/label-actions) to automate responses, `@` authors, and auto-label for some common use cases. Most new labels would fall under the `auto/*` group and apply `status/*` labels as appropriate.

## Stale issues

Automatically nudge contributors if issues or pull requests have gone stale after a set number of days and close after a configured number of days post-nudge. As initially configured, the first prompt would occur after 14 days, with closure 7 days after the prompt for a total time of 21 days before closure.