### PR TITLE
build: use better references for --call fallback images

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -53,8 +53,8 @@ import (
 )
 
 const (
-	printFallbackImage     = "docker/dockerfile:1.5@sha256:dbbd5e059e8a07ff7ea6233b213b36aa516b4c53c645f1817a4dd18b83cbea56"
-	printLintFallbackImage = "docker.io/docker/dockerfile-upstream:1.8.1@sha256:e87caa74dcb7d46cd820352bfea12591f3dba3ddc4285e19c7dcd13359f7cefd"
+	printFallbackImage     = "docker/dockerfile:1.7.1@sha256:a57df69d0ea827fb7266491f2813635de6f17269be881f696fbfdf2d83dda33e"
+	printLintFallbackImage = "docker/dockerfile:1.8.1@sha256:e87caa74dcb7d46cd820352bfea12591f3dba3ddc4285e19c7dcd13359f7cefd"
 )
 
 type Options struct {


### PR DESCRIPTION
- printFallbackImage -> this image was actually 1.7.0 and using wrong text tag. Updated in https://github.com/docker/buildx/pull/2406 . I don't think it makes sense to use `.0` that has a patch release with bugfixes so updated to that.
- printLintFallbackImage -> pull the reference from production dockerfile upstream instead of staging area. The image is the same but users would previously see confusing "upstream" repo in the progress. 