### PR TITLE
k8s: fix concurrent kubeconfig access when loading nodes

### DIFF
--- a/driver/kubernetes/context/fixtures/k3s-kubeconfig
+++ b/driver/kubernetes/context/fixtures/k3s-kubeconfig
@@ -9,8 +9,8 @@ contexts:
     cluster: test-cluster
     user: test-user
     namespace: zoinx
-  name: test
-current-context: test
+  name: k3s
+current-context: k3s
 kind: Config
 preferences: {}
 users:

--- a/driver/kubernetes/context/load.go
+++ b/driver/kubernetes/context/load.go
@@ -167,11 +167,12 @@ func NewKubernetesConfig(configPath string) clientcmd.ClientConfig {
 // ConfigFromEndpoint loads kubernetes config from endpoint
 func ConfigFromEndpoint(endpointName string, s store.Reader) (clientcmd.ClientConfig, error) {
 	if strings.HasPrefix(endpointName, "kubernetes://") {
+		rules := clientcmd.NewDefaultClientConfigLoadingRules()
 		u, _ := url.Parse(endpointName)
 		if kubeconfig := u.Query().Get("kubeconfig"); kubeconfig != "" {
-			_ = os.Setenv(clientcmd.RecommendedConfigPathEnvVar, kubeconfig)
+			rules.Precedence = append(rules.Precedence, kubeconfig)
+			rules.ExplicitPath = kubeconfig
 		}
-		rules := clientcmd.NewDefaultClientConfigLoadingRules()
 		apiConfig, err := rules.Load()
 		if err != nil {
 			return nil, err

--- a/driver/kubernetes/context/load_test.go
+++ b/driver/kubernetes/context/load_test.go
@@ -1,20 +1,35 @@
 package context
 
 import (
-	"os"
 	"testing"
 
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/config"
+	"github.com/docker/cli/cli/context/store"
 	cliflags "github.com/docker/cli/cli/flags"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestDefaultContextInitializer(t *testing.T) {
-	os.Setenv("KUBECONFIG", "./fixtures/test-kubeconfig")
-	defer os.Unsetenv("KUBECONFIG")
+	t.Setenv("KUBECONFIG", "./fixtures/test-kubeconfig")
 	ctx, err := command.ResolveDefaultContext(&cliflags.ClientOptions{}, command.DefaultContextStoreConfig())
 	require.NoError(t, err)
 	assert.Equal(t, "default", ctx.Meta.Name)
 	assert.Equal(t, "zoinx", ctx.Meta.Endpoints[KubernetesEndpoint].(EndpointMeta).DefaultNamespace)
+}
+
+func TestConfigFromEndpoint(t *testing.T) {
+	t.Setenv("KUBECONFIG", "./fixtures/test-kubeconfig")
+	cfg, err := ConfigFromEndpoint(
+		"kubernetes:///buildx-test-4c972a3f9d369614b40f28a281790c7e?deployment=buildkit-4c2ed3ed-970f-4f3d-a6df-a4fcbab4d5cf-d9d73&kubeconfig=.%2Ffixtures%2Fk3s-kubeconfig",
+		store.New(config.ContextStoreDir(), command.DefaultContextStoreConfig()),
+	)
+	require.NoError(t, err)
+	rawcfg, err := cfg.RawConfig()
+	require.NoError(t, err)
+	ctxcfg := "k3s"
+	if _, ok := rawcfg.Contexts[ctxcfg]; !ok {
+		t.Errorf("Context config %q not found", ctxcfg)
+	}
 }


### PR DESCRIPTION
fixes #2436 

Addresses a concurrency issue in the `ConfigFromEndpoint` function where multiple kubeconfig files were accessed simultaneously when loading nodes. This change ensures that kubeconfig files are accessed in a thread-safe manner by making config from the endpoint taking precedence, preventing potential race conditions.

cc @gitfxx