### PR TITLE
support metadata file with call flag for build and bake commands

### DIFF
--- a/commands/bake.go
+++ b/commands/bake.go
@@ -252,13 +252,15 @@ func runBake(ctx context.Context, dockerCli command.Cli, targets []string, in ba
 	if progressMode != progressui.QuietMode && progressMode != progressui.RawJSONMode {
 		desktop.PrintBuildDetails(os.Stderr, printer.BuildRefs(), term)
 	}
-	if callFunc == nil && len(in.metadataFile) > 0 {
+	if len(in.metadataFile) > 0 {
 		dt := make(map[string]interface{})
 		for t, r := range resp {
 			dt[t] = decodeExporterResponse(r.ExporterResponse)
 		}
-		if warnings := printer.Warnings(); len(warnings) > 0 && confutil.MetadataWarningsEnabled() {
-			dt["buildx.build.warnings"] = warnings
+		if callFunc == nil {
+			if warnings := printer.Warnings(); len(warnings) > 0 && confutil.MetadataWarningsEnabled() {
+				dt["buildx.build.warnings"] = warnings
+			}
 		}
 		if err := writeMetadataFile(in.metadataFile, dt); err != nil {
 			return err


### PR DESCRIPTION
Atm when using `--call` or `--check`, the metadata file is not generated:

```
$ docker buildx build --call check --file ./test/bad.Dockerfile --metadata-file md.json ./test
...
  12 |     CMD [ "echo", "Hello, Sweden!" ]
  13 |     ENTRYPOINT my-program start
--------------------

WARNING: JSONArgsRecommended - https://docs.docker.com/go/dockerfile/rule/json-args-recommended/
JSON arguments recommended for ENTRYPOINT to prevent unintended behavior related to OS signals
bad.Dockerfile:13
--------------------
  11 |     CMD [ "echo", "Hello, Norway!" ]
  12 |     CMD [ "echo", "Hello, Sweden!" ]
  13 | >>> ENTRYPOINT my-program start
  14 |
--------------------

$ cat md.json
cat: md.json: No such file or directory
```

I think we should allow it for build warnings related to https://github.com/docker/buildx/pull/2551

So we can ingest call result if we want to do extra work with similar to https://github.com/docker/build-push-action/pull/1197.