### PR TITLE
build: when building multiple targets include name in error

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -309,7 +309,7 @@ func BuildWithResultHandler(ctx context.Context, nodes []builder.Node, opt map[s
 	childTargets := calculateChildTargets(reqForNodes, opt)
 
 	for k, opt := range opt {
-		err := func(k string) error {
+		err := func(k string) (err error) {
 			opt := opt
 			dps := drivers[k]
 			multiDriver := len(drivers[k]) > 1
@@ -320,6 +320,12 @@ func BuildWithResultHandler(ctx context.Context, nodes []builder.Node, opt map[s
 				span, ctx = tracing.StartSpan(ctx, k)
 			}
 			baseCtx := ctx
+
+			if multiTarget {
+				defer func() {
+					err = errors.Wrapf(err, "target %s", k)
+				}()
+			}
 
 			res := make([]*client.SolveResponse, len(dps))
 			eg2, ctx := errgroup.WithContext(ctx)
@@ -563,6 +569,13 @@ func BuildWithResultHandler(ctx context.Context, nodes []builder.Node, opt map[s
 						tracing.FinishWithError(span, err)
 					}
 				}()
+
+				if multiTarget {
+					defer func() {
+						err = errors.Wrapf(err, "target %s", k)
+					}()
+				}
+
 				pw := progress.WithPrefix(w, "default", false)
 				if err := eg2.Wait(); err != nil {
 					return err


### PR DESCRIPTION
Some errors can appear without a stacktrace or progress record, eg. wrong Dockerfile name passed. In that case when building many targets with bake it might be hard to figure out which target failed as in the progressbar there will only be steps that were cancelled.