### PR TITLE
test: fix missing envs when cleaning up some workers

### DIFF
--- a/tests/workers/docker-container.go
+++ b/tests/workers/docker-container.go
@@ -73,6 +73,11 @@ func (w *containerWorker) New(ctx context.Context, cfg *integration.BackendConfi
 
 	cl := func() error {
 		cmd := exec.Command("buildx", "rm", "-f", name)
+		cmd.Env = append(
+			os.Environ(),
+			"BUILDX_CONFIG=/tmp/buildx-"+name,
+			"DOCKER_CONTEXT="+w.docker.DockerAddress(),
+		)
 		return cmd.Run()
 	}
 

--- a/tests/workers/remote.go
+++ b/tests/workers/remote.go
@@ -56,6 +56,7 @@ func (w remoteWorker) New(ctx context.Context, cfg *integration.BackendConfig) (
 	cl = func() error {
 		err := bkclose()
 		cmd := exec.Command("buildx", "rm", "-f", name)
+		cmd.Env = append(os.Environ(), "BUILDX_CONFIG=/tmp/buildx-"+name)
 		if err1 := cmd.Run(); err == nil {
 			err = err1
 		}


### PR DESCRIPTION
We are missing some envs to use the right buildx config dir when cleaning up remote and container workers.