### PR TITLE
Add `--prefer-index` flag for`imagetools create` on a single source

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -608,7 +608,7 @@ func BuildWithResultHandler(ctx context.Context, nodes []builder.Node, opt map[s
 								}
 							}
 
-							dt, desc, err := itpull.Combine(ctx, srcs, nil)
+							dt, desc, err := itpull.Combine(ctx, srcs, nil, false)
 							if err != nil {
 								return err
 							}

--- a/commands/imagetools/create.go
+++ b/commands/imagetools/create.go
@@ -29,6 +29,7 @@ type createOptions struct {
 	dryrun       bool
 	actionAppend bool
 	progress     string
+	preferIndex  bool
 }
 
 func runCreate(ctx context.Context, dockerCli command.Cli, in createOptions, args []string) error {
@@ -153,7 +154,7 @@ func runCreate(ctx context.Context, dockerCli command.Cli, in createOptions, arg
 		}
 	}
 
-	dt, desc, err := r.Combine(ctx, srcs, in.annotations)
+	dt, desc, err := r.Combine(ctx, srcs, in.annotations, in.preferIndex)
 	if err != nil {
 		return err
 	}
@@ -283,6 +284,7 @@ func createCmd(dockerCli command.Cli, opts RootOptions) *cobra.Command {
 	flags.BoolVar(&options.actionAppend, "append", false, "Append to existing manifest")
 	flags.StringVar(&options.progress, "progress", "auto", `Set type of progress output ("auto", "plain", "tty"). Use plain to show container output`)
 	flags.StringArrayVarP(&options.annotations, "annotation", "", []string{}, "Add annotation to the image")
+	flags.BoolVar(&options.preferIndex, "prefer-index", true, "When only a single source is specified, prefer outputting an image index or manifest list instead of performing a carbon copy")
 
 	return cmd
 }

--- a/docs/reference/buildx_imagetools_create.md
+++ b/docs/reference/buildx_imagetools_create.md
@@ -9,15 +9,16 @@ Create a new image based on source images
 
 ### Options
 
-| Name                             | Type          | Default | Description                                                                              |
-|:---------------------------------|:--------------|:--------|:-----------------------------------------------------------------------------------------|
-| [`--annotation`](#annotation)    | `stringArray` |         | Add annotation to the image                                                              |
-| [`--append`](#append)            |               |         | Append to existing manifest                                                              |
-| [`--builder`](#builder)          | `string`      |         | Override the configured builder instance                                                 |
-| [`--dry-run`](#dry-run)          |               |         | Show final image instead of pushing                                                      |
-| [`-f`](#file), [`--file`](#file) | `stringArray` |         | Read source descriptor from file                                                         |
-| `--progress`                     | `string`      | `auto`  | Set type of progress output (`auto`, `plain`, `tty`). Use plain to show container output |
-| [`-t`](#tag), [`--tag`](#tag)    | `stringArray` |         | Set reference for new image                                                              |
+| Name                             | Type          | Default | Description                                                                                                                   |
+|:---------------------------------|:--------------|:--------|:------------------------------------------------------------------------------------------------------------------------------|
+| [`--annotation`](#annotation)    | `stringArray` |         | Add annotation to the image                                                                                                   |
+| [`--append`](#append)            |               |         | Append to existing manifest                                                                                                   |
+| [`--builder`](#builder)          | `string`      |         | Override the configured builder instance                                                                                      |
+| [`--dry-run`](#dry-run)          |               |         | Show final image instead of pushing                                                                                           |
+| [`-f`](#file), [`--file`](#file) | `stringArray` |         | Read source descriptor from file                                                                                              |
+| `--prefer-index`                 | `bool`        | `true`  | When only a single source is specified, prefer outputting an image index or manifest list instead of performing a carbon copy |
+| `--progress`                     | `string`      | `auto`  | Set type of progress output (`auto`, `plain`, `tty`). Use plain to show container output                                      |
+| [`-t`](#tag), [`--tag`](#tag)    | `stringArray` |         | Set reference for new image                                                                                                   |
 
 
 <!---MARKER_GEN_END-->
@@ -26,8 +27,13 @@ Create a new image based on source images
 
 Create a new manifest list based on source manifests. The source manifests can
 be manifest lists or single platform distribution manifests and must already
-exist in the registry where the new manifest is created. If only one source is
-specified, create performs a carbon copy.
+exist in the registry where the new manifest is created.
+
+If only one source is specified and that source is a manifest list or image index,
+create performs a carbon copy. If one source is specified and that source is *not*
+a list or index, the output will be a manifest list, however you can disable this
+behavior with `--prefer-index=false` which attempts to preserve the source manifest
+format in the output.
 
 ## Examples
 

--- a/tests/imagetools.go
+++ b/tests/imagetools.go
@@ -140,6 +140,24 @@ func testImagetoolsCopyIndex(t *testing.T, sb integration.Sandbox) {
 	for i := range idx.Manifests {
 		require.Equal(t, idx.Manifests[i].Digest, idx2.Manifests[i].Digest)
 	}
+
+	cmd = buildxCmd(sb, withArgs("imagetools", "create", "--prefer-index=false", "-t", target2+"-still-index", target))
+	dt, err = cmd.CombinedOutput()
+	require.NoError(t, err, string(dt))
+
+	cmd = buildxCmd(sb, withArgs("imagetools", "inspect", target2+"-still-index", "--raw"))
+	dt, err = cmd.CombinedOutput()
+	require.NoError(t, err, string(dt))
+
+	var idx3 ocispecs.Index
+	err = json.Unmarshal(dt, &idx3)
+	require.NoError(t, err)
+	require.Equal(t, images.MediaTypeDockerSchema2ManifestList, idx3.MediaType)
+
+	require.Equal(t, len(idx.Manifests), len(idx3.Manifests))
+	for i := range idx.Manifests {
+		require.Equal(t, idx.Manifests[i].Digest, idx3.Manifests[i].Digest)
+	}
 }
 
 func testImagetoolsInspectAndFilter(t *testing.T, sb integration.Sandbox) {

--- a/tests/imagetools.go
+++ b/tests/imagetools.go
@@ -61,23 +61,7 @@ func testImagetoolsCopyManifest(t *testing.T, sb integration.Sandbox) {
 	var idx2 ocispecs.Index
 	err = json.Unmarshal(dt, &idx2)
 	require.NoError(t, err)
-	require.Equal(t, images.MediaTypeDockerSchema2ManifestList, idx2.MediaType)
-	require.Equal(t, 1, len(idx2.Manifests))
-
-	cmd = buildxCmd(sb, withArgs("imagetools", "inspect", target2+"@"+string(idx2.Manifests[0].Digest), "--raw"))
-	dt, err = cmd.CombinedOutput()
-	require.NoError(t, err, string(dt))
-
-	var mfst2 ocispecs.Manifest
-	err = json.Unmarshal(dt, &mfst2)
-	require.NoError(t, err)
-	require.Equal(t, images.MediaTypeDockerSchema2Manifest, mfst2.MediaType)
-
-	require.Equal(t, mfst.Config.Digest, mfst2.Config.Digest)
-	require.Equal(t, len(mfst.Layers), len(mfst2.Layers))
-	for i := range mfst.Layers {
-		require.Equal(t, mfst.Layers[i].Digest, mfst2.Layers[i].Digest)
-	}
+	require.Equal(t, images.MediaTypeDockerSchema2Manifest, idx2.MediaType)
 }
 
 func testImagetoolsCopyIndex(t *testing.T, sb integration.Sandbox) {
@@ -161,7 +145,15 @@ func testImagetoolsInspectAndFilter(t *testing.T, sb integration.Sandbox) {
 	mfst = idx.Manifests[1]
 	require.Equal(t, "linux/arm64", platforms.Format(*mfst.Platform))
 
-	// create amd64 only image
+	cmd = buildxCmd(sb, withArgs("imagetools", "inspect", target+"@"+string(idx.Manifests[1].Digest), "--raw"))
+	dt, err = cmd.CombinedOutput()
+	require.NoError(t, err, string(dt))
+
+	var armMfst ocispecs.Manifest
+	err = json.Unmarshal(dt, &armMfst)
+	require.NoError(t, err)
+
+	// create arm64 only image
 	cmd = buildxCmd(sb, withArgs("imagetools", "create", "-t", target+"-arm64", target+"@"+string(idx.Manifests[1].Digest)))
 	dt, err = cmd.CombinedOutput()
 	require.NoError(t, err, string(dt))
@@ -170,14 +162,12 @@ func testImagetoolsInspectAndFilter(t *testing.T, sb integration.Sandbox) {
 	dt, err = cmd.CombinedOutput()
 	require.NoError(t, err, string(dt))
 
-	var idx2 ocispecs.Index
+	var idx2 ocispecs.Manifest
 	err = json.Unmarshal(dt, &idx2)
 	require.NoError(t, err)
 
-	require.Equal(t, 1, len(idx2.Manifests))
-
-	require.Equal(t, idx.Manifests[1].Digest, idx2.Manifests[0].Digest)
-	require.Equal(t, platforms.Format(*idx.Manifests[1].Platform), platforms.Format(*idx2.Manifests[0].Platform))
+	require.Equal(t, armMfst.Config.Digest, idx2.Config.Digest)
+	require.Equal(t, armMfst.MediaType, idx2.MediaType)
 }
 
 func testImagetoolsAnnotation(t *testing.T, sb integration.Sandbox) {

--- a/util/imagetools/create.go
+++ b/util/imagetools/create.go
@@ -80,12 +80,15 @@ func (r *Resolver) Combine(ctx context.Context, srcs []*Source, ann []string, pr
 	// on single source, return original bytes
 	if len(srcs) == 1 && len(ann) == 0 {
 		switch srcs[0].Desc.MediaType {
-		case images.MediaTypeDockerSchema2Manifest:
+		// if the source is already an image index or manifest list, there is no need to consider the value
+		// of preferIndex since if set to true then the source is already in the preferred format, and if false
+		// it doesn't matter since we're not going to split it into separate manifests
+		case images.MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex:
+			return dts[0], srcs[0].Desc, nil
+		default:
 			if !preferIndex {
 				return dts[0], srcs[0].Desc, nil
 			}
-		case images.MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex:
-			return dts[0], srcs[0].Desc, nil
 		}
 	}
 

--- a/util/imagetools/create.go
+++ b/util/imagetools/create.go
@@ -79,7 +79,7 @@ func (r *Resolver) Combine(ctx context.Context, srcs []*Source, ann []string) ([
 
 	// on single source, return original bytes
 	if len(srcs) == 1 && len(ann) == 0 {
-		if mt := srcs[0].Desc.MediaType; mt == images.MediaTypeDockerSchema2ManifestList || mt == ocispec.MediaTypeImageIndex {
+		if mt := srcs[0].Desc.MediaType; mt == images.MediaTypeDockerSchema2ManifestList || mt == images.MediaTypeDockerSchema2Manifest || mt == ocispec.MediaTypeImageIndex {
 			return dts[0], srcs[0].Desc, nil
 		}
 	}

--- a/util/imagetools/create.go
+++ b/util/imagetools/create.go
@@ -29,7 +29,7 @@ type Source struct {
 	Ref  reference.Named
 }
 
-func (r *Resolver) Combine(ctx context.Context, srcs []*Source, ann []string) ([]byte, ocispec.Descriptor, error) {
+func (r *Resolver) Combine(ctx context.Context, srcs []*Source, ann []string, preferIndex bool) ([]byte, ocispec.Descriptor, error) {
 	eg, ctx := errgroup.WithContext(ctx)
 
 	dts := make([][]byte, len(srcs))
@@ -79,7 +79,12 @@ func (r *Resolver) Combine(ctx context.Context, srcs []*Source, ann []string) ([
 
 	// on single source, return original bytes
 	if len(srcs) == 1 && len(ann) == 0 {
-		if mt := srcs[0].Desc.MediaType; mt == images.MediaTypeDockerSchema2ManifestList || mt == images.MediaTypeDockerSchema2Manifest || mt == ocispec.MediaTypeImageIndex {
+		switch srcs[0].Desc.MediaType {
+		case images.MediaTypeDockerSchema2Manifest:
+			if !preferIndex {
+				return dts[0], srcs[0].Desc, nil
+			}
+		case images.MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex:
 			return dts[0], srcs[0].Desc, nil
 		}
 	}


### PR DESCRIPTION
- Fixes issue #2481 
- I updated the tests that were affected by this change to test the new logic, however there were some tests in the repo that seem to have already been failing before I made any changes, so the few tests that are failing shouldn't have anything to do with my changes
- As a response to comments below, the default behavior isn't being changed -- the new logic is now behind the flag `--prefer-index=false`
- As a response to the comments below, I removed the mediaType check that I originally just added to because I can't really see a reason for it at this point
- Updated docs