### PR TITLE
update warning message

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -835,7 +835,7 @@ func printWarnings(w io.Writer, warnings []client.VertexWarning, mode progressui
 		fmt.Fprintf(sb, "%d warnings found", len(warnings))
 	}
 	if logrus.GetLevel() < logrus.DebugLevel {
-		fmt.Fprintf(sb, " (use --debug to expand)")
+		fmt.Fprintf(sb, " (use docker --debug to expand)")
 	}
 	fmt.Fprintf(sb, ":\n")
 	fmt.Fprint(w, aec.Apply(sb.String(), aec.YellowF))


### PR DESCRIPTION
This updates the warning message to clarify where to pass in the `--debug` flag when viewing warnings.