### PR TITLE
prune: allow negative and prefix filters

### DIFF
--- a/commands/prune.go
+++ b/commands/prune.go
@@ -195,6 +195,8 @@ func toBuildkitPruneInfo(f filters.Args) (*client.PruneInfo, error) {
 		case 1:
 			if filterKey == "id" {
 				filters = append(filters, filterKey+"~="+values[0])
+			} else if strings.HasSuffix(filterKey, "!") || strings.HasSuffix(filterKey, "~") {
+				filters = append(filters, filterKey+"="+values[0])
 			} else {
 				filters = append(filters, filterKey+"=="+values[0])
 			}


### PR DESCRIPTION
This allows negative prune filters, eg. `docker buildx prune --filter 'type!=exec.cachemount'`

The patch slightly abuses how the `docker/api/types/filters` package can't understand these separators but alternative would have been to create another package that is a mix of Docker and Containerd filter style.