### PR TITLE
bake: fix validation for linking to itself

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -480,7 +480,7 @@ func (c Config) loadLinks(name string, t *Target, m map[string]*Target, o map[st
 	for _, v := range t.Contexts {
 		if strings.HasPrefix(v, "target:") {
 			target := strings.TrimPrefix(v, "target:")
-			if target == t.Name {
+			if target == name {
 				return errors.Errorf("target %s cannot link to itself", target)
 			}
 			for _, v := range visited {


### PR DESCRIPTION
Small fix for the condition of linking to itself. `target.Name` is usually empty as used by the matrix feature. This still errored before as well because the infinite loop was detected, but this error condition was ineffective.