### PR TITLE
bake: use cacheonly exporter for implicit targets

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -494,7 +494,7 @@ func (c Config) loadLinks(name string, t *Target, m map[string]*Target, o map[st
 				if err != nil {
 					return err
 				}
-				t2.Outputs = nil
+				t2.Outputs = []string{"type=cacheonly"}
 				t2.linked = true
 				m[target] = t2
 			}

--- a/bake/bake_test.go
+++ b/bake/bake_test.go
@@ -838,7 +838,8 @@ func TestReadContextFromTargetChain(t *testing.T) {
 
 	mid, ok := m["mid"]
 	require.True(t, ok)
-	require.Equal(t, 0, len(mid.Outputs))
+	require.Equal(t, 1, len(mid.Outputs))
+	require.Equal(t, "type=cacheonly", mid.Outputs[0])
 	require.Equal(t, 1, len(mid.Contexts))
 
 	base, ok := m["base"]


### PR DESCRIPTION
Clearing the exporter may result in default export behavior from the driver.

fixes #2580