### PR TITLE
build: display Dockerfile path on check warnings

### DIFF
--- a/build/opt.go
+++ b/build/opt.go
@@ -35,7 +35,7 @@ import (
 	"github.com/tonistiigi/fsutil"
 )
 
-func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt Options, bopts gateway.BuildOpts, configDir string, pw progress.Writer, docker *dockerutil.Client) (_ *client.SolveOpt, release func(), err error) {
+func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt Options, bopts gateway.BuildOpts, configDir string, pw progress.Writer, docker *dockerutil.Client) (_ *client.SolveOpt, release func(), dockerfileMapping *DockerfileMapping, err error) {
 	nodeDriver := node.Driver
 	defers := make([]func(), 0, 2)
 	releaseF := func() {
@@ -62,7 +62,7 @@ func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt Op
 
 	for _, e := range opt.CacheTo {
 		if e.Type != "inline" && !nodeDriver.Features(ctx)[driver.CacheExport] {
-			return nil, nil, notSupported(driver.CacheExport, nodeDriver, "https://docs.docker.com/go/build-cache-backends/")
+			return nil, nil, nil, notSupported(driver.CacheExport, nodeDriver, "https://docs.docker.com/go/build-cache-backends/")
 		}
 	}
 
@@ -131,9 +131,9 @@ func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt Op
 	if len(attests) > 0 {
 		if !supportAttestations {
 			if !nodeDriver.Features(ctx)[driver.MultiPlatform] {
-				return nil, nil, notSupported("Attestation", nodeDriver, "https://docs.docker.com/go/attestations/")
+				return nil, nil, nil, notSupported("Attestation", nodeDriver, "https://docs.docker.com/go/attestations/")
 			}
-			return nil, nil, errors.Errorf("Attestations are not supported by the current BuildKit daemon")
+			return nil, nil, nil, errors.Errorf("Attestations are not supported by the current BuildKit daemon")
 		}
 		for k, v := range attests {
 			so.FrontendAttrs["attest:"+k] = v
@@ -146,7 +146,7 @@ func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt Op
 		if v, ok := os.LookupEnv(noAttestEnv); ok {
 			noProv, err = strconv.ParseBool(v)
 			if err != nil {
-				return nil, nil, errors.Wrap(err, "invalid "+noAttestEnv)
+				return nil, nil, nil, errors.Wrap(err, "invalid "+noAttestEnv)
 			}
 		}
 		if !noProv {
@@ -169,7 +169,7 @@ func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt Op
 		}
 	default:
 		if err := bopts.LLBCaps.Supports(pb.CapMultipleExporters); err != nil {
-			return nil, nil, errors.Errorf("multiple outputs currently unsupported by the current BuildKit daemon, please upgrade to version v0.13+ or use a single output")
+			return nil, nil, nil, errors.Errorf("multiple outputs currently unsupported by the current BuildKit daemon, please upgrade to version v0.13+ or use a single output")
 		}
 	}
 
@@ -179,7 +179,7 @@ func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt Op
 		for i, tag := range opt.Tags {
 			ref, err := reference.Parse(tag)
 			if err != nil {
-				return nil, nil, errors.Wrapf(err, "invalid tag %q", tag)
+				return nil, nil, nil, errors.Wrapf(err, "invalid tag %q", tag)
 			}
 			tags[i] = ref.String()
 		}
@@ -193,7 +193,7 @@ func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt Op
 		for _, e := range opt.Exports {
 			if e.Type == "image" && e.Attrs["name"] == "" && e.Attrs["push"] != "" {
 				if ok, _ := strconv.ParseBool(e.Attrs["push"]); ok {
-					return nil, nil, errors.Errorf("tag is needed when pushing to registry")
+					return nil, nil, nil, errors.Errorf("tag is needed when pushing to registry")
 				}
 			}
 		}
@@ -211,7 +211,7 @@ func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt Op
 	// set up exporters
 	for i, e := range opt.Exports {
 		if e.Type == "oci" && !nodeDriver.Features(ctx)[driver.OCIExporter] {
-			return nil, nil, notSupported(driver.OCIExporter, nodeDriver, "https://docs.docker.com/go/build-exporters/")
+			return nil, nil, nil, notSupported(driver.OCIExporter, nodeDriver, "https://docs.docker.com/go/build-exporters/")
 		}
 		if e.Type == "docker" {
 			features := docker.Features(ctx, e.Attrs["context"])
@@ -221,9 +221,9 @@ func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt Op
 				opt.Exports[i].Type = "oci"
 			} else if len(opt.Platforms) > 1 || len(attests) > 0 {
 				if e.Output != nil {
-					return nil, nil, errors.Errorf("docker exporter does not support exporting manifest lists, use the oci exporter instead")
+					return nil, nil, nil, errors.Errorf("docker exporter does not support exporting manifest lists, use the oci exporter instead")
 				}
-				return nil, nil, errors.Errorf("docker exporter does not currently support exporting manifest lists")
+				return nil, nil, nil, errors.Errorf("docker exporter does not currently support exporting manifest lists")
 			}
 			if e.Output == nil {
 				if nodeDriver.IsMobyDriver() {
@@ -231,7 +231,7 @@ func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt Op
 				} else {
 					w, cancel, err := docker.LoadImage(ctx, e.Attrs["context"], pw)
 					if err != nil {
-						return nil, nil, err
+						return nil, nil, nil, err
 					}
 					defers = append(defers, cancel)
 					opt.Exports[i].Output = func(_ map[string]string) (io.WriteCloser, error) {
@@ -239,7 +239,7 @@ func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt Op
 					}
 				}
 			} else if !nodeDriver.Features(ctx)[driver.DockerExporter] {
-				return nil, nil, notSupported(driver.DockerExporter, nodeDriver, "https://docs.docker.com/go/build-exporters/")
+				return nil, nil, nil, notSupported(driver.DockerExporter, nodeDriver, "https://docs.docker.com/go/build-exporters/")
 			}
 		}
 		if e.Type == "image" && nodeDriver.IsMobyDriver() {
@@ -247,7 +247,7 @@ func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt Op
 			if e.Attrs["push"] != "" {
 				if ok, _ := strconv.ParseBool(e.Attrs["push"]); ok {
 					if ok, _ := strconv.ParseBool(e.Attrs["push-by-digest"]); ok {
-						return nil, nil, errors.Errorf("push-by-digest is currently not implemented for docker driver, please create a new builder instance")
+						return nil, nil, nil, errors.Errorf("push-by-digest is currently not implemented for docker driver, please create a new builder instance")
 					}
 				}
 			}
@@ -263,9 +263,9 @@ func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt Op
 	so.Exports = opt.Exports
 	so.Session = slices.Clone(opt.Session)
 
-	releaseLoad, err := loadInputs(ctx, nodeDriver, opt.Inputs, pw, &so)
+	releaseLoad, dockerfileMapping, err := loadInputs(ctx, nodeDriver, opt.Inputs, pw, &so)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	defers = append(defers, releaseLoad)
 
@@ -309,7 +309,7 @@ func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt Op
 			pp[i] = platforms.Format(p)
 		}
 		if len(pp) > 1 && !nodeDriver.Features(ctx)[driver.MultiPlatform] {
-			return nil, nil, notSupported(driver.MultiPlatform, nodeDriver, "https://docs.docker.com/go/build-multi-platform/")
+			return nil, nil, nil, notSupported(driver.MultiPlatform, nodeDriver, "https://docs.docker.com/go/build-multi-platform/")
 		}
 		so.FrontendAttrs["platform"] = strings.Join(pp, ",")
 	}
@@ -323,13 +323,13 @@ func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt Op
 		so.FrontendAttrs["force-network-mode"] = opt.NetworkMode
 	case "", "default":
 	default:
-		return nil, nil, errors.Errorf("network mode %q not supported by buildkit - you can define a custom network for your builder using the network driver-opt in buildx create", opt.NetworkMode)
+		return nil, nil, nil, errors.Errorf("network mode %q not supported by buildkit - you can define a custom network for your builder using the network driver-opt in buildx create", opt.NetworkMode)
 	}
 
 	// setup extrahosts
 	extraHosts, err := toBuildkitExtraHosts(ctx, opt.ExtraHosts, nodeDriver)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	if len(extraHosts) > 0 {
 		so.FrontendAttrs["add-hosts"] = extraHosts
@@ -343,7 +343,7 @@ func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt Op
 	// setup ulimits
 	ulimits, err := toBuildkitUlimits(opt.Ulimits)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	} else if len(ulimits) > 0 {
 		so.FrontendAttrs["ulimit"] = ulimits
 	}
@@ -353,23 +353,34 @@ func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt Op
 		so.Internal = true
 	}
 
-	return &so, releaseF, nil
+	return &so, releaseF, dockerfileMapping, nil
 }
 
-func loadInputs(ctx context.Context, d *driver.DriverHandle, inp Inputs, pw progress.Writer, target *client.SolveOpt) (func(), error) {
+type DockerfileMapping struct {
+	Src string
+	Dst string
+}
+
+func loadInputs(ctx context.Context, d *driver.DriverHandle, inp Inputs, pw progress.Writer, target *client.SolveOpt) (func(), *DockerfileMapping, error) {
 	if inp.ContextPath == "" {
-		return nil, errors.New("please specify build context (e.g. \".\" for the current directory)")
+		return nil, nil, errors.New("please specify build context (e.g. \".\" for the current directory)")
 	}
 
 	// TODO: handle stdin, symlinks, remote contexts, check files exist
 
 	var (
-		err              error
-		dockerfileReader io.ReadCloser
-		dockerfileDir    string
-		dockerfileName   = inp.DockerfilePath
-		toRemove         []string
+		err               error
+		dockerfileReader  io.ReadCloser
+		dockerfileDir     string
+		dockerfileName    = inp.DockerfilePath
+		dockerfileSrcName = inp.DockerfilePath
+		toRemove          []string
 	)
+	if inp.DockerfilePath == "-" {
+		dockerfileSrcName = "stdin"
+	} else if inp.DockerfilePath == "" {
+		dockerfileSrcName = filepath.Join(inp.ContextPath, "Dockerfile")
+	}
 
 	switch {
 	case inp.ContextState != nil:
@@ -380,13 +391,13 @@ func loadInputs(ctx context.Context, d *driver.DriverHandle, inp Inputs, pw prog
 		target.FrontendInputs["dockerfile"] = *inp.ContextState
 	case inp.ContextPath == "-":
 		if inp.DockerfilePath == "-" {
-			return nil, errors.Errorf("invalid argument: can't use stdin for both build context and dockerfile")
+			return nil, nil, errors.Errorf("invalid argument: can't use stdin for both build context and dockerfile")
 		}
 
 		rc := inp.InStream.NewReadCloser()
 		magic, err := inp.InStream.Peek(archiveHeaderSize * 2)
 		if err != nil && err != io.EOF {
-			return nil, errors.Wrap(err, "failed to peek context header from STDIN")
+			return nil, nil, errors.Wrap(err, "failed to peek context header from STDIN")
 		}
 		if !(err == io.EOF && len(magic) == 0) {
 			if isArchive(magic) {
@@ -396,20 +407,20 @@ func loadInputs(ctx context.Context, d *driver.DriverHandle, inp Inputs, pw prog
 				target.Session = append(target.Session, up)
 			} else {
 				if inp.DockerfilePath != "" {
-					return nil, errors.Errorf("ambiguous Dockerfile source: both stdin and flag correspond to Dockerfiles")
+					return nil, nil, errors.Errorf("ambiguous Dockerfile source: both stdin and flag correspond to Dockerfiles")
 				}
 				// stdin is dockerfile
 				dockerfileReader = rc
 				inp.ContextPath, _ = os.MkdirTemp("", "empty-dir")
 				toRemove = append(toRemove, inp.ContextPath)
 				if err := setLocalMount("context", inp.ContextPath, target); err != nil {
-					return nil, err
+					return nil, nil, err
 				}
 			}
 		}
 	case osutil.IsLocalDir(inp.ContextPath):
 		if err := setLocalMount("context", inp.ContextPath, target); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		sharedKey := inp.ContextPath
 		if p, err := filepath.Abs(sharedKey); err == nil {
@@ -435,7 +446,7 @@ func loadInputs(ctx context.Context, d *driver.DriverHandle, inp Inputs, pw prog
 		}
 		target.FrontendAttrs["context"] = inp.ContextPath
 	default:
-		return nil, errors.Errorf("unable to prepare context: path %q not found", inp.ContextPath)
+		return nil, nil, errors.Errorf("unable to prepare context: path %q not found", inp.ContextPath)
 	}
 
 	if inp.DockerfileInline != "" {
@@ -445,7 +456,7 @@ func loadInputs(ctx context.Context, d *driver.DriverHandle, inp Inputs, pw prog
 	if dockerfileReader != nil {
 		dockerfileDir, err = createTempDockerfile(dockerfileReader, inp.InStream)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		toRemove = append(toRemove, dockerfileDir)
 		dockerfileName = "Dockerfile"
@@ -454,7 +465,7 @@ func loadInputs(ctx context.Context, d *driver.DriverHandle, inp Inputs, pw prog
 	if isHTTPURL(inp.DockerfilePath) {
 		dockerfileDir, err = createTempDockerfileFromURL(ctx, d, inp.DockerfilePath, pw)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		toRemove = append(toRemove, dockerfileDir)
 		dockerfileName = "Dockerfile"
@@ -468,7 +479,7 @@ func loadInputs(ctx context.Context, d *driver.DriverHandle, inp Inputs, pw prog
 
 	if dockerfileDir != "" {
 		if err := setLocalMount("dockerfile", dockerfileDir, target); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		dockerfileName = handleLowercaseDockerfile(dockerfileDir, dockerfileName)
 	}
@@ -502,12 +513,12 @@ func loadInputs(ctx context.Context, d *driver.DriverHandle, inp Inputs, pw prog
 			if !hasDigest {
 				dig, err = resolveDigest(localPath, tag)
 				if err != nil {
-					return nil, errors.Wrapf(err, "oci-layout reference %q could not be resolved", v.Path)
+					return nil, nil, errors.Wrapf(err, "oci-layout reference %q could not be resolved", v.Path)
 				}
 			}
 			store, err := local.NewStore(localPath)
 			if err != nil {
-				return nil, errors.Wrapf(err, "invalid store at %s", localPath)
+				return nil, nil, errors.Wrapf(err, "invalid store at %s", localPath)
 			}
 			storeName := identity.NewID()
 			if target.OCIStores == nil {
@@ -520,17 +531,17 @@ func loadInputs(ctx context.Context, d *driver.DriverHandle, inp Inputs, pw prog
 		}
 		st, err := os.Stat(v.Path)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to get build context %v", k)
+			return nil, nil, errors.Wrapf(err, "failed to get build context %v", k)
 		}
 		if !st.IsDir() {
-			return nil, errors.Wrapf(syscall.ENOTDIR, "failed to get build context path %v", v)
+			return nil, nil, errors.Wrapf(syscall.ENOTDIR, "failed to get build context path %v", v)
 		}
 		localName := k
 		if k == "context" || k == "dockerfile" {
 			localName = "_" + k // underscore to avoid collisions
 		}
 		if err := setLocalMount(localName, v.Path, target); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		target.FrontendAttrs["context:"+k] = "local:" + localName
 	}
@@ -540,7 +551,7 @@ func loadInputs(ctx context.Context, d *driver.DriverHandle, inp Inputs, pw prog
 			_ = os.RemoveAll(dir)
 		}
 	}
-	return release, nil
+	return release, &DockerfileMapping{Src: dockerfileSrcName, Dst: dockerfileName}, nil
 }
 
 func resolveDigest(localPath, tag string) (dig string, _ error) {

--- a/commands/bake.go
+++ b/commands/bake.go
@@ -265,7 +265,7 @@ func runBake(ctx context.Context, dockerCli command.Cli, targets []string, in ba
 	}
 
 	done := timeBuildCommand(mp, attributes)
-	resp, retErr := build.Build(ctx, nodes, bo, dockerutil.NewClient(dockerCli), confutil.ConfigDir(dockerCli), printer)
+	resp, dfmap, retErr := build.Build(ctx, nodes, bo, dockerutil.NewClient(dockerCli), confutil.ConfigDir(dockerCli), printer)
 	if err := printer.Wait(); retErr == nil {
 		retErr = err
 	}
@@ -335,7 +335,7 @@ func runBake(ctx context.Context, dockerCli command.Cli, targets []string, in ba
 		if callFormatJSON {
 			jsonResults[name] = map[string]any{}
 			buf := &bytes.Buffer{}
-			if code, err := printResult(buf, pf, res); err != nil {
+			if code, err := printResult(buf, pf, res, name, dfmap); err != nil {
 				jsonResults[name]["error"] = err.Error()
 				exitCode = 1
 			} else if code != 0 && exitCode == 0 {
@@ -361,7 +361,7 @@ func runBake(ctx context.Context, dockerCli command.Cli, targets []string, in ba
 			}
 
 			fmt.Fprintln(dockerCli.Out())
-			if code, err := printResult(dockerCli.Out(), pf, res); err != nil {
+			if code, err := printResult(dockerCli.Out(), pf, res, name, dfmap); err != nil {
 				fmt.Fprintf(dockerCli.Out(), "error: %v\n", err)
 				exitCode = 1
 			} else if code != 0 && exitCode == 0 {

--- a/commands/bake.go
+++ b/commands/bake.go
@@ -265,7 +265,7 @@ func runBake(ctx context.Context, dockerCli command.Cli, targets []string, in ba
 	}
 
 	done := timeBuildCommand(mp, attributes)
-	resp, dfmap, retErr := build.Build(ctx, nodes, bo, dockerutil.NewClient(dockerCli), confutil.ConfigDir(dockerCli), printer)
+	resp, retErr := build.Build(ctx, nodes, bo, dockerutil.NewClient(dockerCli), confutil.ConfigDir(dockerCli), printer)
 	if err := printer.Wait(); retErr == nil {
 		retErr = err
 	}
@@ -335,7 +335,7 @@ func runBake(ctx context.Context, dockerCli command.Cli, targets []string, in ba
 		if callFormatJSON {
 			jsonResults[name] = map[string]any{}
 			buf := &bytes.Buffer{}
-			if code, err := printResult(buf, pf, res, name, dfmap); err != nil {
+			if code, err := printResult(buf, pf, res, name, &req.Inputs); err != nil {
 				jsonResults[name]["error"] = err.Error()
 				exitCode = 1
 			} else if code != 0 && exitCode == 0 {
@@ -361,7 +361,7 @@ func runBake(ctx context.Context, dockerCli command.Cli, targets []string, in ba
 			}
 
 			fmt.Fprintln(dockerCli.Out())
-			if code, err := printResult(dockerCli.Out(), pf, res, name, dfmap); err != nil {
+			if code, err := printResult(dockerCli.Out(), pf, res, name, &req.Inputs); err != nil {
 				fmt.Fprintf(dockerCli.Out(), "error: %v\n", err)
 				exitCode = 1
 			} else if code != 0 && exitCode == 0 {

--- a/controller/control/controller.go
+++ b/controller/control/controller.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"io"
 
+	"github.com/docker/buildx/build"
 	controllerapi "github.com/docker/buildx/controller/pb"
 	"github.com/docker/buildx/util/progress"
 	"github.com/moby/buildkit/client"
 )
 
 type BuildxController interface {
-	Build(ctx context.Context, options controllerapi.BuildOptions, in io.ReadCloser, progress progress.Writer) (ref string, resp *client.SolveResponse, dockerfileMappings map[string]string, err error)
+	Build(ctx context.Context, options controllerapi.BuildOptions, in io.ReadCloser, progress progress.Writer) (ref string, resp *client.SolveResponse, inputs *build.Inputs, err error)
 	// Invoke starts an IO session into the specified process.
 	// If pid doesn't matche to any running processes, it starts a new process with the specified config.
 	// If there is no container running or InvokeConfig.Rollback is speicfied, the process will start in a newly created container.

--- a/controller/control/controller.go
+++ b/controller/control/controller.go
@@ -10,7 +10,7 @@ import (
 )
 
 type BuildxController interface {
-	Build(ctx context.Context, options controllerapi.BuildOptions, in io.ReadCloser, progress progress.Writer) (ref string, resp *client.SolveResponse, err error)
+	Build(ctx context.Context, options controllerapi.BuildOptions, in io.ReadCloser, progress progress.Writer) (ref string, resp *client.SolveResponse, dockerfileMappings map[string]string, err error)
 	// Invoke starts an IO session into the specified process.
 	// If pid doesn't matche to any running processes, it starts a new process with the specified config.
 	// If there is no container running or InvokeConfig.Rollback is speicfied, the process will start in a newly created container.

--- a/controller/local/controller.go
+++ b/controller/local/controller.go
@@ -42,7 +42,7 @@ type localController struct {
 	buildOnGoing atomic.Bool
 }
 
-func (b *localController) Build(ctx context.Context, options controllerapi.BuildOptions, in io.ReadCloser, progress progress.Writer) (string, *client.SolveResponse, map[string]string, error) {
+func (b *localController) Build(ctx context.Context, options controllerapi.BuildOptions, in io.ReadCloser, progress progress.Writer) (string, *client.SolveResponse, *build.Inputs, error) {
 	if !b.buildOnGoing.CompareAndSwap(false, true) {
 		return "", nil, nil, errors.New("build ongoing")
 	}

--- a/controller/remote/client.go
+++ b/controller/remote/client.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/containerd/containerd/defaults"
 	"github.com/containerd/containerd/pkg/dialer"
+	"github.com/docker/buildx/build"
 	"github.com/docker/buildx/controller/pb"
 	"github.com/docker/buildx/util/progress"
 	"github.com/moby/buildkit/client"
@@ -113,7 +114,7 @@ func (c *Client) Inspect(ctx context.Context, ref string) (*pb.InspectResponse, 
 	return c.client().Inspect(ctx, &pb.InspectRequest{Ref: ref})
 }
 
-func (c *Client) Build(ctx context.Context, options pb.BuildOptions, in io.ReadCloser, progress progress.Writer) (string, *client.SolveResponse, map[string]string, error) {
+func (c *Client) Build(ctx context.Context, options pb.BuildOptions, in io.ReadCloser, progress progress.Writer) (string, *client.SolveResponse, *build.Inputs, error) {
 	ref := identity.NewID()
 	statusChan := make(chan *client.SolveStatus)
 	eg, egCtx := errgroup.WithContext(ctx)

--- a/controller/remote/client.go
+++ b/controller/remote/client.go
@@ -113,7 +113,7 @@ func (c *Client) Inspect(ctx context.Context, ref string) (*pb.InspectResponse, 
 	return c.client().Inspect(ctx, &pb.InspectRequest{Ref: ref})
 }
 
-func (c *Client) Build(ctx context.Context, options pb.BuildOptions, in io.ReadCloser, progress progress.Writer) (string, *client.SolveResponse, error) {
+func (c *Client) Build(ctx context.Context, options pb.BuildOptions, in io.ReadCloser, progress progress.Writer) (string, *client.SolveResponse, map[string]string, error) {
 	ref := identity.NewID()
 	statusChan := make(chan *client.SolveStatus)
 	eg, egCtx := errgroup.WithContext(ctx)
@@ -131,7 +131,7 @@ func (c *Client) Build(ctx context.Context, options pb.BuildOptions, in io.ReadC
 		}
 		return nil
 	})
-	return ref, resp, eg.Wait()
+	return ref, resp, nil, eg.Wait()
 }
 
 func (c *Client) build(ctx context.Context, ref string, options pb.BuildOptions, in io.ReadCloser, statusChan chan *client.SolveStatus) (*client.SolveResponse, error) {

--- a/controller/remote/controller.go
+++ b/controller/remote/controller.go
@@ -148,7 +148,7 @@ func serveCmd(dockerCli command.Cli) *cobra.Command {
 			}()
 
 			// prepare server
-			b := NewServer(func(ctx context.Context, options *controllerapi.BuildOptions, stdin io.Reader, progress progress.Writer) (*client.SolveResponse, *build.ResultHandle, error) {
+			b := NewServer(func(ctx context.Context, options *controllerapi.BuildOptions, stdin io.Reader, progress progress.Writer) (*client.SolveResponse, *build.ResultHandle, map[string]string, error) {
 				return cbuild.RunBuild(ctx, dockerCli, *options, stdin, progress, true)
 			})
 			defer b.Close()

--- a/controller/remote/controller.go
+++ b/controller/remote/controller.go
@@ -148,7 +148,7 @@ func serveCmd(dockerCli command.Cli) *cobra.Command {
 			}()
 
 			// prepare server
-			b := NewServer(func(ctx context.Context, options *controllerapi.BuildOptions, stdin io.Reader, progress progress.Writer) (*client.SolveResponse, *build.ResultHandle, map[string]string, error) {
+			b := NewServer(func(ctx context.Context, options *controllerapi.BuildOptions, stdin io.Reader, progress progress.Writer) (*client.SolveResponse, *build.ResultHandle, *build.Inputs, error) {
 				return cbuild.RunBuild(ctx, dockerCli, *options, stdin, progress, true)
 			})
 			defer b.Close()

--- a/controller/remote/server.go
+++ b/controller/remote/server.go
@@ -19,7 +19,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-type BuildFunc func(ctx context.Context, options *pb.BuildOptions, stdin io.Reader, progress progress.Writer) (resp *client.SolveResponse, res *build.ResultHandle, dfmappping map[string]string, err error)
+type BuildFunc func(ctx context.Context, options *pb.BuildOptions, stdin io.Reader, progress progress.Writer) (resp *client.SolveResponse, res *build.ResultHandle, inp *build.Inputs, err error)
 
 func NewServer(buildFunc BuildFunc) *Server {
 	return &Server{

--- a/controller/remote/server.go
+++ b/controller/remote/server.go
@@ -19,7 +19,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-type BuildFunc func(ctx context.Context, options *pb.BuildOptions, stdin io.Reader, progress progress.Writer) (resp *client.SolveResponse, res *build.ResultHandle, err error)
+type BuildFunc func(ctx context.Context, options *pb.BuildOptions, stdin io.Reader, progress progress.Writer) (resp *client.SolveResponse, res *build.ResultHandle, dfmappping map[string]string, err error)
 
 func NewServer(buildFunc BuildFunc) *Server {
 	return &Server{
@@ -200,7 +200,7 @@ func (m *Server) Build(ctx context.Context, req *pb.BuildRequest) (*pb.BuildResp
 	// Build the specified request
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	resp, res, buildErr := m.buildFunc(ctx, req.Options, inR, pw)
+	resp, res, _, buildErr := m.buildFunc(ctx, req.Options, inR, pw)
 	m.sessionMu.Lock()
 	if s, ok := m.session[ref]; ok {
 		// NOTE: buildFunc can return *build.ResultHandle even on error (e.g. when it's implemented using (github.com/docker/buildx/controller/build).RunBuild).

--- a/monitor/commands/reload.go
+++ b/monitor/commands/reload.go
@@ -61,7 +61,7 @@ func (cm *ReloadCmd) Exec(ctx context.Context, args []string) error {
 	}
 	var resultUpdated bool
 	cm.progress.Unpause()
-	ref, _, err := cm.m.Build(ctx, *bo, nil, cm.progress) // TODO: support stdin, hold build ref
+	ref, _, _, err := cm.m.Build(ctx, *bo, nil, cm.progress) // TODO: support stdin, hold build ref
 	cm.progress.Pause()
 	if err != nil {
 		var be *controllererrors.BuildError

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -243,8 +243,8 @@ type monitor struct {
 	lastBuildResult *MonitorBuildResult
 }
 
-func (m *monitor) Build(ctx context.Context, options controllerapi.BuildOptions, in io.ReadCloser, progress progress.Writer) (ref string, resp *client.SolveResponse, err error) {
-	ref, resp, err = m.BuildxController.Build(ctx, options, in, progress)
+func (m *monitor) Build(ctx context.Context, options controllerapi.BuildOptions, in io.ReadCloser, progress progress.Writer) (ref string, resp *client.SolveResponse, dockerMappings map[string]string, err error) {
+	ref, resp, _, err = m.BuildxController.Build(ctx, options, in, progress)
 	m.lastBuildResult = &MonitorBuildResult{Resp: resp, Err: err} // Record build result
 	return
 }

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -10,6 +10,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/containerd/console"
+	"github.com/docker/buildx/build"
 	"github.com/docker/buildx/controller/control"
 	controllerapi "github.com/docker/buildx/controller/pb"
 	"github.com/docker/buildx/monitor/commands"
@@ -243,7 +244,7 @@ type monitor struct {
 	lastBuildResult *MonitorBuildResult
 }
 
-func (m *monitor) Build(ctx context.Context, options controllerapi.BuildOptions, in io.ReadCloser, progress progress.Writer) (ref string, resp *client.SolveResponse, dockerMappings map[string]string, err error) {
+func (m *monitor) Build(ctx context.Context, options controllerapi.BuildOptions, in io.ReadCloser, progress progress.Writer) (ref string, resp *client.SolveResponse, input *build.Inputs, err error) {
 	ref, resp, _, err = m.BuildxController.Build(ctx, options, in, progress)
 	m.lastBuildResult = &MonitorBuildResult{Resp: resp, Err: err} // Record build result
 	return

--- a/tests/bake.go
+++ b/tests/bake.go
@@ -1398,4 +1398,48 @@ target "second" {
 		require.Contains(t, stdout.String(), "Check complete, 1 warning has been found!")
 		require.Contains(t, stdout.String(), "Check complete, 2 warnings have been found!")
 	})
+	t.Run("check for Dockerfile path printed with context when displaying rule check warnings with multiple build targets", func(t *testing.T) {
+		dockerfile := []byte(`
+FROM busybox
+copy Dockerfile .
+		`)
+		bakefile := []byte(`
+target "first" {
+	dockerfile = "Dockerfile"
+}
+target "second" {
+	dockerfile = "subdir/Dockerfile"
+}
+target "third" {
+	dockerfile = "subdir/subsubdir/Dockerfile"
+}
+	`)
+		dir := tmpdir(
+			t,
+			fstest.CreateDir("subdir", 0700),
+			fstest.CreateDir("subdir/subsubdir", 0700),
+			fstest.CreateFile("Dockerfile", dockerfile, 0600),
+			fstest.CreateFile("subdir/Dockerfile", dockerfile, 0600),
+			fstest.CreateFile("subdir/subsubdir/Dockerfile", dockerfile, 0600),
+			fstest.CreateFile("docker-bake.hcl", bakefile, 0600),
+		)
+
+		dockerfilePathFirst := filepath.Join("Dockerfile")
+		dockerfilePathSecond := filepath.Join("subdir", "Dockerfile")
+		dockerfilePathThird := filepath.Join("subdir", "subsubdir", "Dockerfile")
+
+		cmd := buildxCmd(
+			sb,
+			withDir(dir),
+			withArgs("bake", "--call", "check", "first", "second", "third"),
+		)
+		stdout := bytes.Buffer{}
+		stderr := bytes.Buffer{}
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		require.Error(t, cmd.Run(), stdout.String(), stderr.String())
+		require.Contains(t, stdout.String(), dockerfilePathFirst+":3")
+		require.Contains(t, stdout.String(), dockerfilePathSecond+":3")
+		require.Contains(t, stdout.String(), dockerfilePathThird+":3")
+	})
 }

--- a/tests/build.go
+++ b/tests/build.go
@@ -1291,6 +1291,29 @@ cOpy Dockerfile .
 		require.Error(t, cmd.Run(), stdout.String(), stderr.String())
 		require.Contains(t, stdout.String(), "Check complete, 2 warnings have been found!")
 	})
+
+	t.Run("check for Dockerfile path printed with context when displaying rule check warnings", func(t *testing.T) {
+		dockerfile := []byte(`
+frOM busybox as base
+cOpy Dockerfile .
+	`)
+		dir := tmpdir(
+			t,
+			fstest.CreateDir("subdir", 0700),
+			fstest.CreateFile("subdir/Dockerfile", dockerfile, 0600),
+		)
+		dockerfilePath := filepath.Join(dir, "subdir", "Dockerfile")
+
+		cmd := buildxCmd(sb, withArgs("build", "--call=check", "-f", dockerfilePath, dir))
+		stdout := bytes.Buffer{}
+		stderr := bytes.Buffer{}
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		require.Error(t, cmd.Run(), stdout.String(), stderr.String())
+		require.Contains(t, stdout.String(), "Check complete, 2 warnings have been found!")
+		require.Contains(t, stdout.String(), dockerfilePath+":2")
+		require.Contains(t, stdout.String(), dockerfilePath+":3")
+	})
 }
 
 func createTestProject(t *testing.T) string {


### PR DESCRIPTION
fixes https://github.com/docker/buildx/issues/2542

Currently, when printing warnings from the rule checks, it will only report the base Dockerfile name.
 
`docker build --check -f foo/bar/Dockerfile .`

```WARNING: ConsistentInstructionCasing - https://docs.docker.com/go/dockerfile/rule/consistent-instruction-casing/
Command 'copy' should match the case of the command majority (uppercase)
Dockerfile:2
--------------------
   1 |     FROM alpine
   2 | >>> copy ./tmp /tmp
   3 |
   4 |
--------------------
```

This updates printing for the warnings to include a more specific path if one is available.


```WARNING: ConsistentInstructionCasing - https://docs.docker.com/go/dockerfile/rule/consistent-instruction-casing/
Command 'copy' should match the case of the command majority (uppercase)
foo/bar/Dockerfile:2
--------------------
   1 |     FROM alpine
   2 | >>> copy ./tmp /tmp
   3 |
   4 |
--------------------
```