### PR TITLE
build: set same ref when building on multiple nodes

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -32,6 +32,7 @@ import (
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	gateway "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver/errdefs"
 	"github.com/moby/buildkit/solver/pb"
@@ -215,6 +216,9 @@ func BuildWithResultHandler(ctx context.Context, nodes []builder.Node, opt map[s
 		gitattrs, addVCSLocalDir, err := getGitAttributes(ctx, opt.Inputs.ContextPath, opt.Inputs.DockerfilePath)
 		if err != nil {
 			logrus.WithError(err).Warn("current commit information was not captured by the build")
+		}
+		if opt.Ref == "" {
+			opt.Ref = identity.NewID()
 		}
 		var reqn []*reqForNode
 		for _, np := range drivers[k] {

--- a/build/opt.go
+++ b/build/opt.go
@@ -104,10 +104,6 @@ func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt Op
 		SourcePolicy:        opt.SourcePolicy,
 	}
 
-	if so.Ref == "" {
-		so.Ref = identity.NewID()
-	}
-
 	if opt.CgroupParent != "" {
 		so.FrontendAttrs["cgroup-parent"] = opt.CgroupParent
 	}


### PR DESCRIPTION
Currently when building with `bake` we are setting the build ref for each target which results with the same ref being set in solve request when building on multiple nodes: https://github.com/docker/buildx/blob/5656c9813373bda688737449735d080905871aeb/commands/bake.go#L232-L238

But for `build` we don't do this in commands package and therefore it will generate a different one for each node: 
* https://github.com/docker/buildx/blob/5656c9813373bda688737449735d080905871aeb/build/build.go#L229
* https://github.com/docker/buildx/blob/5656c9813373bda688737449735d080905871aeb/build/opt.go#L108

@tonistiigi I think we should align `build` with `bake` to have the same ref across nodes but let me know if this should be the other way around.

cc @fiam 