### PR TITLE
dial-stdio: remove extra cmd.flags()

### DIFF
--- a/commands/dial_stdio.go
+++ b/commands/dial_stdio.go
@@ -125,7 +125,6 @@ func dialStdioCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	cmd.Flags()
 	flags.StringVar(&opts.platform, "platform", os.Getenv("DOCKER_DEFAULT_PLATFORM"), "Target platform: this is used for node selection")
 	flags.StringVar(&opts.progress, "progress", "quiet", "Set type of progress output (auto, plain, tty).")
 	return cmd


### PR DESCRIPTION
might have been an oversight in https://github.com/docker/buildx/pull/2112

cc @cpuguy83 