### PR TITLE
inspect: display buildkit daemon configuration file

### DIFF
--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -126,6 +126,12 @@ func runInspect(ctx context.Context, dockerCli command.Cli, in inspectOptions) e
 						fmt.Fprintf(w, "\tKeep Bytes:\t%s\n", units.BytesSize(float64(rule.KeepBytes)))
 					}
 				}
+				for f, dt := range nodes[i].Files {
+					fmt.Fprintf(w, "File#%s:\n", f)
+					for _, line := range strings.Split(string(dt), "\n") {
+						fmt.Fprintf(w, "\t> %s\n", line)
+					}
+				}
 			}
 		}
 	}

--- a/tests/inspect.go
+++ b/tests/inspect.go
@@ -1,6 +1,9 @@
 package tests
 
 import (
+	"os"
+	"path"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -19,6 +22,7 @@ var inspectTests = []func(t *testing.T, sb integration.Sandbox){
 	testInspect,
 	testInspectBuildkitdFlags,
 	testInspectNetworkHostEntitlement,
+	testInspectBuildkitdConf,
 }
 
 func testInspect(t *testing.T, sb integration.Sandbox) {
@@ -108,4 +112,69 @@ func testInspectNetworkHostEntitlement(t *testing.T, sb integration.Sandbox) {
 		}
 	}
 	require.Fail(t, "network.host insecure entitlement not found in inspect output")
+}
+
+func testInspectBuildkitdConf(t *testing.T, sb integration.Sandbox) {
+	if !isDockerContainerWorker(sb) {
+		t.Skip("only testing with docker-container worker")
+	}
+
+	buildkitdConf := `
+# debug enables additional debug logging
+debug = true
+# insecure-entitlements allows insecure entitlements, disabled by default.
+insecure-entitlements = [ "network.host", "security.insecure" ]
+
+[log]
+  # log formatter: json or text
+  format = "text"
+`
+
+	expectedContent := `debug = true
+insecure-entitlements = ["network.host", "security.insecure"]
+
+[log]
+  format = "text"
+`
+
+	var builderName string
+	t.Cleanup(func() {
+		if builderName == "" {
+			return
+		}
+		out, err := rmCmd(sb, withArgs(builderName))
+		require.NoError(t, err, out)
+	})
+
+	dirConf := t.TempDir()
+	buildkitdConfPath := path.Join(dirConf, "buildkitd-conf.toml")
+	require.NoError(t, os.WriteFile(buildkitdConfPath, []byte(buildkitdConf), 0644))
+
+	out, err := createCmd(sb, withArgs("--driver", "docker-container", "--buildkitd-config="+buildkitdConfPath))
+	require.NoError(t, err, out)
+	builderName = strings.TrimSpace(out)
+
+	out, err = inspectCmd(sb, withArgs(builderName))
+	require.NoError(t, err, out)
+
+	var fileLines []string
+	var fileFound bool
+	var reConfLine = regexp.MustCompile(`^[\s\t]*>\s(.*)`)
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "File#buildkitd.toml:") {
+			fileFound = true
+			continue
+		}
+		if fileFound {
+			if matches := reConfLine.FindStringSubmatch(line); len(matches) > 1 {
+				fileLines = append(fileLines, matches[1])
+			} else {
+				break
+			}
+		}
+	}
+	if !fileFound {
+		require.Fail(t, "File#buildkitd.toml not found in inspect output")
+	}
+	require.Equal(t, expectedContent, strings.Join(fileLines, "\n"), "File#buildkitd.toml content mismatch")
 }


### PR DESCRIPTION
follow-up https://github.com/docker/buildx/issues/2683#issuecomment-2343001508

Displays buildkit daemon configuration file content used when creating a builder in inspect output:

```toml
# ~/.docker/buildx/buildkitd.default.toml

# debug enables additional debug logging
debug = true
# trace enables additional trace logging (very verbose, with potential performance impacts)
trace = true
# insecure-entitlements allows insecure entitlements, disabled by default.
insecure-entitlements = [ "network.host", "security.insecure" ]

[log]
  # log formatter: json or text
  format = "text"
```

```
$ docker buildx create --name builder --driver-opt "image=moby/buildkit:v0.16.0"
builder
```

```
$ docker buildx inspect builder --bootstrap
Name:          builder
Driver:        docker-container
Last Activity: 2024-09-11 08:31:27 +0000 UTC

Nodes:
Name:                  builder0
Endpoint:              unix:///var/run/docker.sock
Driver Options:        image="moby/buildkit:v0.16.0"
Status:                running
BuildKit daemon flags: --allow-insecure-entitlement=network.host
BuildKit version:      v0.16.0
Platforms:             linux/amd64, linux/amd64/v2, linux/amd64/v3, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/mips64le, linux/mips64, linux/arm/v7, linux/arm/v6
Features:
 Automatically load images to the Docker Engine image store: false
 Cache export:                                               true
 Docker exporter:                                            true
 Multi-platform build:                                       true
 OCI exporter:                                               true
Labels:
 org.mobyproject.buildkit.worker.executor:         oci
 org.mobyproject.buildkit.worker.hostname:         e5772cf17e94
 org.mobyproject.buildkit.worker.network:          host
 org.mobyproject.buildkit.worker.oci.process-mode: sandbox
 org.mobyproject.buildkit.worker.selinux.enabled:  false
 org.mobyproject.buildkit.worker.snapshotter:      overlayfs
GC Policy rule#0:
 All:           false
 Filters:       type==source.local,type==exec.cachemount,type==source.git.checkout
 Keep Duration: 48h0m0s
 Keep Bytes:    488.3MiB
GC Policy rule#1:
 All:           false
 Keep Duration: 1440h0m0s
 Keep Bytes:    94.06GiB
GC Policy rule#2:
 All:        false
 Keep Bytes: 94.06GiB
GC Policy rule#3:
 All:        true
 Keep Bytes: 94.06GiB
File#buildkitd.toml:
 > debug = true
 > insecure-entitlements = ["network.host", "security.insecure"]
 > trace = true
 >
 > [log]
 >   format = "text"
 >
```