### PR TITLE
[0.17] vendor: bump github.com/docker/cli v27.3.0-rc.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/containerd/typeurl/v2 v2.2.0
 	github.com/creack/pty v1.1.21
 	github.com/distribution/reference v0.6.0
-	github.com/docker/cli v27.2.2-0.20240913085431-48a2cdff970d+incompatible
+	github.com/docker/cli v27.3.0-rc.1+incompatible
 	github.com/docker/cli-docs-tool v0.8.0
 	github.com/docker/docker v27.2.1+incompatible
 	github.com/docker/go-units v0.5.0

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/containerd/typeurl/v2 v2.2.0
 	github.com/creack/pty v1.1.21
 	github.com/distribution/reference v0.6.0
-	github.com/docker/cli v27.3.0-rc.1+incompatible
+	github.com/docker/cli v27.3.0-rc.2+incompatible
 	github.com/docker/cli-docs-tool v0.8.0
 	github.com/docker/docker v27.2.1+incompatible
 	github.com/docker/go-units v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/denisenkom/go-mssqldb v0.0.0-20191128021309-1d7a30a10f73/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/docker/cli v27.3.0-rc.1+incompatible h1:yc++0aWWMlq4QBYrvuuzYhVHc+Y/MRrWa4T/g/0mVPQ=
-github.com/docker/cli v27.3.0-rc.1+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v27.3.0-rc.2+incompatible h1:z/lQXreGSzWl0RySxyFOm6WygLQtre2EkB4SCwsEut0=
+github.com/docker/cli v27.3.0-rc.2+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli-docs-tool v0.8.0 h1:YcDWl7rQJC3lJ7WVZRwSs3bc9nka97QLWfyJQli8yJU=
 github.com/docker/cli-docs-tool v0.8.0/go.mod h1:8TQQ3E7mOXoYUs811LiPdUnAhXrcVsBIrW21a5pUbdk=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/denisenkom/go-mssqldb v0.0.0-20191128021309-1d7a30a10f73/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/docker/cli v27.2.2-0.20240913085431-48a2cdff970d+incompatible h1:jbTJwvM0LKQUti9X1KfPCnRasE5894IGaqs5Y90YeXM=
-github.com/docker/cli v27.2.2-0.20240913085431-48a2cdff970d+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v27.3.0-rc.1+incompatible h1:yc++0aWWMlq4QBYrvuuzYhVHc+Y/MRrWa4T/g/0mVPQ=
+github.com/docker/cli v27.3.0-rc.1+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli-docs-tool v0.8.0 h1:YcDWl7rQJC3lJ7WVZRwSs3bc9nka97QLWfyJQli8yJU=
 github.com/docker/cli-docs-tool v0.8.0/go.mod h1:8TQQ3E7mOXoYUs811LiPdUnAhXrcVsBIrW21a5pUbdk=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=

--- a/vendor/github.com/docker/cli/cli/command/telemetry_docker.go
+++ b/vendor/github.com/docker/cli/cli/command/telemetry_docker.go
@@ -180,7 +180,7 @@ func toWslPath(s string) string {
 	if !ok {
 		return ""
 	}
-	return fmt.Sprintf("mnt/%s%s", drive, p)
+	return fmt.Sprintf("mnt/%s%s", strings.ToLower(drive), p)
 }
 
 func parseUNCPath(s string) (drive, p string, ok bool) {

--- a/vendor/github.com/docker/cli/cli/command/telemetry_utils.go
+++ b/vendor/github.com/docker/cli/cli/command/telemetry_utils.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/cli/cli/version"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
@@ -94,7 +95,9 @@ func startCobraCommandTimer(mp metric.MeterProvider, attrs []attribute.KeyValue)
 			metric.WithAttributes(cmdStatusAttrs...),
 		)
 		if mp, ok := mp.(MeterProvider); ok {
-			mp.ForceFlush(ctx)
+			if err := mp.ForceFlush(ctx); err != nil {
+				otel.Handle(err)
+			}
 		}
 	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -218,7 +218,7 @@ github.com/davecgh/go-spew/spew
 # github.com/distribution/reference v0.6.0
 ## explicit; go 1.20
 github.com/distribution/reference
-# github.com/docker/cli v27.2.2-0.20240913085431-48a2cdff970d+incompatible
+# github.com/docker/cli v27.3.0-rc.1+incompatible
 ## explicit
 github.com/docker/cli/cli
 github.com/docker/cli/cli-plugins/hooks

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -218,7 +218,7 @@ github.com/davecgh/go-spew/spew
 # github.com/distribution/reference v0.6.0
 ## explicit; go 1.20
 github.com/distribution/reference
-# github.com/docker/cli v27.3.0-rc.1+incompatible
+# github.com/docker/cli v27.3.0-rc.2+incompatible
 ## explicit
 github.com/docker/cli/cli
 github.com/docker/cli/cli-plugins/hooks


### PR DESCRIPTION
relates to:

- https://github.com/docker/cli/pull/5445
- https://github.com/docker/cli/pull/5444


### vendor: github.com/docker/cli v27.3.0-rc.1

no diff; same commit, but tagged

full diff: https://github.com/docker/cli/compare/48a2cdff970d...v27.3.0-rc.1


### vendor: bump github.com/docker/cli v27.3.0-rc.2

full diff: https://github.com/docker/cli/compare/v27.3.0-rc.1...v27.3.0-rc.2