### PR TITLE
ci: fix golvulncheck job permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -220,6 +220,8 @@ jobs:
     permissions:
       # required to write sarif report
       security-events: write
+      # required to check out the repository
+      contents: read
     steps:
       -
         name: Checkout


### PR DESCRIPTION
follow-up https://github.com/moby/buildkit/pull/5326