### PR TITLE
bake: add call methods support and printing

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -675,7 +675,8 @@ type Group struct {
 }
 
 type Target struct {
-	Name string `json:"-" hcl:"name,label" cty:"name"`
+	Name        string `json:"-" hcl:"name,label" cty:"name"`
+	Description string `json:"description,omitempty" hcl:"description,optional" cty:"description"`
 
 	// Inherits is the only field that cannot be overridden with --set
 	Inherits []string `json:"inherits,omitempty" hcl:"inherits,optional" cty:"inherits"`
@@ -822,6 +823,9 @@ func (t *Target) Merge(t2 *Target) {
 	}
 	if t2.Ulimits != nil { // merge
 		t.Ulimits = append(t.Ulimits, t2.Ulimits...)
+	}
+	if t2.Description != "" {
+		t.Description = t2.Description
 	}
 	t.Inherits = append(t.Inherits, t2.Inherits...)
 }

--- a/bake/bake.go
+++ b/bake/bake.go
@@ -669,8 +669,9 @@ func (c Config) target(name string, visited map[string]*Target, overrides map[st
 }
 
 type Group struct {
-	Name    string   `json:"-" hcl:"name,label" cty:"name"`
-	Targets []string `json:"targets" hcl:"targets" cty:"targets"`
+	Name        string   `json:"-" hcl:"name,label" cty:"name"`
+	Description string   `json:"description,omitempty" hcl:"description,optional" cty:"description"`
+	Targets     []string `json:"targets" hcl:"targets" cty:"targets"`
 	// Target // TODO?
 }
 

--- a/bake/bake_test.go
+++ b/bake/bake_test.go
@@ -1528,7 +1528,7 @@ services:
         v2: "bar"
 `)
 
-	c, err := ParseFiles([]File{
+	c, _, err := ParseFiles([]File{
 		{Data: dt, Name: "c1.foo"},
 		{Data: dt2, Name: "c2.bar"},
 	}, nil)

--- a/bake/hcl_test.go
+++ b/bake/hcl_test.go
@@ -273,7 +273,7 @@ func TestHCLMultiFileSharedVariables(t *testing.T) {
 		}
 		`)
 
-	c, err := ParseFiles([]File{
+	c, _, err := ParseFiles([]File{
 		{Data: dt, Name: "c1.hcl"},
 		{Data: dt2, Name: "c2.hcl"},
 	}, nil)
@@ -285,7 +285,7 @@ func TestHCLMultiFileSharedVariables(t *testing.T) {
 
 	t.Setenv("FOO", "def")
 
-	c, err = ParseFiles([]File{
+	c, _, err = ParseFiles([]File{
 		{Data: dt, Name: "c1.hcl"},
 		{Data: dt2, Name: "c2.hcl"},
 	}, nil)
@@ -322,7 +322,7 @@ func TestHCLVarsWithVars(t *testing.T) {
 		}
 		`)
 
-	c, err := ParseFiles([]File{
+	c, _, err := ParseFiles([]File{
 		{Data: dt, Name: "c1.hcl"},
 		{Data: dt2, Name: "c2.hcl"},
 	}, nil)
@@ -334,7 +334,7 @@ func TestHCLVarsWithVars(t *testing.T) {
 
 	t.Setenv("BASE", "new")
 
-	c, err = ParseFiles([]File{
+	c, _, err = ParseFiles([]File{
 		{Data: dt, Name: "c1.hcl"},
 		{Data: dt2, Name: "c2.hcl"},
 	}, nil)
@@ -612,7 +612,7 @@ func TestHCLMultiFileAttrs(t *testing.T) {
 		FOO="def"
 		`)
 
-	c, err := ParseFiles([]File{
+	c, _, err := ParseFiles([]File{
 		{Data: dt, Name: "c1.hcl"},
 		{Data: dt2, Name: "c2.hcl"},
 	}, nil)
@@ -623,7 +623,7 @@ func TestHCLMultiFileAttrs(t *testing.T) {
 
 	t.Setenv("FOO", "ghi")
 
-	c, err = ParseFiles([]File{
+	c, _, err = ParseFiles([]File{
 		{Data: dt, Name: "c1.hcl"},
 		{Data: dt2, Name: "c2.hcl"},
 	}, nil)
@@ -647,7 +647,7 @@ func TestHCLMultiFileGlobalAttrs(t *testing.T) {
 		FOO = "def"
 		`)
 
-	c, err := ParseFiles([]File{
+	c, _, err := ParseFiles([]File{
 		{Data: dt, Name: "c1.hcl"},
 		{Data: dt2, Name: "c2.hcl"},
 	}, nil)
@@ -830,7 +830,7 @@ func TestHCLRenameMultiFile(t *testing.T) {
 		}
 		`)
 
-	c, err := ParseFiles([]File{
+	c, _, err := ParseFiles([]File{
 		{Data: dt, Name: "c1.hcl"},
 		{Data: dt2, Name: "c2.hcl"},
 		{Data: dt3, Name: "c3.hcl"},
@@ -1050,7 +1050,7 @@ func TestHCLMatrixArgsOverride(t *testing.T) {
 	}
 	`)
 
-	c, err := ParseFiles([]File{
+	c, _, err := ParseFiles([]File{
 		{Data: dt, Name: "docker-bake.hcl"},
 	}, map[string]string{"ABC": "11,22,33"})
 	require.NoError(t, err)
@@ -1236,7 +1236,7 @@ services:
         v2: "bar"
 `)
 
-	c, err := ParseFiles([]File{
+	c, _, err := ParseFiles([]File{
 		{Data: dt, Name: "c1.hcl"},
 		{Data: dt2, Name: "c2.yml"},
 	}, nil)
@@ -1258,7 +1258,7 @@ func TestHCLBuiltinVars(t *testing.T) {
 		}
 		`)
 
-	c, err := ParseFiles([]File{
+	c, _, err := ParseFiles([]File{
 		{Data: dt, Name: "c1.hcl"},
 	}, map[string]string{
 		"BAKE_CMD_CONTEXT": "foo",
@@ -1272,7 +1272,7 @@ func TestHCLBuiltinVars(t *testing.T) {
 }
 
 func TestCombineHCLAndJSONTargets(t *testing.T) {
-	c, err := ParseFiles([]File{
+	c, _, err := ParseFiles([]File{
 		{
 			Name: "docker-bake.hcl",
 			Data: []byte(`
@@ -1348,7 +1348,7 @@ target "b" {
 }
 
 func TestCombineHCLAndJSONVars(t *testing.T) {
-	c, err := ParseFiles([]File{
+	c, _, err := ParseFiles([]File{
 		{
 			Name: "docker-bake.hcl",
 			Data: []byte(`

--- a/bake/hclparser/merged.go
+++ b/bake/hclparser/merged.go
@@ -111,21 +111,19 @@ func (mb mergedBodies) JustAttributes() (hcl.Attributes, hcl.Diagnostics) {
 			diags = append(diags, thisDiags...)
 		}
 
-		if thisAttrs != nil {
-			for name, attr := range thisAttrs {
-				if existing := attrs[name]; existing != nil {
-					diags = diags.Append(&hcl.Diagnostic{
-						Severity: hcl.DiagError,
-						Summary:  "Duplicate argument",
-						Detail: fmt.Sprintf(
-							"Argument %q was already set at %s",
-							name, existing.NameRange.String(),
-						),
-						Subject: thisAttrs[name].NameRange.Ptr(),
-					})
-				}
-				attrs[name] = attr
+		for name, attr := range thisAttrs {
+			if existing := attrs[name]; existing != nil {
+				diags = diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Duplicate argument",
+					Detail: fmt.Sprintf(
+						"Argument %q was already set at %s",
+						name, existing.NameRange.String(),
+					),
+					Subject: thisAttrs[name].NameRange.Ptr(),
+				})
 			}
+			attrs[name] = attr
 		}
 	}
 

--- a/commands/bake.go
+++ b/commands/bake.go
@@ -302,7 +302,6 @@ func runBake(ctx context.Context, dockerCli command.Cli, targets []string, in ba
 	}
 
 	err = printer.Wait()
-	printer = nil
 	if err != nil {
 		return err
 	}

--- a/commands/bake.go
+++ b/commands/bake.go
@@ -337,11 +337,16 @@ func runBake(ctx context.Context, dockerCli command.Cli, targets []string, in ba
 			}
 		} else {
 			if sep {
-				fmt.Fprintf(dockerCli.Out(), "\n\n")
+				fmt.Fprintln(dockerCli.Out())
 			} else {
 				sep = true
 			}
 			fmt.Fprintf(dockerCli.Out(), "%s\n", name)
+			if descr := tgts[name].Description; descr != "" {
+				fmt.Fprintf(dockerCli.Out(), "%s\n", descr)
+			}
+
+			fmt.Fprintln(dockerCli.Out())
 			if code, err := printResult(dockerCli.Out(), pf, res); err != nil {
 				fmt.Fprintf(dockerCli.Out(), "error: %v\n", err)
 				exitCode = 1

--- a/commands/bake.go
+++ b/commands/bake.go
@@ -21,6 +21,7 @@ import (
 	"github.com/docker/buildx/controller/pb"
 	"github.com/docker/buildx/localstate"
 	"github.com/docker/buildx/util/buildflags"
+	"github.com/docker/buildx/util/cobrautil"
 	"github.com/docker/buildx/util/cobrautil/completion"
 	"github.com/docker/buildx/util/confutil"
 	"github.com/docker/buildx/util/desktop"
@@ -443,15 +444,22 @@ func bakeCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 	flags.StringArrayVarP(&options.files, "file", "f", []string{}, "Build definition file")
 	flags.BoolVar(&options.exportLoad, "load", false, `Shorthand for "--set=*.output=type=docker"`)
 	flags.BoolVar(&options.printOnly, "print", false, "Print the options without building")
-	flags.BoolVar(&options.listTargets, "list-targets", false, "List available targets")
-	flags.BoolVar(&options.listVars, "list-variables", false, "List defined variables")
 	flags.BoolVar(&options.exportPush, "push", false, `Shorthand for "--set=*.output=type=registry"`)
 	flags.StringVar(&options.sbom, "sbom", "", `Shorthand for "--set=*.attest=type=sbom"`)
 	flags.StringVar(&options.provenance, "provenance", "", `Shorthand for "--set=*.attest=type=provenance"`)
 	flags.StringArrayVar(&options.overrides, "set", nil, `Override target value (e.g., "targetpattern.key=value")`)
 	flags.StringVar(&options.callFunc, "call", "build", `Set method for evaluating build ("check", "outline", "targets")`)
+
 	flags.VarPF(callAlias(&options.callFunc, "check"), "check", "", `Shorthand for "--call=check"`)
 	flags.Lookup("check").NoOptDefVal = "true"
+
+	flags.BoolVar(&options.listTargets, "list-targets", false, "List available targets")
+	cobrautil.MarkFlagsExperimental(flags, "list-targets")
+	flags.MarkHidden("list-targets")
+
+	flags.BoolVar(&options.listVars, "list-variables", false, "List defined variables")
+	cobrautil.MarkFlagsExperimental(flags, "list-variables")
+	flags.MarkHidden("list-variables")
 
 	commonBuildFlags(&cFlags, flags)
 

--- a/commands/build.go
+++ b/commands/build.go
@@ -890,7 +890,7 @@ func printResult(w io.Writer, f *controllerapi.PrintFunc, res map[string]string)
 			// but here we want to print the error in a way that's consistent with how
 			// the lint warnings are printed via the `lint.PrintLintViolations` function,
 			// which differs from the default error printing.
-			if f.Format != "json" {
+			if f.Format != "json" && len(lintResults.Warnings) > 0 {
 				fmt.Fprintln(w)
 			}
 			lintBuf := bytes.NewBuffer([]byte(lintResults.Error.Message + "\n"))

--- a/docs/reference/buildx_bake.md
+++ b/docs/reference/buildx_bake.md
@@ -19,8 +19,6 @@ Build from a file
 | `--call`                            | `string`      | `build` | Set method for evaluating build (`check`, `outline`, `targets`)                                     |
 | `--check`                           | `bool`        |         | Shorthand for `--call=check`                                                                        |
 | [`-f`](#file), [`--file`](#file)    | `stringArray` |         | Build definition file                                                                               |
-| `--list-targets`                    | `bool`        |         | List available targets                                                                              |
-| `--list-variables`                  | `bool`        |         | List defined variables                                                                              |
 | `--load`                            | `bool`        |         | Shorthand for `--set=*.output=type=docker`                                                          |
 | [`--metadata-file`](#metadata-file) | `string`      |         | Write build result metadata to a file                                                               |
 | [`--no-cache`](#no-cache)           | `bool`        |         | Do not use cache when building the image                                                            |

--- a/docs/reference/buildx_bake.md
+++ b/docs/reference/buildx_bake.md
@@ -16,7 +16,11 @@ Build from a file
 | Name                                | Type          | Default | Description                                                                                         |
 |:------------------------------------|:--------------|:--------|:----------------------------------------------------------------------------------------------------|
 | [`--builder`](#builder)             | `string`      |         | Override the configured builder instance                                                            |
+| `--call`                            | `string`      | `build` | Set method for evaluating build (`check`, `outline`, `targets`)                                     |
+| `--check`                           | `bool`        |         | Shorthand for `--call=check`                                                                        |
 | [`-f`](#file), [`--file`](#file)    | `stringArray` |         | Build definition file                                                                               |
+| `--list-targets`                    | `bool`        |         | List available targets                                                                              |
+| `--list-variables`                  | `bool`        |         | List defined variables                                                                              |
 | `--load`                            | `bool`        |         | Shorthand for `--set=*.output=type=docker`                                                          |
 | [`--metadata-file`](#metadata-file) | `string`      |         | Write build result metadata to a file                                                               |
 | [`--no-cache`](#no-cache)           | `bool`        |         | Do not use cache when building the image                                                            |

--- a/util/progress/printer.go
+++ b/util/progress/printer.go
@@ -19,9 +19,10 @@ import (
 type Printer struct {
 	status chan *client.SolveStatus
 
-	ready  chan struct{}
-	done   chan struct{}
-	paused chan struct{}
+	ready     chan struct{}
+	done      chan struct{}
+	paused    chan struct{}
+	closeOnce sync.Once
 
 	err          error
 	warnings     []client.VertexWarning
@@ -36,8 +37,10 @@ type Printer struct {
 }
 
 func (p *Printer) Wait() error {
-	close(p.status)
-	<-p.done
+	p.closeOnce.Do(func() {
+		close(p.status)
+		<-p.done
+	})
 	return p.err
 }
 


### PR DESCRIPTION
### Define call method in the bake target

```
target "validate" {
	call = "check"
}
```

```
docker buildx bake validate
```

### Set call/check on all active targets

```
docker buildx bake --call=outline
docker buildx bake --check
docker buildx bake --call check,format=json
```

The text output of `call=outline` should be updated in follow-up to include bake definition and variables. Getting variables seems tricky and I think needs HCL parser updates.

```
» docker buildx bake binaries test --call=outline 
[+] Building 1.0s (11/11) FINISHED                                                                                                                                           0.0s
binaries

TARGET: binaries

BUILD ARG                  VALUE   DESCRIPTION
GO_VERSION                 1.21
XX_VERSION                 1.4.0
GO_EXTRA_FLAGS
BUILDKIT_SBOM_SCAN_STAGE   true


test

TARGET: test-coverage

BUILD ARG    VALUE   DESCRIPTION
GO_VERSION   1.21
XX_VERSION   1.4.0
```

JSON output contains both Bake definition and the method result.

### List all bake targets

```
docker buildx bake --list-targets
```

```
TARGET				DESCRIPTION
binaries
binaries-cross
default				binaries
image
image-cross
image-local
integration-test
integration-test-base
lint
lint-gopls			Run gopls analyzers
meta-helper
```

### List all bake variables

```
docker buildx bake --list-variables
```

```
VARIABLE			VALUE	DESCRIPTION
DESTDIR				./bin	Destination directory for build artifacts
DOCS_FORMATS			md
GOLANGCI_LINT_MULTIPLATFORM
GO_VERSION			<null>
HTTPS_PROXY
HTTP_PROXY
NO_PROXY
TEST_BUILDKIT_TAG		<null>
TEST_COVERAGE			<null>
```