### PR TITLE
Fix k8s driver with certs cannot boot

### DIFF
--- a/driver/kubernetes/manifest/manifest.go
+++ b/driver/kubernetes/manifest/manifest.go
@@ -148,13 +148,13 @@ func NewDeployment(opt *DeploymentOpt) (d *appsv1.Deployment, c []*corev1.Config
 			Data: cfg.files,
 		}
 
-		d.Spec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{{
+		d.Spec.Template.Spec.Containers[0].VolumeMounts = append(d.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
 			Name:      cfg.name,
 			MountPath: path.Join("/etc/buildkit", cfg.path),
-		}}
+		})
 
-		d.Spec.Template.Spec.Volumes = []corev1.Volume{{
-			Name: "config",
+		d.Spec.Template.Spec.Volumes = append(d.Spec.Template.Spec.Volumes, corev1.Volume{
+			Name: cfg.name,
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
@@ -162,7 +162,7 @@ func NewDeployment(opt *DeploymentOpt) (d *appsv1.Deployment, c []*corev1.Config
 					},
 				},
 			},
-		}}
+		})
 		c = append(c, cc)
 	}
 


### PR DESCRIPTION
When a self-signed certificate is specified in `buildkitd.toml`, the current implementation registers the certificate as a `ConfigMap`, but the `volumes` and `volumeMounts` in `Deployment` are incorrect, so the `Deploymetnt` cannot start.

This fixes #1800.