### PR TITLE
ci: update runner to macos-14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,7 +158,7 @@ jobs:
       matrix:
         os:
           - ubuntu-24.04
-          - macos-12
+          - macos-14
           - windows-2022
     env:
       SKIP_INTEGRATION_TESTS: 1


### PR DESCRIPTION
relates to https://github.com/actions/runner-images/issues/10721