### PR TITLE
chore: update dependabot labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,5 +11,5 @@ updates:
       # trigger a new version: https://github.com/docker/buildx/pull/2222#issuecomment-1919092153
       - dependency-name: "docker/docs"
     labels:
-      - "dependencies"
+      - "area/dependencies"
       - "bot"


### PR DESCRIPTION
follow-up https://github.com/moby/buildkit/pull/5153#discussion_r1683157902

swap issues/prs with `dependencies` label to `area/dependencies` and remove `dependencies` label when merged.