### PR TITLE
cli: error out on unknown command

### DIFF
--- a/commands/imagetools/root.go
+++ b/commands/imagetools/root.go
@@ -10,11 +10,12 @@ type RootOptions struct {
 	Builder *string
 }
 
-func RootCmd(dockerCli command.Cli, opts RootOptions) *cobra.Command {
+func RootCmd(rootcmd *cobra.Command, dockerCli command.Cli, opts RootOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "imagetools",
 		Short:             "Commands to work on images in registry",
 		ValidArgsFunction: completion.Disable,
+		RunE:              rootcmd.RunE,
 	}
 
 	cmd.AddCommand(

--- a/tests/common.go
+++ b/tests/common.go
@@ -1,0 +1,29 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/moby/buildkit/util/testutil/integration"
+	"github.com/stretchr/testify/require"
+)
+
+var commonTests = []func(t *testing.T, sb integration.Sandbox){
+	testUnknownCommand,
+	testUnknownFlag,
+}
+
+func testUnknownCommand(t *testing.T, sb integration.Sandbox) {
+	cmd := buildxCmd(sb, withArgs("foo"))
+	out, err := cmd.CombinedOutput()
+	require.Error(t, err, string(out))
+
+	cmd = buildxCmd(sb, withArgs("imagetools", "foo"))
+	out, err = cmd.CombinedOutput()
+	require.Error(t, err, string(out))
+}
+
+func testUnknownFlag(t *testing.T, sb integration.Sandbox) {
+	cmd := buildxCmd(sb, withArgs("build", "--foo=bar"))
+	out, err := cmd.CombinedOutput()
+	require.Error(t, err, string(out))
+}

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -21,6 +21,7 @@ func init() {
 
 func TestIntegration(t *testing.T) {
 	var tests []func(t *testing.T, sb integration.Sandbox)
+	tests = append(tests, commonTests...)
 	tests = append(tests, buildTests...)
 	tests = append(tests, bakeTests...)
 	tests = append(tests, inspectTests...)


### PR DESCRIPTION
fixes #2738 

By default if there is no `Run` / `RunE` in parent command, cobra will just print help and exit 0.

No regression point, it fails since first release https://github.com/docker/buildx/releases/tag/v0.2.0 in plugin mode (`docker buildx`) but "only" since `v0.9.0` in standalone.