### PR TITLE
bake: print warnings on progress

### DIFF
--- a/commands/bake.go
+++ b/commands/bake.go
@@ -124,8 +124,12 @@ func runBake(ctx context.Context, dockerCli command.Cli, targets []string, in ba
 	}
 
 	progressMode := progressui.DisplayMode(cFlags.progress)
-	printer, err := progress.NewPrinter(ctx2, os.Stderr, progressMode,
+	var printer *progress.Printer
+	printer, err = progress.NewPrinter(ctx2, os.Stderr, progressMode,
 		progress.WithDesc(progressTextDesc, progressConsoleDesc),
+		progress.WithOnClose(func() {
+			printWarnings(os.Stderr, printer.Warnings(), progressMode)
+		}),
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
Add progress warnings to the output for `bake` commands same way as they show up in `build`.

```
 1 warning found (use --debug to expand):
 - UndefinedVar: Usage of undefined variable '$PAHT' (did you mean $PATH?) (line 2)
```

```
 1 warning found:
 - UndefinedVar: Usage of undefined variable '$PAHT' (did you mean $PATH?) (line 2)
Variables should be defined before their use
More info: https://docs.docker.com/go/dockerfile/rule/undefined-var/
Dockerfile:2
--------------------
   1 |     FROM alpine
   2 | >>> ENV PATH=$PAHT:/foo
   3 |     RUN env && stop
   4 |
--------------------
```


--

There is a bit of an issue with this atm that when two targets invoked by `bake` use the same Dockerfile they are likely to generate the same warnings. Some deduplication would be needed.