### PR TITLE
bake: default variable to null if not defined

### DIFF
--- a/bake/hcl_test.go
+++ b/bake/hcl_test.go
@@ -394,6 +394,44 @@ func TestHCLTypedVariables(t *testing.T) {
 	require.Contains(t, err.Error(), "failed to parse IS_FOO as bool")
 }
 
+func TestHCLNullVariableDefault(t *testing.T) {
+	dt := []byte(`
+		variable "FOO" {}
+		target "default" {
+			args = {
+				isNull = equal(FOO, null)
+				isEmptyString = equal(FOO, "")
+			}
+		}`)
+
+	c, err := ParseFile(dt, "docker-bake.hcl")
+	require.NoError(t, err)
+	require.Len(t, c.Targets, 1)
+	require.Len(t, c.Targets[0].Args, 2)
+	require.Equal(t, "true", *c.Targets[0].Args["isNull"])
+	require.Equal(t, "false", *c.Targets[0].Args["isEmptyString"])
+}
+
+func TestHCLEmptyVariable(t *testing.T) {
+	dt := []byte(`
+		variable "FOO" {
+			default = ""
+		}
+		target "default" {
+			args = {
+				isNull = equal(FOO, null)
+				isEmptyString = equal(FOO, "")
+			}
+		}`)
+
+	c, err := ParseFile(dt, "docker-bake.hcl")
+	require.NoError(t, err)
+	require.Len(t, c.Targets, 1)
+	require.Len(t, c.Targets[0].Args, 2)
+	require.Equal(t, "false", *c.Targets[0].Args["isNull"])
+	require.Equal(t, "true", *c.Targets[0].Args["isEmptyString"])
+}
+
 func TestHCLNullVariables(t *testing.T) {
 	dt := []byte(`
 		variable "FOO" {

--- a/bake/hclparser/hclparser.go
+++ b/bake/hclparser/hclparser.go
@@ -266,7 +266,12 @@ func (p *parser) resolveValue(ectx *hcl.EvalContext, name string) (err error) {
 	if def == nil {
 		val, ok := p.opt.Vars[name]
 		if !ok {
-			val, _ = p.opt.LookupVar(name)
+			val, ok = p.opt.LookupVar(name)
+			if !ok {
+				vv := cty.NullVal(cty.DynamicPseudoType)
+				v = &vv
+				return
+			}
 		}
 		vv := cty.StringVal(val)
 		v = &vv


### PR DESCRIPTION
fixes #2529 

With `null` val supported for variables in https://github.com/docker/buildx/pull/1449, we should default default to this type instead of empty string. Might have been an oversight.