### PR TITLE
build: don't generate local state for subrequests

### DIFF
--- a/build/localstate.go
+++ b/build/localstate.go
@@ -11,7 +11,7 @@ import (
 
 func saveLocalState(so *client.SolveOpt, target string, opts Options, node builder.Node, cfg *confutil.Config) error {
 	var err error
-	if so.Ref == "" {
+	if so.Ref == "" || opts.CallFunc != nil {
 		return nil
 	}
 	lp := opts.Inputs.ContextPath

--- a/commands/bake.go
+++ b/commands/bake.go
@@ -464,11 +464,17 @@ func saveLocalStateGroup(dockerCli command.Cli, in bakeOptions, targets []string
 	groupRef := identity.NewID()
 	refs := make([]string, 0, len(bo))
 	for k, b := range bo {
+		if b.CallFunc != nil {
+			continue
+		}
 		b.Ref = identity.NewID()
 		b.GroupRef = groupRef
 		b.ProvenanceResponseMode = prm
 		refs = append(refs, b.Ref)
 		bo[k] = b
+	}
+	if len(refs) == 0 {
+		return nil
 	}
 	l, err := localstate.New(confutil.NewConfig(dockerCli))
 	if err != nil {


### PR DESCRIPTION
Relates to https://github.com/docker/docs/actions/runs/11502549192/job/32017891983#step:6:21

```
Warning: Failed to export build record: /home/runner/work/_temp/docker-actions-toolkit-16m5IG/export/rec.dockerbuild not found
```

When generating build summary in our GitHub Actions, we are using the `buildx.build.ref` from metadata to export the build record. When using `call`, this attribute is not set: https://github.com/docker/buildx/blob/746eadd16e461ac1a961bb22e7fea8f1d05da88f/build/build.go#L525-L526

Which is the right behavior as no build record is written for subrequests anyway.

But we also have a fallback in our GitHub Actions in case `buildx.build.ref` is not set that checks if a local state is available as part of this build. And in this case we have one as we are generating a local state for subrequests but I don't think it makes sense to do so.

cc @dvdksn 