### PR TITLE
docs: clarify options for secret types (file, env)

### DIFF
--- a/docs/reference/buildx_build.md
+++ b/docs/reference/buildx_build.md
@@ -626,7 +626,7 @@ For example, the following Dockerfile contains four stages:
 ```dockerfile
 # syntax=docker/dockerfile:1
 
-FROM oven/bun:1 as base
+FROM oven/bun:1 AS base
 WORKDIR /app
 
 FROM base AS install

--- a/docs/reference/buildx_build.md
+++ b/docs/reference/buildx_build.md
@@ -912,17 +912,39 @@ For more information about how to use build secrets, see
 
 Supported types are:
 
-- [`file`](#file)
-- [`env`](#env)
+- [`type=file`](#typefile)
+- [`type=env`](#typeenv)
 
-Buildx attempts to detect the `type` automatically if unset.
+Buildx attempts to detect the `type` automatically if unset. If an environment
+variable with the same key as `id` is set, then Buildx uses `type=env` and the
+variable value becomes the secret. If no such environment variable is set, and
+`type` is not set, then Buildx falls back to `type=file`.
 
-#### `file`
+#### `type=file`
 
-Attribute keys:
+Source a build secret from a file.
 
-- `id` - ID of the secret. Defaults to base name of the `src` path.
-- `src`, `source` - Secret filename. `id` used if unset.
+##### `type=file` synopsis
+
+```console
+$ docker buildx build --secret [type=file,]id=<ID>[,src=<FILEPATH>] .
+```
+
+##### `type=file` attributes
+
+| Key             | Description                                                                                           | Default                    |
+| --------------- | ----------------------------------------------------------------------------------------------------- | -------------------------- |
+| `id`            | ID of the secret.                                                                                     | N/A (this key is required) |
+| `src`, `source` | Filepath of the file containing the secret value (absolute or relative to current working directory). | `id` if unset.             |
+
+###### `type=file` usage
+
+In the following example, `type=file` is automatically detected because no
+environment variable mathing `aws` (the ID) is set.
+
+```console
+$ docker buildx build --secret id=aws,src=$HOME/.aws/credentials .
+```
 
 ```dockerfile
 # syntax=docker/dockerfile:1
@@ -932,16 +954,31 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials \
   aws s3 cp s3://... ...
 ```
 
+#### `type=env`
+
+Source a build secret from an environment variable.
+
+##### `type=env` synopsis
+
 ```console
-$ docker buildx build --secret id=aws,src=$HOME/.aws/credentials .
+$ docker buildx build --secret [type=env,]id=<ID>[,env=<VARIABLE>] .
 ```
 
-#### `env`
+##### `type=env` attributes
 
-Attribute keys:
+| Key                    | Description                                     | Default                    |
+| ---------------------- | ----------------------------------------------- | -------------------------- |
+| `id`                   | ID of the secret.                               | N/A (this key is required) |
+| `env`, `src`, `source` | Environment variable to source the secret from. | `id` if unset.             |
 
-- `id` - ID of the secret. Defaults to `env` name.
-- `env` - Secret environment variable. `id` used if unset, otherwise will look for `src`, `source` if `id` unset.
+##### `type=env` usage
+
+In the following example, `type=env` is automatically detected because an
+environment variable matching `id` is set.
+
+```console
+$ SECRET_TOKEN=token docker buildx build --secret id=SECRET_TOKEN .
+```
 
 ```dockerfile
 # syntax=docker/dockerfile:1
@@ -951,9 +988,25 @@ RUN --mount=type=bind,target=. \
   yarn run test
 ```
 
+In the following example, the build argument `SECRET_TOKEN` is set to contain
+the value of the environment variable `API_KEY`.
+
 ```console
-$ SECRET_TOKEN=token docker buildx build --secret id=SECRET_TOKEN .
+$ API_KEY=token docker buildx build --secret id=SECRET_TOKEN,env=API_KEY .
 ```
+
+You can also specify the name of the environment variable with `src` or `source`:
+
+```console
+$ API_KEY=token docker buildx build --secret type=env,id=SECRET_TOKEN,src=API_KEY .
+```
+
+> [!NOTE]
+> Specifying the environment variable name with `src` or `source`, you are
+> required to set `type=env` explicitly, or else Buildx assumes that the secret
+> is `type=file`, and looks for a file with the name of `src` or `source` (in
+> this case, a file named `API_KEY` relative to the location where the `docker
+> buildx build` command was executed.
 
 ### <a name="shm-size"></a> Shared memory size for build containers (--shm-size)
 


### PR DESCRIPTION
Improve descriptions of the attributes for the `--secret` flag for `buildx build`.

- Clarify how buildx determines whether to use `type=file` or `type=env`.
- Clarify that relative filepaths for `type=file` are calculated based on CWD where the buildx command is executed.
- Add `src` and `source` as possible attributes for `type=env`, but clarify that they require `type=env` to be set explicitly if you want to source from an env var (otherwise `type=file` is assumed).

## Related issues

- Closes docker/buildx#2386
