### PR TITLE
commands: add debug as persistent flag

### DIFF
--- a/docs/reference/buildx.md
+++ b/docs/reference/buildx.md
@@ -32,6 +32,7 @@ Extended build capabilities with BuildKit
 | Name                    | Type     | Default | Description                              |
 |:------------------------|:---------|:--------|:-----------------------------------------|
 | [`--builder`](#builder) | `string` |         | Override the configured builder instance |
+| `-D`, `--debug`         | `bool`   |         | Enable debug logging                     |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_bake.md
+++ b/docs/reference/buildx_bake.md
@@ -18,6 +18,7 @@ Build from a file
 | [`--builder`](#builder)             | `string`      |         | Override the configured builder instance                                                            |
 | [`--call`](#call)                   | `string`      | `build` | Set method for evaluating build (`check`, `outline`, `targets`)                                     |
 | [`--check`](#check)                 | `bool`        |         | Shorthand for `--call=check`                                                                        |
+| `-D`, `--debug`                     | `bool`        |         | Enable debug logging                                                                                |
 | [`-f`](#file), [`--file`](#file)    | `stringArray` |         | Build definition file                                                                               |
 | `--load`                            | `bool`        |         | Shorthand for `--set=*.output=type=docker`                                                          |
 | [`--metadata-file`](#metadata-file) | `string`      |         | Write build result metadata to a file                                                               |

--- a/docs/reference/buildx_build.md
+++ b/docs/reference/buildx_build.md
@@ -27,6 +27,7 @@ Start a build
 | [`--call`](#call)                       | `string`      | `build`   | Set method for evaluating build (`check`, `outline`, `targets`)                                     |
 | [`--cgroup-parent`](#cgroup-parent)     | `string`      |           | Set the parent cgroup for the `RUN` instructions during build                                       |
 | [`--check`](#check)                     | `bool`        |           | Shorthand for `--call=check`                                                                        |
+| `-D`, `--debug`                         | `bool`        |           | Enable debug logging                                                                                |
 | `--detach`                              | `bool`        |           | Detach buildx server (supported only on linux) (EXPERIMENTAL)                                       |
 | [`-f`](#file), [`--file`](#file)        | `string`      |           | Name of the Dockerfile (default: `PATH/Dockerfile`)                                                 |
 | `--iidfile`                             | `string`      |           | Write the image ID to a file                                                                        |

--- a/docs/reference/buildx_create.md
+++ b/docs/reference/buildx_create.md
@@ -15,6 +15,7 @@ Create a new builder instance
 | `--bootstrap`                             | `bool`        |         | Boot builder after creation                                           |
 | [`--buildkitd-config`](#buildkitd-config) | `string`      |         | BuildKit daemon config file                                           |
 | [`--buildkitd-flags`](#buildkitd-flags)   | `string`      |         | BuildKit daemon flags                                                 |
+| `-D`, `--debug`                           | `bool`        |         | Enable debug logging                                                  |
 | [`--driver`](#driver)                     | `string`      |         | Driver to use (available: `docker-container`, `kubernetes`, `remote`) |
 | [`--driver-opt`](#driver-opt)             | `stringArray` |         | Options for the driver                                                |
 | [`--leave`](#leave)                       | `bool`        |         | Remove a node from builder instead of changing it                     |

--- a/docs/reference/buildx_debug.md
+++ b/docs/reference/buildx_debug.md
@@ -15,6 +15,7 @@ Start debugger (EXPERIMENTAL)
 | Name              | Type     | Default | Description                                                                                                         |
 |:------------------|:---------|:--------|:--------------------------------------------------------------------------------------------------------------------|
 | `--builder`       | `string` |         | Override the configured builder instance                                                                            |
+| `-D`, `--debug`   | `bool`   |         | Enable debug logging                                                                                                |
 | `--detach`        | `bool`   | `true`  | Detach buildx server for the monitor (supported only on linux) (EXPERIMENTAL)                                       |
 | `--invoke`        | `string` |         | Launch a monitor with executing specified command (EXPERIMENTAL)                                                    |
 | `--on`            | `string` | `error` | When to launch the monitor ([always, error]) (EXPERIMENTAL)                                                         |

--- a/docs/reference/buildx_debug_build.md
+++ b/docs/reference/buildx_debug_build.md
@@ -23,6 +23,7 @@ Start a build
 | `--call`            | `string`      | `build`   | Set method for evaluating build (`check`, `outline`, `targets`)                                     |
 | `--cgroup-parent`   | `string`      |           | Set the parent cgroup for the `RUN` instructions during build                                       |
 | `--check`           | `bool`        |           | Shorthand for `--call=check`                                                                        |
+| `-D`, `--debug`     | `bool`        |           | Enable debug logging                                                                                |
 | `--detach`          | `bool`        |           | Detach buildx server (supported only on linux) (EXPERIMENTAL)                                       |
 | `-f`, `--file`      | `string`      |           | Name of the Dockerfile (default: `PATH/Dockerfile`)                                                 |
 | `--iidfile`         | `string`      |           | Write the image ID to a file                                                                        |

--- a/docs/reference/buildx_dial-stdio.md
+++ b/docs/reference/buildx_dial-stdio.md
@@ -5,11 +5,12 @@ Proxy current stdio streams to builder instance
 
 ### Options
 
-| Name         | Type     | Default | Description                                                                                         |
-|:-------------|:---------|:--------|:----------------------------------------------------------------------------------------------------|
-| `--builder`  | `string` |         | Override the configured builder instance                                                            |
-| `--platform` | `string` |         | Target platform: this is used for node selection                                                    |
-| `--progress` | `string` | `quiet` | Set type of progress output (`auto`, `plain`, `tty`, `rawjson`). Use plain to show container output |
+| Name            | Type     | Default | Description                                                                                         |
+|:----------------|:---------|:--------|:----------------------------------------------------------------------------------------------------|
+| `--builder`     | `string` |         | Override the configured builder instance                                                            |
+| `-D`, `--debug` | `bool`   |         | Enable debug logging                                                                                |
+| `--platform`    | `string` |         | Target platform: this is used for node selection                                                    |
+| `--progress`    | `string` | `quiet` | Set type of progress output (`auto`, `plain`, `tty`, `rawjson`). Use plain to show container output |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_du.md
+++ b/docs/reference/buildx_du.md
@@ -12,6 +12,7 @@ Disk usage
 | Name                    | Type     | Default | Description                              |
 |:------------------------|:---------|:--------|:-----------------------------------------|
 | [`--builder`](#builder) | `string` |         | Override the configured builder instance |
+| `-D`, `--debug`         | `bool`   |         | Enable debug logging                     |
 | `--filter`              | `filter` |         | Provide filter values                    |
 | [`--verbose`](#verbose) | `bool`   |         | Provide a more verbose output            |
 

--- a/docs/reference/buildx_imagetools.md
+++ b/docs/reference/buildx_imagetools.md
@@ -20,6 +20,7 @@ Commands to work on images in registry
 | Name                    | Type     | Default | Description                              |
 |:------------------------|:---------|:--------|:-----------------------------------------|
 | [`--builder`](#builder) | `string` |         | Override the configured builder instance |
+| `-D`, `--debug`         | `bool`   |         | Enable debug logging                     |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_imagetools_create.md
+++ b/docs/reference/buildx_imagetools_create.md
@@ -14,6 +14,7 @@ Create a new image based on source images
 | [`--annotation`](#annotation)    | `stringArray` |         | Add annotation to the image                                                                                                   |
 | [`--append`](#append)            | `bool`        |         | Append to existing manifest                                                                                                   |
 | [`--builder`](#builder)          | `string`      |         | Override the configured builder instance                                                                                      |
+| `-D`, `--debug`                  | `bool`        |         | Enable debug logging                                                                                                          |
 | [`--dry-run`](#dry-run)          | `bool`        |         | Show final image instead of pushing                                                                                           |
 | [`-f`](#file), [`--file`](#file) | `stringArray` |         | Read source descriptor from file                                                                                              |
 | `--prefer-index`                 | `bool`        | `true`  | When only a single source is specified, prefer outputting an image index or manifest list instead of performing a carbon copy |

--- a/docs/reference/buildx_imagetools_inspect.md
+++ b/docs/reference/buildx_imagetools_inspect.md
@@ -12,6 +12,7 @@ Show details of an image in the registry
 | Name                    | Type     | Default         | Description                                   |
 |:------------------------|:---------|:----------------|:----------------------------------------------|
 | [`--builder`](#builder) | `string` |                 | Override the configured builder instance      |
+| `-D`, `--debug`         | `bool`   |                 | Enable debug logging                          |
 | [`--format`](#format)   | `string` | `{{.Manifest}}` | Format the output using the given Go template |
 | [`--raw`](#raw)         | `bool`   |                 | Show original, unformatted JSON manifest      |
 

--- a/docs/reference/buildx_inspect.md
+++ b/docs/reference/buildx_inspect.md
@@ -13,6 +13,7 @@ Inspect current builder instance
 |:----------------------------|:---------|:--------|:--------------------------------------------|
 | [`--bootstrap`](#bootstrap) | `bool`   |         | Ensure builder has booted before inspecting |
 | [`--builder`](#builder)     | `string` |         | Override the configured builder instance    |
+| `-D`, `--debug`             | `bool`   |         | Enable debug logging                        |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_ls.md
+++ b/docs/reference/buildx_ls.md
@@ -9,9 +9,10 @@ List builder instances
 
 ### Options
 
-| Name                  | Type     | Default | Description       |
-|:----------------------|:---------|:--------|:------------------|
-| [`--format`](#format) | `string` | `table` | Format the output |
+| Name                  | Type     | Default | Description          |
+|:----------------------|:---------|:--------|:---------------------|
+| `-D`, `--debug`       | `bool`   |         | Enable debug logging |
+| [`--format`](#format) | `string` | `table` | Format the output    |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_prune.md
+++ b/docs/reference/buildx_prune.md
@@ -13,6 +13,7 @@ Remove build cache
 |:------------------------|:---------|:--------|:------------------------------------------|
 | `-a`, `--all`           | `bool`   |         | Include internal/frontend images          |
 | [`--builder`](#builder) | `string` |         | Override the configured builder instance  |
+| `-D`, `--debug`         | `bool`   |         | Enable debug logging                      |
 | `--filter`              | `filter` |         | Provide filter values (e.g., `until=24h`) |
 | `-f`, `--force`         | `bool`   |         | Do not prompt for confirmation            |
 | `--keep-storage`        | `bytes`  | `0`     | Amount of disk space to keep for cache    |

--- a/docs/reference/buildx_rm.md
+++ b/docs/reference/buildx_rm.md
@@ -13,6 +13,7 @@ Remove one or more builder instances
 |:------------------------------------|:---------|:--------|:-----------------------------------------|
 | [`--all-inactive`](#all-inactive)   | `bool`   |         | Remove all inactive builders             |
 | [`--builder`](#builder)             | `string` |         | Override the configured builder instance |
+| `-D`, `--debug`                     | `bool`   |         | Enable debug logging                     |
 | [`-f`](#force), [`--force`](#force) | `bool`   |         | Do not prompt for confirmation           |
 | [`--keep-daemon`](#keep-daemon)     | `bool`   |         | Keep the BuildKit daemon running         |
 | [`--keep-state`](#keep-state)       | `bool`   |         | Keep BuildKit state                      |

--- a/docs/reference/buildx_stop.md
+++ b/docs/reference/buildx_stop.md
@@ -12,6 +12,7 @@ Stop builder instance
 | Name                    | Type     | Default | Description                              |
 |:------------------------|:---------|:--------|:-----------------------------------------|
 | [`--builder`](#builder) | `string` |         | Override the configured builder instance |
+| `-D`, `--debug`         | `bool`   |         | Enable debug logging                     |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_use.md
+++ b/docs/reference/buildx_use.md
@@ -12,6 +12,7 @@ Set the current builder instance
 | Name                    | Type     | Default | Description                                |
 |:------------------------|:---------|:--------|:-------------------------------------------|
 | [`--builder`](#builder) | `string` |         | Override the configured builder instance   |
+| `-D`, `--debug`         | `bool`   |         | Enable debug logging                       |
 | `--default`             | `bool`   |         | Set builder as default for current context |
 | `--global`              | `bool`   |         | Builder persists context changes           |
 

--- a/docs/reference/buildx_version.md
+++ b/docs/reference/buildx_version.md
@@ -7,6 +7,12 @@ docker buildx version
 <!---MARKER_GEN_START-->
 Show buildx version information
 
+### Options
+
+| Name            | Type   | Default | Description          |
+|:----------------|:-------|:--------|:---------------------|
+| `-D`, `--debug` | `bool` |         | Enable debug logging |
+
 
 <!---MARKER_GEN_END-->
 


### PR DESCRIPTION
Allows using `--debug` to enable debug logging under any subcommand. Currently it needed to be set as
`docker --debug buildx` meaning only way to enable debug in standalone mode was to set env variable instead and updating existing commands to add `--debug` was cumbersome.