### PR TITLE
govulncheck to report known vulnerabilities

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,6 +215,36 @@ jobs:
           name: test-reports-${{ env.TESTREPORTS_NAME }}
           path: ${{ env.TESTREPORTS_BASEDIR }}
 
+  govulncheck:
+    runs-on: ubuntu-24.04
+    permissions:
+      # required to write sarif report
+      security-events: write
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          version: ${{ env.BUILDX_VERSION }}
+          driver-opts: image=${{ env.BUILDKIT_IMAGE }}
+          buildkitd-flags: --debug
+      -
+        name: Run
+        uses: docker/bake-action@v5
+        with:
+          targets: govulncheck
+        env:
+          GOVULNCHECK_FORMAT: sarif
+      -
+        name: Upload SARIF report
+        if: ${{ github.ref == 'refs/heads/master' && github.repository == 'docker/buildx' }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ env.DESTDIR }}/govulncheck.out
+
   prepare-binaries:
     runs-on: ubuntu-24.04
     outputs:

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -217,3 +217,18 @@ target "integration-test" {
   inherits = ["integration-test-base"]
   target = "integration-test"
 }
+
+variable "GOVULNCHECK_FORMAT" {
+  default = null
+}
+
+target "govulncheck" {
+  inherits = ["_common"]
+  dockerfile = "./hack/dockerfiles/govulncheck.Dockerfile"
+  target = "output"
+  args = {
+    FORMAT = GOVULNCHECK_FORMAT
+  }
+  no-cache-filter = ["run"]
+  output = ["${DESTDIR}"]
+}

--- a/hack/dockerfiles/govulncheck.Dockerfile
+++ b/hack/dockerfiles/govulncheck.Dockerfile
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1
+
+ARG GO_VERSION="1.22"
+ARG GOVULNCHECK_VERSION="v1.1.3"
+ARG FORMAT="text"
+
+FROM golang:${GO_VERSION}-alpine AS base
+WORKDIR /go/src/github.com/docker/buildx
+ARG GOVULNCHECK_VERSION
+RUN --mount=type=cache,target=/root/.cache \
+    --mount=type=cache,target=/go/pkg/mod \
+    go install golang.org/x/vuln/cmd/govulncheck@$GOVULNCHECK_VERSION
+
+FROM base AS run
+ARG FORMAT
+RUN --mount=type=bind,target=. <<EOT
+  set -ex
+  mkdir /out
+  govulncheck -format ${FORMAT} ./... | tee /out/govulncheck.out
+EOT
+
+FROM scratch AS output
+COPY --from=run /out /


### PR DESCRIPTION
Runs [govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) tool in our workflow to report known vulnerabilities that affect Go code using the Go vulnerability database at https://vuln.go.dev/ and output a SARIF report that will be uploaded to [GitHub Code scanning](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning) so we have these issues reported in the [Security tab](https://github.com/docker/buildx/security) like we have done with Docker Scout in https://github.com/docker/buildx/pull/2624.

Atm dependabot will open a pull request when such vulnerabilities are found similar to https://github.com/docker/buildx/pull/2337 but we often close them because it needs coordination with upstream repositories first.

I suggest to disable security updates for Dependabot under https://github.com/docker/buildx/settings/security_analysis and check issues reported in the Security tab instead with this workflow if we are ok with it:

![image](https://github.com/user-attachments/assets/c1b6aa8b-6467-4193-9f26-bb0ba99aaa52)
