### PR TITLE
Skip Builder Init For Bake List Flags

### DIFF
--- a/commands/bake.go
+++ b/commands/bake.go
@@ -116,7 +116,7 @@ func runBake(ctx context.Context, dockerCli command.Cli, targets []string, in ba
 
 	// instance only needed for reading remote bake files or building
 	var driverType string
-	if url != "" || !in.printOnly {
+	if url != "" || !(in.printOnly || in.listTargets || in.listVars) {
 		b, err := builder.New(dockerCli,
 			builder.WithName(in.builder),
 			builder.WithContextPathHash(contextPathHash),


### PR DESCRIPTION
Add the flags `--list-targets` and `--list-variables` to the cases where initializing the builder can be skipped.

This allows the listing of targets and variables when no builder is available.

Resolves: docker/buildx#2755