### PR TITLE
build: don't force default configuration

### DIFF
--- a/controller/build/build.go
+++ b/controller/build/build.go
@@ -3,7 +3,6 @@ package build
 import (
 	"context"
 	"io"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -19,7 +18,6 @@ import (
 	"github.com/docker/buildx/util/platformutil"
 	"github.com/docker/buildx/util/progress"
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/cli/cli/config"
 	dockeropts "github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types/container"
 	"github.com/moby/buildkit/client"
@@ -76,7 +74,7 @@ func RunBuild(ctx context.Context, dockerCli command.Cli, in controllerapi.Build
 	}
 	opts.Platforms = platforms
 
-	dockerConfig := config.LoadDefaultConfigFile(os.Stderr)
+	dockerConfig := dockerCli.ConfigFile()
 	opts.Session = append(opts.Session, authprovider.NewDockerAuthProvider(dockerConfig, nil))
 
 	secrets, err := controllerapi.CreateSecrets(in.Secrets)


### PR DESCRIPTION
`RunBuild` accepts a `command.Cli` interface, but the configuration it ultimately uses for builds is always sourced from `LoadDefaultConfigFile`. This makes it impossible for custom `Cli` implementations to directly provide their own non-default `ConfigFile`.

This PR changes the logic to use the output of `cli.ConfigFile()` instead of `LoadDefaultConfigFile`. The common-case `DockerCli` implementation will continue to use the result of `LoadDefaultConfigFile` ([ref](https://github.com/docker/cli/blob/dc23e775077b00cae2b6c239144053c8e2b5202e/cli/command/cli.go#L152-L159), [ref](https://github.com/docker/cli/blob/dc23e775077b00cae2b6c239144053c8e2b5202e/cli/command/cli.go#L279)), however it will now respect the CLI's error stream instead of forcing stderr.