### PR TITLE
bake: add basename, dirname and sanitize functions

### DIFF
--- a/bake/hclparser/stdlib_test.go
+++ b/bake/hclparser/stdlib_test.go
@@ -3,6 +3,7 @@ package hclparser
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -35,15 +36,164 @@ func TestIndexOf(t *testing.T) {
 		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			got, err := indexOfFunc().Call([]cty.Value{test.input, test.key})
-			if err != nil {
-				if test.wantErr {
-					return
-				}
-				t.Fatalf("unexpected error: %s", err)
+			if test.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.want, got)
 			}
-			if !got.RawEquals(test.want) {
-				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.want)
+		})
+	}
+}
+
+func TestBasename(t *testing.T) {
+	type testCase struct {
+		input   cty.Value
+		want    cty.Value
+		wantErr bool
+	}
+	tests := map[string]testCase{
+		"empty": {
+			input: cty.StringVal(""),
+			want:  cty.StringVal("."),
+		},
+		"slash": {
+			input: cty.StringVal("/"),
+			want:  cty.StringVal("/"),
+		},
+		"simple": {
+			input: cty.StringVal("/foo/bar"),
+			want:  cty.StringVal("bar"),
+		},
+		"simple no slash": {
+			input: cty.StringVal("foo/bar"),
+			want:  cty.StringVal("bar"),
+		},
+		"dot": {
+			input: cty.StringVal("/foo/bar."),
+			want:  cty.StringVal("bar."),
+		},
+		"dotdot": {
+			input: cty.StringVal("/foo/bar.."),
+			want:  cty.StringVal("bar.."),
+		},
+		"dotdotdot": {
+			input: cty.StringVal("/foo/bar..."),
+			want:  cty.StringVal("bar..."),
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			got, err := basenameFunc().Call([]cty.Value{test.input})
+			if test.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.want, got)
 			}
+		})
+	}
+}
+
+func TestDirname(t *testing.T) {
+	type testCase struct {
+		input   cty.Value
+		want    cty.Value
+		wantErr bool
+	}
+	tests := map[string]testCase{
+		"empty": {
+			input: cty.StringVal(""),
+			want:  cty.StringVal("."),
+		},
+		"slash": {
+			input: cty.StringVal("/"),
+			want:  cty.StringVal("/"),
+		},
+		"simple": {
+			input: cty.StringVal("/foo/bar"),
+			want:  cty.StringVal("/foo"),
+		},
+		"simple no slash": {
+			input: cty.StringVal("foo/bar"),
+			want:  cty.StringVal("foo"),
+		},
+		"dot": {
+			input: cty.StringVal("/foo/bar."),
+			want:  cty.StringVal("/foo"),
+		},
+		"dotdot": {
+			input: cty.StringVal("/foo/bar.."),
+			want:  cty.StringVal("/foo"),
+		},
+		"dotdotdot": {
+			input: cty.StringVal("/foo/bar..."),
+			want:  cty.StringVal("/foo"),
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			got, err := dirnameFunc().Call([]cty.Value{test.input})
+			if test.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.want, got)
+			}
+		})
+	}
+}
+
+func TestSanitize(t *testing.T) {
+	type testCase struct {
+		input cty.Value
+		want  cty.Value
+	}
+	tests := map[string]testCase{
+		"empty": {
+			input: cty.StringVal(""),
+			want:  cty.StringVal(""),
+		},
+		"simple": {
+			input: cty.StringVal("foo/bar"),
+			want:  cty.StringVal("foo_bar"),
+		},
+		"simple no slash": {
+			input: cty.StringVal("foobar"),
+			want:  cty.StringVal("foobar"),
+		},
+		"dot": {
+			input: cty.StringVal("foo/bar."),
+			want:  cty.StringVal("foo_bar_"),
+		},
+		"dotdot": {
+			input: cty.StringVal("foo/bar.."),
+			want:  cty.StringVal("foo_bar__"),
+		},
+		"dotdotdot": {
+			input: cty.StringVal("foo/bar..."),
+			want:  cty.StringVal("foo_bar___"),
+		},
+		"utf8": {
+			input: cty.StringVal("foo/🍕bar"),
+			want:  cty.StringVal("foo__bar"),
+		},
+		"symbols": {
+			input: cty.StringVal("foo/bar!@(ba+z)"),
+			want:  cty.StringVal("foo_bar___ba_z_"),
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			got, err := sanitizeFunc().Call([]cty.Value{test.input})
+			require.NoError(t, err)
+			require.Equal(t, test.want, got)
 		})
 	}
 }


### PR DESCRIPTION
These functions help with dealing with path inputs and using parts of them to configure targets.

For example, this improves cases like https://github.com/moby/buildkit/pull/5248/files#diff-870f6fe23fc034f008f5203ee1e628d7bfa65a49095d5a4688db498328449ed2R238 where current best approach is to take hash and lose readability of the variable.