### PR TITLE
ci: checkout step for scout job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -331,9 +331,9 @@ jobs:
 
   scout:
     runs-on: ubuntu-24.04
-    if: ${{ github.ref == 'refs/heads/master' }}
+    if: ${{ github.ref == 'refs/heads/master' && github.repository == 'docker/buildx' }}
     permissions:
-      # required to wirte sarif report
+      # required to write sarif report
       security-events: write
     needs:
       - bin-image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -339,6 +339,9 @@ jobs:
       - bin-image
     steps:
       -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
         name: Login to DockerHub
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
checkout seems suggested when uploading the SARIF report: https://github.com/docker/buildx/actions/runs/10093571745/job/27910395571#step:4:25

```
  Processing sarif files: ["/tmp/docker-scout-action-72Brf6/result.txt"]
  Validating /tmp/docker-scout-action-72Brf6/result.txt
  Combining SARIF files using the CodeQL CLI
  Adding fingerprints to SARIF file. See https://docs.github.com/en/enterprise-cloud@latest/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#providing-data-to-track-code-scanning-alerts-across-runs for more information.
  Could not determine current commit SHA using git. Continuing with data from user input or environment. The checkout path provided to the action does not appear to be a git repository.
  Uploading results
  Successfully uploaded results
```

I guess this is to determine the origin. That's smth we might need for https://github.com/moby/buildkit/pull/5184#discussion_r1688125228

Last commit is related to https://github.com/docker/buildx/pull/1715