### PR TITLE
Add message when --check does not produce warnings or errors

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -885,7 +885,10 @@ func printResult(f *controllerapi.PrintFunc, res map[string]string) error {
 			// the lint warnings are printed via the `lint.PrintLintViolations` function,
 			// which differs from the default error printing.
 			fmt.Println()
-			lintBuf := bytes.NewBuffer([]byte(lintResults.Error.Message + "\n"))
+			lintBuf := bytes.NewBuffer([]byte(lintResults.Error.Message))
+			if f.Format != "json" {
+				fmt.Fprintln(lintBuf)
+			}
 			sourceInfo := lintResults.Sources[lintResults.Error.Location.SourceIndex]
 			source := errdefs.Source{
 				Info:   sourceInfo,
@@ -893,6 +896,8 @@ func printResult(f *controllerapi.PrintFunc, res map[string]string) error {
 			}
 			source.Print(lintBuf)
 			return errors.New(lintBuf.String())
+		} else if len(lintResults.Warnings) == 0 && f.Format != "json" {
+			fmt.Println("Check complete, no warnings found.")
 		}
 	default:
 		if dt, ok := res["result.json"]; ok && f.Format == "json" {


### PR DESCRIPTION
Currently, in the case that `--check` produces no errors or warnings, there is no output to clarify this. This adds a simple user facing message in the case to indicate such when it occurs.

```
~/example$ BUILDX_EXPERIMENTAL=1 docker --debug buildx --builder=dev build --check .
[+] Building 0.1s (3/3) FINISHED                                                                                                         docker-container:dev
 => [internal] connecting to local controller                                                                                                            0.0s
 => [internal] load build definition from Dockerfile                                                                                                     0.0s
 => => transferring dockerfile: 105B                                                                                                                     0.0s
 => [internal] load .dockerignore                                                                                                                        0.0s
 => => transferring context: 2B                                                                                                                          0.0s
 ```
 
 Becomes
 
 ```
~/example$ BUILDX_EXPERIMENTAL=1 docker --debug buildx --builder=dev build --check .
[+] Building 0.2s (3/3) FINISHED                                                                                                         docker-container:dev
 => [internal] connecting to local controller                                                                                                            0.0s
 => [internal] load build definition from Dockerfile                                                                                                     0.0s
 => => transferring dockerfile: 105B                                                                                                                     0.0s
 => [internal] load .dockerignore                                                                                                                        0.0s
 => => transferring context: 2B                                                                                                                          0.0s
Check complete, no warnings found.
