### PR TITLE
Add stale issue and PR labeler workflows

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,104 @@
+
+# Add 'area/project' label to changes in basic project documentation and .github folder, excluding .github/workflows
+area/project:
+- all:
+  - changed-files:
+    - any-glob-to-any-file: 
+      - .github/**
+      - LICENSE
+      - AUTHORS
+      - MAINTAINERS
+      - PROJECT.md
+      - README.md
+      - .gitignore
+      - codecov.yml
+    - all-globs-to-all-files: '!.github/workflows/*'
+
+# Add 'area/github-actions' label to changes in the .github/workflows folder
+area/ci:
+  - changed-files:
+    - any-glob-to-any-file: '.github/workflows/**'
+
+# Add 'area/bake' label to changes in the bake
+area/bake:
+  - changed-files:
+    - any-glob-to-any-file: 'bake/**'
+
+# Add 'area/bake/compose' label to changes in the bake+compose
+area/bake/compose:
+  - changed-files:
+    - any-glob-to-any-file:
+      - bake/compose.go
+      - bake/compose_test.go
+
+# Add 'area/build' label to changes in build files
+area/build:
+  - changed-files:
+    - any-glob-to-any-file: 'build/**'
+
+# Add 'area/builder' label to changes in builder files
+area/builder:
+  - changed-files:
+    - any-glob-to-any-file: 'builder/**'
+
+# Add 'area/cli' label to changes in the CLI
+area/cli:
+  - changed-files:
+    - any-glob-to-any-file: 
+      - cmd/**
+      - commands/**
+
+# Add 'area/controller' label to changes in the controller
+area/controller:
+  - changed-files:
+    - any-glob-to-any-file: 'controller/**'
+
+# Add 'area/docs' label to markdown files in the docs folder
+area/docs:
+  - changed-files:
+    - any-glob-to-any-file: 'docs/**/*.md'
+
+# Add 'area/dependencies' label to changes in go dependency files
+area/dependencies:
+  - changed-files:
+    - any-glob-to-any-file:
+      - go.mod
+      - go.sum
+      - vendor/**
+
+# Add 'area/driver' label to changes in the driver folder
+area/driver:
+  - changed-files:
+    - any-glob-to-any-file: 'driver/**'
+
+# Add 'area/driver/docker' label to changes in the docker driver
+area/driver/docker:
+  - changed-files:
+    - any-glob-to-any-file: 'driver/docker/**'
+
+# Add 'area/driver/docker-container' label to changes in the docker-container driver
+area/driver/docker-container:
+  - changed-files:
+    - any-glob-to-any-file: 'driver/docker-container/**'
+
+# Add 'area/driver/kubernetes' label to changes in the kubernetes driver
+area/driver/kubernetes:
+  - changed-files:
+    - any-glob-to-any-file: 'driver/kubernetes/**'
+
+# Add 'area/driver/remote' label to changes in the remote driver
+area/driver/remote:
+  - changed-files:
+    - any-glob-to-any-file: 'driver/remote/**'
+
+# Add 'area/hack' label to changes in the hack folder
+area/hack:
+  - changed-files:
+    - any-glob-to-any-file: 'hack/**'
+
+# Add 'area/tests' label to changes in test files
+area/tests:
+  - changed-files:
+    - any-glob-to-any-file: 
+      - tests/**
+      - '**/*_test.go'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,19 @@
+name: labeler
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request_target:
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Run
+        uses: actions/labeler@v5

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,17 @@
 name: stale
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Run in debug mode without actually performing any operations on the repo.'
+        required: false
+        type: boolean
+        default: true
   schedule:
     - cron: '30 1 * * *'
 
@@ -34,3 +45,4 @@ jobs:
           # General configuration
           exempt-milestones: true
           start-date: '2024-05-01T00:00:00+0000'
+          debug-only: ${{ inputs.dry-run }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,9 +19,9 @@ jobs:
           ## Issue configuration
           days-before-issue-stale: 20
           days-before-issue-close: 10
-          stale-issue-label: 'stale'
-          close-issue-label: 'rotten'
-          exempt-issue-labels: 'frozen'
+          stale-issue-label: 'status/stale'
+          close-issue-label: 'status/rotten'
+          exempt-issue-labels: 'status/frozen'
           stale-issue-message: 'This issue is stale because it has been open 20 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
           close-issue-message: 'This issue was closed because it has been stalled for 30 days with no activity.'
           # Pull request configuration
@@ -29,9 +29,9 @@ jobs:
           days-before-pr-close: 10
           stale-pr-message: 'This PR is stale because it has been open 20 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
           close-pr-message: 'This PR was closed because it has been stalled for 30 days with no activity.'
-          stale-pr-label: 'stale'
-          close-pr-label: 'rotten'
-          exempt-pr-labels: 'frozen'
+          stale-pr-label: 'status/stale'
+          close-pr-label: 'status/rotten'
+          exempt-pr-labels: 'status/frozen'
           # General configuration
           exempt-milestones: true
           start-date: '2024-05-01T00:00:00+0000'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,37 @@
+name: stale
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Run
+        uses: actions/stale@v9
+        with:
+          ## Issue configuration
+          days-before-issue-stale: 20
+          days-before-issue-close: 10
+          stale-issue-label: 'stale'
+          close-issue-label: 'rotten'
+          exempt-issue-labels: 'frozen'
+          stale-issue-message: 'This issue is stale because it has been open 20 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 30 days with no activity.'
+          # Pull request configuration
+          days-before-pr-stale: 20
+          days-before-pr-close: 10
+          stale-pr-message: 'This PR is stale because it has been open 20 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          close-pr-message: 'This PR was closed because it has been stalled for 30 days with no activity.'
+          stale-pr-label: 'stale'
+          close-pr-label: 'rotten'
+          exempt-pr-labels: 'frozen'
+          # General configuration
+          exempt-milestones: true
+          start-date: '2024-05-01T00:00:00+0000'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,13 +4,12 @@ on:
   schedule:
     - cron: '30 1 * * *'
 
-permissions:
-  issues: write
-  pull-requests: write
-
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       -
         name: Run


### PR DESCRIPTION
This PR adds [**Close Stale Issues**](https://github.com/marketplace/actions/close-stale-issues#exempt-issue-labels) and [**PR Labeler**](https://github.com/marketplace/actions/labeler) action workflows. Durations for stale item comments and closure are initial suggestions.

A first attempt was made in a [previous PR](https://github.com/docker/buildx/pull/2450) that had great comments (thanks @crazy-max and @thaJeztah). This iteration drops the 3rd-party auto-labeler and strictly focuses on official GitHub actions. 

## Goals

- Encourage timely processing of Issues and PRs
- Automatically identify areas being modified by a PR (slight toil reduction, faster binning, may yield insights over time).

## Close Stale Issues

> Warns and then closes issues and PRs that have had no activity for a specified amount of time.

### General

The configuration as proposed will exempt Issues and PRs that have been assigned milestones (even arbitrarily long ones such `v-future`). In addition, the workflow would process only items created after the `start-date`. We can adjust this date as desired. There is also an option to exempt items that have been assigned to a user.

```yaml
exempt-milestones: true
start-date: '2024-05-01T00:00:00+0000'
```

### Issues

Notable [configuration options](https://github.com/marketplace/actions/close-stale-issues#all-options)

```yaml
# durations before stale and close actions are taken
days-before-issue-stale: <integer>
days-before-issue-close: <integer>
# labels applied as the issue transitions from active -> stale -> closed
stale-issue-label: 'stale' 
close-issue-label: 'rotten'
# labels that can be applied to avoid stale processing
exempt-issue-labels: 'frozen'
```

### Pull Requests

Notable [configuration options](https://github.com/marketplace/actions/close-stale-issues#all-options)

```yaml
# durations before stale and close actions are taken
days-before-pr-stale: <integer>
days-before-pr-close: <integer>
# labels applied as the issue transitions from active -> stale -> closed
stale-pr-label: 'stale'
close-pr-label: 'rotten'
# labels that can be applied to avoid stale processing
exempt-pr-labels: 'frozen'
```

## Pull Request Labeler

> Automatically label new pull requests based on the paths of files being changed or the branch name.

At present, this is primarily applying `area/*` labels but can be extended if it helps.