### PR TITLE
builder: do not set network.host entitlement flag if already set in buildkitd conf

### DIFF
--- a/util/confutil/config.go
+++ b/util/confutil/config.go
@@ -34,8 +34,8 @@ func DefaultConfigFile(dockerCli command.Cli) (string, bool) {
 	return "", false
 }
 
-// loadConfigTree loads BuildKit config toml tree
-func loadConfigTree(fp string) (*toml.Tree, error) {
+// LoadConfigTree loads BuildKit config toml tree
+func LoadConfigTree(fp string) (*toml.Tree, error) {
 	f, err := os.Open(fp)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {

--- a/util/confutil/container.go
+++ b/util/confutil/container.go
@@ -32,7 +32,7 @@ func LoadConfigFiles(bkconfig string) (map[string][]byte, error) {
 	}
 
 	// Load config tree
-	btoml, err := loadConfigTree(bkconfig)
+	btoml, err := LoadConfigTree(bkconfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
follow-up https://github.com/docker/buildx/issues/2683#issuecomment-2343100380

On container builder creation, it's possible to define buildkitd configuration path that will injected and used inside the container.

If insecure-entitlements opts are set in this configuration they will be skipped because we are always setting the `--allow-insecure-entitlement network.host` https://github.com/docker/buildx/pull/2266 if user does not set it explicitly and buildkitd overrides configuration values with flags: https://github.com/moby/buildkit/blob/3a7055008a5e58a2abbe0e0c21c919d9e014e062/cmd/buildkitd/main.go#L583-L584.

With this change we are now detecting if `network.host` insecure entitlement is set within the buildkitd configuration and skip setting `--allow-insecure-entitlement network.host` flag.

cc @dvdksn 