### PR TITLE
metrics: add mutex to the metric writer

### DIFF
--- a/util/progress/metricwriter.go
+++ b/util/progress/metricwriter.go
@@ -45,6 +45,7 @@ var re = sync.OnceValue(func() *rePatterns {
 type metricWriter struct {
 	recorders []metricRecorder
 	attrs     attribute.Set
+	mu        sync.Mutex
 }
 
 func newMetrics(mp metric.MeterProvider, attrs attribute.Set) *metricWriter {
@@ -63,6 +64,9 @@ func newMetrics(mp metric.MeterProvider, attrs attribute.Set) *metricWriter {
 }
 
 func (mw *metricWriter) Write(ss *client.SolveStatus) {
+	mw.mu.Lock()
+	defer mw.mu.Unlock()
+
 	for _, recorder := range mw.recorders {
 		recorder.Record(ss)
 	}


### PR DESCRIPTION
It was possible for multiple status messages to be written at the same time which caused some of the metric writer code to have a race condition.

This code should be fast enough that it doesn't interrupt the display, but some further work might be needed here.