### PR TITLE
build: retain local and tar exporter attributes

### DIFF
--- a/util/buildflags/export.go
+++ b/util/buildflags/export.go
@@ -32,6 +32,7 @@ func ParseExports(inp []string) ([]*controllerapi.ExportEntry, error) {
 			if s != "-" {
 				outs = append(outs, &controllerapi.ExportEntry{
 					Type:        client.ExporterLocal,
+					Attrs:       map[string]string{"dest": s},
 					Destination: s,
 				})
 				continue
@@ -71,7 +72,8 @@ func ParseExports(inp []string) ([]*controllerapi.ExportEntry, error) {
 
 		if dest, ok := out.Attrs["dest"]; ok {
 			out.Destination = dest
-			delete(out.Attrs, "dest")
+		} else if !ok && out.Destination != "" {
+			out.Attrs["dest"] = out.Destination
 		}
 
 		outs = append(outs, &out)


### PR DESCRIPTION
When investigating https://github.com/moby/buildkit/pull/5017 I found that `local` and `tar` didn't have the `dest` attribute set. I think we should keep it even if not used as we want to keep track of it in the build record.