### PR TITLE
build: loadInputs: remove redundant checks for hasTag, hasDigest

### DIFF
--- a/build/opt.go
+++ b/build/opt.go
@@ -500,7 +500,6 @@ func loadInputs(ctx context.Context, d *driver.DriverHandle, inp Inputs, addVCSL
 			localPath, tag, hasTag := strings.Cut(localPath, ":")
 			if !hasTag {
 				tag = "latest"
-				hasTag = true
 			}
 			idx := ociindex.NewStoreIndex(localPath)
 			if !hasDigest {
@@ -543,10 +542,7 @@ func loadInputs(ctx context.Context, d *driver.DriverHandle, inp Inputs, addVCSL
 			}
 			target.OCIStores[storeName] = store
 
-			layout := "oci-layout://" + storeName
-			if hasTag {
-				layout += ":" + tag
-			}
+			layout := "oci-layout://" + storeName + ":" + tag
 			if hasDigest {
 				layout += "@" + dig
 			}

--- a/build/opt.go
+++ b/build/opt.go
@@ -542,12 +542,7 @@ func loadInputs(ctx context.Context, d *driver.DriverHandle, inp Inputs, addVCSL
 			}
 			target.OCIStores[storeName] = store
 
-			layout := "oci-layout://" + storeName + ":" + tag
-			if hasDigest {
-				layout += "@" + dig
-			}
-
-			target.FrontendAttrs["context:"+k] = layout
+			target.FrontendAttrs["context:"+k] = "oci-layout://" + storeName + ":" + tag + "@" + dig
 			continue
 		}
 		st, err := os.Stat(v.Path)


### PR DESCRIPTION
### build: loadInputs: remove redundant check for hasTag

hasTag was always true as it was set to "true" when missing, in which case
the default (`:latest`) tag was applied; https://github.com/docker/buildx/blob/37c4ff09448f30204b141a757d46ccc11982762e/build/opt.go#L500-L504

### build: loadInputs: remove redundant check for hasDigest

hasDigest would always be true when reaching this code, because the function
would return with an error when failing to resolve the digest; https://github.com/docker/buildx/blob/37c4ff09448f30204b141a757d46ccc11982762e/build/opt.go#L528-L530
