### PR TITLE
k8s: opt to customize timeout during deployment

### DIFF
--- a/driver/kubernetes/manifest/manifest.go
+++ b/driver/kubernetes/manifest/manifest.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/docker/buildx/util/platformutil"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -15,12 +16,13 @@ import (
 )
 
 type DeploymentOpt struct {
-	Namespace          string
-	Name               string
-	Image              string
-	Replicas           int
-	ServiceAccountName string
-	SchedulerName      string
+	Namespace           string
+	Name                string
+	Image               string
+	Replicas            int
+	ProvisioningTimeout time.Duration
+	ServiceAccountName  string
+	SchedulerName       string
 
 	// Qemu
 	Qemu struct {

--- a/driver/kubernetes/manifest/manifest.go
+++ b/driver/kubernetes/manifest/manifest.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"path"
 	"strings"
-	"time"
 
 	"github.com/docker/buildx/util/platformutil"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -16,13 +15,12 @@ import (
 )
 
 type DeploymentOpt struct {
-	Namespace           string
-	Name                string
-	Image               string
-	Replicas            int
-	ProvisioningTimeout time.Duration
-	ServiceAccountName  string
-	SchedulerName       string
+	Namespace          string
+	Name               string
+	Image              string
+	Replicas           int
+	ServiceAccountName string
+	SchedulerName      string
 
 	// Qemu
 	Qemu struct {


### PR DESCRIPTION
closes https://github.com/docker/buildx/pull/2457
closes https://github.com/docker/buildx/pull/2472

carry https://github.com/docker/buildx/pull/2457 with some changes to rename `provisioningTimeout` to `timeout` and also remove the attribute from deployment manifest that is not actually used.

