### PR TITLE
align file and folder permissions

### DIFF
--- a/controller/remote/controller.go
+++ b/controller/remote/controller.go
@@ -247,11 +247,11 @@ func prepareRootDir(dockerCli command.Cli, config *serverConfig) (string, error)
 	if rootDir == "" {
 		return "", errors.New("buildx root dir must be determined")
 	}
-	if err := os.MkdirAll(rootDir, 0700); err != nil {
+	if err := os.MkdirAll(rootDir, 0755); err != nil {
 		return "", err
 	}
 	serverRoot := filepath.Join(rootDir, "shared")
-	if err := os.MkdirAll(serverRoot, 0700); err != nil {
+	if err := os.MkdirAll(serverRoot, 0755); err != nil {
 		return "", err
 	}
 	return serverRoot, nil

--- a/localstate/localstate.go
+++ b/localstate/localstate.go
@@ -49,7 +49,7 @@ func New(root string) (*LocalState, error) {
 	if root == "" {
 		return nil, errors.Errorf("root dir empty")
 	}
-	if err := os.MkdirAll(filepath.Join(root, refsDir), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Join(root, refsDir), 0755); err != nil {
 		return nil, err
 	}
 	return &LocalState{
@@ -77,14 +77,14 @@ func (ls *LocalState) SaveRef(builderName, nodeName, id string, st State) error 
 		return err
 	}
 	refDir := filepath.Join(ls.root, refsDir, builderName, nodeName)
-	if err := os.MkdirAll(refDir, 0700); err != nil {
+	if err := os.MkdirAll(refDir, 0755); err != nil {
 		return err
 	}
 	dt, err := json.Marshal(st)
 	if err != nil {
 		return err
 	}
-	return ioutils.AtomicWriteFile(filepath.Join(refDir, id), dt, 0600)
+	return ioutils.AtomicWriteFile(filepath.Join(refDir, id), dt, 0644)
 }
 
 func (ls *LocalState) ReadGroup(id string) (*StateGroup, error) {
@@ -101,14 +101,14 @@ func (ls *LocalState) ReadGroup(id string) (*StateGroup, error) {
 
 func (ls *LocalState) SaveGroup(id string, stg StateGroup) error {
 	refDir := filepath.Join(ls.root, refsDir, groupDir)
-	if err := os.MkdirAll(refDir, 0700); err != nil {
+	if err := os.MkdirAll(refDir, 0755); err != nil {
 		return err
 	}
 	dt, err := json.Marshal(stg)
 	if err != nil {
 		return err
 	}
-	return ioutils.AtomicWriteFile(filepath.Join(refDir, id), dt, 0600)
+	return ioutils.AtomicWriteFile(filepath.Join(refDir, id), dt, 0644)
 }
 
 func (ls *LocalState) RemoveBuilder(builderName string) error {

--- a/store/store.go
+++ b/store/store.go
@@ -21,13 +21,13 @@ const (
 )
 
 func New(root string) (*Store, error) {
-	if err := os.MkdirAll(filepath.Join(root, instanceDir), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Join(root, instanceDir), 0755); err != nil {
 		return nil, err
 	}
-	if err := os.MkdirAll(filepath.Join(root, defaultsDir), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Join(root, defaultsDir), 0755); err != nil {
 		return nil, err
 	}
-	if err := os.MkdirAll(filepath.Join(root, activityDir), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Join(root, activityDir), 0755); err != nil {
 		return nil, err
 	}
 	return &Store{root: root}, nil
@@ -110,7 +110,7 @@ func (t *Txn) Save(ng *NodeGroup) error {
 	if err != nil {
 		return err
 	}
-	return ioutils.AtomicWriteFile(filepath.Join(t.s.root, instanceDir, name), dt, 0600)
+	return ioutils.AtomicWriteFile(filepath.Join(t.s.root, instanceDir, name), dt, 0644)
 }
 
 func (t *Txn) Remove(name string) error {
@@ -141,14 +141,14 @@ func (t *Txn) SetCurrent(key, name string, global, def bool) error {
 	if err != nil {
 		return err
 	}
-	if err := ioutils.AtomicWriteFile(filepath.Join(t.s.root, "current"), dt, 0600); err != nil {
+	if err := ioutils.AtomicWriteFile(filepath.Join(t.s.root, "current"), dt, 0644); err != nil {
 		return err
 	}
 
 	h := toHash(key)
 
 	if def {
-		if err := ioutils.AtomicWriteFile(filepath.Join(t.s.root, defaultsDir, h), []byte(name), 0600); err != nil {
+		if err := ioutils.AtomicWriteFile(filepath.Join(t.s.root, defaultsDir, h), []byte(name), 0644); err != nil {
 			return err
 		}
 	} else {
@@ -158,7 +158,7 @@ func (t *Txn) SetCurrent(key, name string, global, def bool) error {
 }
 
 func (t *Txn) UpdateLastActivity(ng *NodeGroup) error {
-	return ioutils.AtomicWriteFile(filepath.Join(t.s.root, activityDir, ng.Name), []byte(time.Now().UTC().Format(time.RFC3339)), 0600)
+	return ioutils.AtomicWriteFile(filepath.Join(t.s.root, activityDir, ng.Name), []byte(time.Now().UTC().Format(time.RFC3339)), 0644)
 }
 
 func (t *Txn) GetLastActivity(ng *NodeGroup) (la time.Time, _ error) {
@@ -185,7 +185,7 @@ func (t *Txn) reset(key string) error {
 	if err != nil {
 		return err
 	}
-	return ioutils.AtomicWriteFile(filepath.Join(t.s.root, "current"), dt, 0600)
+	return ioutils.AtomicWriteFile(filepath.Join(t.s.root, "current"), dt, 0644)
 }
 
 func (t *Txn) Current(key string) (*NodeGroup, error) {

--- a/util/confutil/node.go
+++ b/util/confutil/node.go
@@ -20,7 +20,7 @@ func TryNodeIdentifier(configDir string) (out string) {
 			if _, err := rand.Read(b); err != nil {
 				return out
 			}
-			if err := os.WriteFile(sessionFile, []byte(hex.EncodeToString(b)), 0600); err != nil {
+			if err := os.WriteFile(sessionFile, []byte(hex.EncodeToString(b)), 0644); err != nil {
 				return out
 			}
 		}


### PR DESCRIPTION
* fixes https://github.com/docker/for-mac/issues/7454
* fixes https://github.com/docker/for-mac/issues/7356
* fixes https://github.com/docker/for-mac/issues/7277
* fixes https://github.com/docker/for-mac/issues/7362
* fixes https://github.com/docker/for-mac/issues/7195
* fixes https://github.com/docker/for-mac/issues/7144
* fixes https://github.com/docker/for-mac/issues/7186
* fixes https://github.com/docker/for-mac/issues/7309

When invoking `docker` with `sudo` the owner will not be the one from user space and therefore some files and folders in buildx config might not be accessible by other tools (on macos `sudo` keeps user home dir). This affects reading current builder, last activity for a builder or local state. This change aligns file and folder permissions. Similar to how image id and metadata file are currently created:

* https://github.com/docker/buildx/blob/1de332530f6c21e69ddf8577fbc7adcf0ae7c723/commands/build.go#L377
* https://github.com/docker/buildx/blob/1de332530f6c21e69ddf8577fbc7adcf0ae7c723/commands/build.go#L745

And same with cli when creating context: https://github.com/docker/cli/blob/31eeed7ca4c951ede2d18c73e4bd47e8189be221/cli/context/store/metadatastore.go#L43

This will avoid permissions issues reported on Docker Desktop when opening the build view on macos.