### PR TITLE
bake: fix linking to targets with entitlements

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -502,6 +503,14 @@ func (c Config) loadLinks(name string, t *Target, m map[string]*Target, o map[st
 			if err := c.loadLinks(target, t2, m, o, visited); err != nil {
 				return err
 			}
+
+			// entitlements are inherited from linked targets
+			for _, ent := range t2.Entitlements {
+				if !slices.Contains(t.Entitlements, ent) {
+					t.Entitlements = append(t.Entitlements, ent)
+				}
+			}
+
 			if len(t.Platforms) > 1 && len(t2.Platforms) > 1 {
 				if !sliceEqual(t.Platforms, t2.Platforms) {
 					return errors.Errorf("target %s can't be used by %s because it is defined for different platforms %v and %v", target, name, t2.Platforms, t.Platforms)


### PR DESCRIPTION
When linked target requires entitlement, same entitlement is also needed by the caller. Otherwise, the request will fail when the build is processed.

Example (before):

```
target "base" {
  target = "base"
  entitlements = ["network.host"]
}

target "default" {
  contexts = {
    base = "target:base"
  }
}

```

```
from alpine as base
run --network=host ip a

from alpine
copy --from=base /etc/passwd /foo
```

```
» docker buildx bake
[+] Building 0.0s (1/1) FINISHED                                                                                                     docker-container:gifted_dijkstra
 => [internal] load local bake definitions                                                                                                                       0.0s
 => => reading docker-bake.hcl 138B / 138B                                                                                                                       0.0s
Your build is requesting privileges for following possibly insecure capabilities:

 - Running build containers that can access host network

In order to not see this message in the future pass "--allow=network.host" to grant requested privileges.

Your full command with requested privileges:

docker buildx bake --allow=network.host

Do you want to grant requested privileges and continue? [y/N] y
[+] Building 0.8s (4/5)                                                                                                              docker-container:gifted_dijkstra
 => [default internal] load build definition from Dockerfile                                                                                                     0.0s
 => => transferring dockerfile: 128B                                                                                                                             0.0s
 => [default internal] load metadata for docker.io/library/alpine:latest                                                                                         0.5s
 => [default internal] load .dockerignore                                                                                                                        0.0s
 => => transferring context: 2B                                                                                                                                  0.0s
 => CANCELED [base base 1/2] FROM docker.io/library/alpine:latest@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d                        0.1s
 => => resolve docker.io/library/alpine:latest@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d                                           0.0s
ERROR: target default: failed to solve: failed to load LLB: network.host is not allowed
```