### PR TITLE
bake: check printer before printing warnings

### DIFF
--- a/commands/bake.go
+++ b/commands/bake.go
@@ -146,7 +146,9 @@ func runBake(ctx context.Context, dockerCli command.Cli, targets []string, in ba
 	printer, err = progress.NewPrinter(ctx2, os.Stderr, progressMode,
 		progress.WithDesc(progressTextDesc, progressConsoleDesc),
 		progress.WithOnClose(func() {
-			printWarnings(os.Stderr, printer.Warnings(), progressMode)
+			if p := printer; p != nil {
+				printWarnings(os.Stderr, p.Warnings(), progressMode)
+			}
 		}),
 	)
 	if err != nil {

--- a/tests/integration.go
+++ b/tests/integration.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -207,4 +208,13 @@ func skipNoCompatBuildKit(t *testing.T, sb integration.Sandbox, constraint strin
 	if !matchesBuildKitVersion(t, sb, constraint) {
 		t.Skipf("buildkit version %s does not match %s constraint (%s)", buildkitVersion(t, sb), constraint, msg)
 	}
+}
+
+func ptrstr(s interface{}) *string {
+	var n *string
+	if reflect.ValueOf(s).Kind() == reflect.String {
+		ss := s.(string)
+		n = &ss
+	}
+	return n
 }


### PR DESCRIPTION
fixes https://github.com/docker/buildx/issues/2598

A simple fix for a patch release but we should do a proper one as follow-up to avoid this situation with `printer` in the first place.