### PR TITLE
vendor: github.com/distribution/reference v0.6.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/containerd/log v0.1.0
 	github.com/containerd/typeurl/v2 v2.1.1
 	github.com/creack/pty v1.1.21
-	github.com/distribution/reference v0.5.0
+	github.com/distribution/reference v0.6.0
 	github.com/docker/cli v26.1.4+incompatible
 	github.com/docker/cli-docs-tool v0.7.0
 	github.com/docker/docker v26.1.4+incompatible

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/denisenkom/go-mssqldb v0.0.0-20191128021309-1d7a30a10f73/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
-github.com/distribution/reference v0.5.0 h1:/FUIFXtfc/x2gpa5/VGfiGLuOIdYa1t65IKK2OFGvA0=
-github.com/distribution/reference v0.5.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
+github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
+github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/cli v26.1.4+incompatible h1:I8PHdc0MtxEADqYJZvhBrW9bo8gawKwwenxRM7/rLu8=
 github.com/docker/cli v26.1.4+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli-docs-tool v0.7.0 h1:M2Da98Unz2kz3A5d4yeSGbhyOge2mfYSNjAFt01Rw0M=

--- a/vendor/github.com/distribution/reference/README.md
+++ b/vendor/github.com/distribution/reference/README.md
@@ -10,7 +10,7 @@ Go library to handle references to container images.
 [![codecov](https://codecov.io/gh/distribution/reference/branch/main/graph/badge.svg)](https://codecov.io/gh/distribution/reference)
 [![FOSSA Status](https://app.fossa.com/api/projects/custom%2B162%2Fgithub.com%2Fdistribution%2Freference.svg?type=shield)](https://app.fossa.com/projects/custom%2B162%2Fgithub.com%2Fdistribution%2Freference?ref=badge_shield)
 
-This repository contains a library for handling refrences to container images held in container registries. Please see [godoc](https://pkg.go.dev/github.com/distribution/reference) for details.
+This repository contains a library for handling references to container images held in container registries. Please see [godoc](https://pkg.go.dev/github.com/distribution/reference) for details.
 
 ## Contribution
 

--- a/vendor/github.com/distribution/reference/reference.go
+++ b/vendor/github.com/distribution/reference/reference.go
@@ -35,8 +35,13 @@ import (
 )
 
 const (
+	// RepositoryNameTotalLengthMax is the maximum total number of characters in a repository name.
+	RepositoryNameTotalLengthMax = 255
+
 	// NameTotalLengthMax is the maximum total number of characters in a repository name.
-	NameTotalLengthMax = 255
+	//
+	// Deprecated: use [RepositoryNameTotalLengthMax] instead.
+	NameTotalLengthMax = RepositoryNameTotalLengthMax
 )
 
 var (
@@ -55,8 +60,8 @@ var (
 	// ErrNameEmpty is returned for empty, invalid repository names.
 	ErrNameEmpty = errors.New("repository name must have at least one component")
 
-	// ErrNameTooLong is returned when a repository name is longer than NameTotalLengthMax.
-	ErrNameTooLong = fmt.Errorf("repository name must not be more than %v characters", NameTotalLengthMax)
+	// ErrNameTooLong is returned when a repository name is longer than RepositoryNameTotalLengthMax.
+	ErrNameTooLong = fmt.Errorf("repository name must not be more than %v characters", RepositoryNameTotalLengthMax)
 
 	// ErrNameNotCanonical is returned when a name is not canonical.
 	ErrNameNotCanonical = errors.New("repository name must be canonical")
@@ -165,25 +170,15 @@ func Path(named Named) (name string) {
 	return path
 }
 
+// splitDomain splits a named reference into a hostname and path string.
+// If no valid hostname is found, the hostname is empty and the full value
+// is returned as name
 func splitDomain(name string) (string, string) {
 	match := anchoredNameRegexp.FindStringSubmatch(name)
 	if len(match) != 3 {
 		return "", name
 	}
 	return match[1], match[2]
-}
-
-// SplitHostname splits a named reference into a
-// hostname and name string. If no valid hostname is
-// found, the hostname is empty and the full value
-// is returned as name
-//
-// Deprecated: Use [Domain] or [Path].
-func SplitHostname(named Named) (string, string) {
-	if r, ok := named.(namedRepository); ok {
-		return r.Domain(), r.Path()
-	}
-	return splitDomain(named.Name())
 }
 
 // Parse parses s and returns a syntactically valid Reference.
@@ -200,10 +195,6 @@ func Parse(s string) (Reference, error) {
 		return nil, ErrReferenceInvalidFormat
 	}
 
-	if len(matches[1]) > NameTotalLengthMax {
-		return nil, ErrNameTooLong
-	}
-
 	var repo repository
 
 	nameMatch := anchoredNameRegexp.FindStringSubmatch(matches[1])
@@ -213,6 +204,10 @@ func Parse(s string) (Reference, error) {
 	} else {
 		repo.domain = ""
 		repo.path = matches[1]
+	}
+
+	if len(repo.path) > RepositoryNameTotalLengthMax {
+		return nil, ErrNameTooLong
 	}
 
 	ref := reference{
@@ -253,14 +248,15 @@ func ParseNamed(s string) (Named, error) {
 // WithName returns a named object representing the given string. If the input
 // is invalid ErrReferenceInvalidFormat will be returned.
 func WithName(name string) (Named, error) {
-	if len(name) > NameTotalLengthMax {
-		return nil, ErrNameTooLong
-	}
-
 	match := anchoredNameRegexp.FindStringSubmatch(name)
 	if match == nil || len(match) != 3 {
 		return nil, ErrReferenceInvalidFormat
 	}
+
+	if len(match[2]) > RepositoryNameTotalLengthMax {
+		return nil, ErrNameTooLong
+	}
+
 	return repository{
 		domain: match[1],
 		path:   match[2],

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -214,7 +214,7 @@ github.com/creack/pty
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/distribution/reference v0.5.0
+# github.com/distribution/reference v0.6.0
 ## explicit; go 1.20
 github.com/distribution/reference
 # github.com/docker/cli v26.1.4+incompatible


### PR DESCRIPTION
- relates to https://github.com/moby/buildkit/pull/5007

full diff: https://github.com/distribution/reference/compare/v0.5.0...v0.6.0

- remove deprecated SplitHostname
- refactor splitDockerDomain to include more documentation
- fix typo in readme
- Exclude domain from name length check