### PR TITLE
update the lint subrequest call to error

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -878,6 +878,12 @@ func printResult(f *controllerapi.PrintFunc, res map[string]string) error {
 			}
 		}
 		if lintResults.Error != nil {
+			// Print the error message and the source
+			// Normally, we would use `errdefs.WithSource` to attach the source to the
+			// error and let the error be printed by the handling that's already in place,
+			// but here we want to print the error in a way that's consistent with how
+			// the lint warnings are printed via the `lint.PrintLintViolations` function,
+			// which differs from the default error printing.
 			fmt.Println()
 			lintBuf := bytes.NewBuffer([]byte(lintResults.Error.Message + "\n"))
 			sourceInfo := lintResults.Sources[lintResults.Error.Location.SourceIndex]

--- a/tests/build.go
+++ b/tests/build.go
@@ -817,7 +817,7 @@ COPy --from=base \
 		stderr := bytes.Buffer{}
 		cmd.Stdout = &stdout
 		cmd.Stderr = &stderr
-		require.NoError(t, cmd.Run(), stdout.String(), stderr.String())
+		require.Error(t, cmd.Run(), stdout.String(), stderr.String())
 
 		var res lint.LintResults
 		require.NoError(t, json.Unmarshal(stdout.Bytes(), &res))


### PR DESCRIPTION
Update the lint subrequest call to error when a build error was encountered during linting.

When using the `--call=check` flag, `buildx` currently returns `0`, even when there was a build error. This correctly updates that behavior and causes the build error to print its source, bringing the behavior in-line with `--call=build`.

Example 

```
$ BUILDX_EXPERIMENTAL=1 docker buildx --builder=dev build -t trash --call=check . && echo "apple"
[+] Building 0.2s (2/2) FINISHED                                                                                                         docker-container:dev
 => [internal] connecting to local controller                                                                                                            0.0s
 => [internal] load build definition from Dockerfile                                                                                                     0.0s
 => => transferring dockerfile: 171B                                                                                                                     0.0s
FromAsCasing - https://docs.docker.com/go/dockerfile/rule/from-as-casing/
The 'as' keyword should match the case of the 'from' keyword
Dockerfile:7
--------------------
   5 |     COPY $app .
   6 |
   7 | >>> FROM scratch asgard third
   8 |
--------------------

ERROR: dockerfile parse error on line 7: FROM requires either one or three arguments
Dockerfile:7
--------------------
   5 |     COPY $app .
   6 |
   7 | >>> FROM scratch asgard third
   8 |
--------------------

```