### PR TITLE
bake: fix testing json formatted output

### DIFF
--- a/tests/bake.go
+++ b/tests/bake.go
@@ -1074,15 +1074,16 @@ target "another" {
 	require.Contains(t, out, "another")
 	require.Contains(t, out, "UndefinedVar")
 
-	out, err = bakeCmd(
+	cmd := buildxCmd(
 		sb,
 		withDir(dir),
-		withArgs("build", "another", "--call", "check,format=json"),
+		withArgs("bake", "--progress=quiet", "build", "another", "--call", "check,format=json"),
 	)
-	require.Error(t, err, out)
+	outB, err := cmd.Output()
+	require.Error(t, err, string(outB))
 
 	var res map[string]any
-	err = json.Unmarshal([]byte(out), &res)
+	err = json.Unmarshal(outB, &res)
 	require.NoError(t, err, out)
 
 	targets, ok := res["target"].(map[string]any)


### PR DESCRIPTION
Because the test checked for combinedoutput, it
could contain internal warning messages in stderr. JSON output is guaranteed in stdout.

Fixes #2575

This was the debug output:

```
=== FAIL: tests TestIntegration/TestBakeCallCheckFlag/worker=docker-container (3.96s)
    bake.go:1086: 
        	Error Trace:	/src/tests/bake.go:1086
        	            				/src/vendor/github.com/moby/buildkit/util/testutil/integration/run.go:96
        	            				/src/vendor/github.com/moby/buildkit/util/testutil/integration/run.go:211
        	Error:      	Received unexpected error:
        	            	invalid character '/' after top-level value
        	Test:       	TestIntegration/TestBakeCallCheckFlag/worker=docker-container
        	Messages:   	2024/07/09 00:57:04 http2: server connection error from localhost: connection error: PROTOCOL_ERROR
        	            	{
        	            	  "group": {
        	            	    "default": {
        	            	      "targets": [
        	            	        "build",
        	            	        "another"
        	            	      ]
        	            	    }
```