### PR TITLE
Improve linter checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ run:
 linters:
   enable:
     - gofmt
+    - gosimple
     - govet
     - depguard
     - goimports

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,20 +5,20 @@ run:
 
 linters:
   enable:
+    - depguard
+    - forbidigo
     - gofmt
+    - goimports
+    - gosec
     - gosimple
     - govet
-    - depguard
-    - goimports
     - ineffassign
     - misspell
-    - unused
+    - nolintlint
     - revive
     - staticcheck
     - typecheck
-    - nolintlint
-    - gosec
-    - forbidigo
+    - unused
   disable-all: true
 
 linters-settings:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,6 +34,16 @@ linters-settings:
       - "appendAssign"
       - "singleCaseSwitch"
       - "exitAfterDefer" # FIXME
+  importas:
+    alias:
+      # Enforce alias to prevent it accidentally being used instead of
+      # buildkit errdefs package (or vice-versa).
+      - pkg: "github.com/containerd/errdefs"
+        alias: "cerrdefs"
+      - pkg: "github.com/opencontainers/image-spec/specs-go/v1"
+        alias: "ocispecs"
+      - pkg: "github.com/opencontainers/go-digest"
+        alias: "digest"
   govet:
     enable:
       - nilness

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,6 +56,10 @@ linters-settings:
             desc: The io/ioutil package has been deprecated.
   forbidigo:
     forbid:
+      - '^context\.WithCancel(# use context\.WithCancelCause instead)?$'
+      - '^context\.WithDeadline(# use context\.WithDeadline instead)?$'
+      - '^context\.WithTimeout(# use context\.WithTimeoutCause instead)?$'
+      - '^ctx\.Err(# use context\.Cause instead)?$'
       - '^fmt\.Errorf(# use errors\.Errorf instead)?$'
       - '^platforms\.DefaultString(# use platforms\.Format(platforms\.DefaultSpec()) instead\.)?$'
   gosec:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,23 +5,35 @@ run:
 
 linters:
   enable:
+    - bodyclose
     - depguard
     - forbidigo
+    - gocritic
     - gofmt
     - goimports
     - gosec
     - gosimple
     - govet
     - ineffassign
+    - makezero
     - misspell
+    - noctx
     - nolintlint
     - revive
     - staticcheck
     - typecheck
     - unused
+    - whitespace
   disable-all: true
 
 linters-settings:
+  gocritic:
+    disabled-checks:
+      - "ifElseChain"
+      - "assignOp"
+      - "appendAssign"
+      - "singleCaseSwitch"
+      - "exitAfterDefer" # FIXME
   govet:
     enable:
       - nilness

--- a/bake/compose.go
+++ b/bake/compose.go
@@ -179,7 +179,6 @@ func ParseCompose(cfgs []composetypes.ConfigFile, envs map[string]string) (*Conf
 			c.Targets = append(c.Targets, t)
 		}
 		c.Groups = append(c.Groups, g)
-
 	}
 
 	return &c, nil

--- a/bake/hclparser/stdlib.go
+++ b/bake/hclparser/stdlib.go
@@ -170,7 +170,6 @@ func indexOfFunc() function.Function {
 				}
 			}
 			return cty.NilVal, errors.New("item not found")
-
 		},
 	})
 }

--- a/build/result.go
+++ b/build/result.go
@@ -82,7 +82,7 @@ func NewResultHandle(ctx context.Context, cc *client.Client, opt client.SolveOpt
 	var respHandle *ResultHandle
 
 	go func() {
-		defer cancel(context.Canceled) // ensure no dangling processes
+		defer func() { cancel(errors.WithStack(context.Canceled)) }() // ensure no dangling processes
 
 		var res *gateway.Result
 		var err error
@@ -181,7 +181,7 @@ func NewResultHandle(ctx context.Context, cc *client.Client, opt client.SolveOpt
 			case <-respHandle.done:
 			case <-ctx.Done():
 			}
-			return nil, ctx.Err()
+			return nil, context.Cause(ctx)
 		}, nil)
 		if respHandle != nil {
 			return

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -288,7 +288,15 @@ func GetBuilders(dockerCli command.Cli, txn *store.Txn) ([]*Builder, error) {
 		return nil, err
 	}
 
-	builders := make([]*Builder, len(storeng))
+	contexts, err := dockerCli.ContextStore().List()
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(contexts, func(i, j int) bool {
+		return contexts[i].Name < contexts[j].Name
+	})
+
+	builders := make([]*Builder, len(storeng), len(storeng)+len(contexts))
 	seen := make(map[string]struct{})
 	for i, ng := range storeng {
 		b, err := New(dockerCli,
@@ -302,14 +310,6 @@ func GetBuilders(dockerCli command.Cli, txn *store.Txn) ([]*Builder, error) {
 		builders[i] = b
 		seen[b.NodeGroup.Name] = struct{}{}
 	}
-
-	contexts, err := dockerCli.ContextStore().List()
-	if err != nil {
-		return nil, err
-	}
-	sort.Slice(contexts, func(i, j int) bool {
-		return contexts[i].Name < contexts[j].Name
-	})
 
 	for _, c := range contexts {
 		// if a context has the same name as an instance from the store, do not

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -522,8 +522,9 @@ func Create(ctx context.Context, txn *store.Txn, dockerCli command.Cli, opts Cre
 		return nil, err
 	}
 
-	timeoutCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
-	defer cancel()
+	cancelCtx, cancel := context.WithCancelCause(ctx)
+	timeoutCtx, _ := context.WithTimeoutCause(cancelCtx, 20*time.Second, errors.WithStack(context.DeadlineExceeded))
+	defer func() { cancel(errors.WithStack(context.Canceled)) }()
 
 	nodes, err := b.LoadNodes(timeoutCtx, WithData())
 	if err != nil {

--- a/commands/bake.go
+++ b/commands/bake.go
@@ -108,8 +108,8 @@ func runBake(ctx context.Context, dockerCli command.Cli, targets []string, in ba
 		return err
 	}
 
-	ctx2, cancel := context.WithCancel(context.TODO())
-	defer cancel()
+	ctx2, cancel := context.WithCancelCause(context.TODO())
+	defer cancel(errors.WithStack(context.Canceled))
 
 	var nodes []builder.Node
 	var progressConsoleDesc, progressTextDesc string

--- a/commands/build.go
+++ b/commands/build.go
@@ -885,7 +885,6 @@ func printWarnings(w io.Writer, warnings []client.VertexWarning, mode progressui
 			src.Print(w)
 		}
 		fmt.Fprintf(w, "\n")
-
 	}
 }
 

--- a/commands/build.go
+++ b/commands/build.go
@@ -325,8 +325,8 @@ func runBuild(ctx context.Context, dockerCli command.Cli, options buildOptions) 
 	}
 	attributes := buildMetricAttributes(dockerCli, driverType, &options)
 
-	ctx2, cancel := context.WithCancel(context.TODO())
-	defer cancel()
+	ctx2, cancel := context.WithCancelCause(context.TODO())
+	defer func() { cancel(errors.WithStack(context.Canceled)) }()
 	progressMode, err := options.toDisplayMode()
 	if err != nil {
 		return err

--- a/commands/imagetools/create.go
+++ b/commands/imagetools/create.go
@@ -173,8 +173,8 @@ func runCreate(ctx context.Context, dockerCli command.Cli, in createOptions, arg
 	// new resolver cause need new auth
 	r = imagetools.New(imageopt)
 
-	ctx2, cancel := context.WithCancel(context.TODO())
-	defer cancel()
+	ctx2, cancel := context.WithCancelCause(context.TODO())
+	defer func() { cancel(errors.WithStack(context.Canceled)) }()
 	printer, err := progress.NewPrinter(ctx2, os.Stderr, progressui.DisplayMode(in.progress))
 	if err != nil {
 		return err

--- a/commands/imagetools/create.go
+++ b/commands/imagetools/create.go
@@ -42,7 +42,7 @@ func runCreate(ctx context.Context, dockerCli command.Cli, in createOptions, arg
 		return errors.Errorf("can't push with no tags specified, please set --tag or --dry-run")
 	}
 
-	fileArgs := make([]string, len(in.files))
+	fileArgs := make([]string, len(in.files), len(in.files)+len(args))
 	for i, f := range in.files {
 		dt, err := os.ReadFile(f)
 		if err != nil {

--- a/commands/ls.go
+++ b/commands/ls.go
@@ -319,7 +319,7 @@ func (tp truncatedPlatforms) String() string {
 		if tpf, ok := tp.res[mpf]; ok {
 			seen[mpf] = struct{}{}
 			if len(tpf) == 1 {
-				out = append(out, fmt.Sprintf("%s", tpf[0]))
+				out = append(out, tpf[0])
 				count++
 			} else {
 				hasPreferredPlatform := false
@@ -347,7 +347,7 @@ func (tp truncatedPlatforms) String() string {
 			continue
 		}
 		if len(tp.res[mpf]) == 1 {
-			out = append(out, fmt.Sprintf("%s", tp.res[mpf][0]))
+			out = append(out, tp.res[mpf][0])
 			count++
 		} else {
 			hasPreferredPlatform := false

--- a/commands/rm.go
+++ b/commands/rm.go
@@ -150,8 +150,9 @@ func rmAllInactive(ctx context.Context, txn *store.Txn, dockerCli command.Cli, i
 		return err
 	}
 
-	timeoutCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
-	defer cancel()
+	timeoutCtx, cancel := context.WithCancelCause(ctx)
+	timeoutCtx, _ = context.WithTimeoutCause(timeoutCtx, 20*time.Second, errors.WithStack(context.DeadlineExceeded))
+	defer func() { cancel(errors.WithStack(context.Canceled)) }()
 
 	eg, _ := errgroup.WithContext(timeoutCtx)
 	for _, b := range builders {

--- a/commands/use.go
+++ b/commands/use.go
@@ -46,7 +46,6 @@ func runUse(dockerCli command.Cli, in useOptions) error {
 					return errors.Errorf("run `docker context use %s` to switch to context %s", in.builder, in.builder)
 				}
 			}
-
 		}
 		return errors.Wrapf(err, "failed to find instance %q", in.builder)
 	}

--- a/controller/local/controller.go
+++ b/controller/local/controller.go
@@ -109,7 +109,7 @@ func (b *localController) Invoke(ctx context.Context, sessionID string, pid stri
 
 	// Attach containerIn to this process
 	ioCancelledCh := make(chan struct{})
-	proc.ForwardIO(&ioset.In{Stdin: ioIn, Stdout: ioOut, Stderr: ioErr}, func() { close(ioCancelledCh) })
+	proc.ForwardIO(&ioset.In{Stdin: ioIn, Stdout: ioOut, Stderr: ioErr}, func(error) { close(ioCancelledCh) })
 
 	select {
 	case <-ioCancelledCh:
@@ -117,7 +117,7 @@ func (b *localController) Invoke(ctx context.Context, sessionID string, pid stri
 	case err := <-proc.Done():
 		return err
 	case <-ctx.Done():
-		return ctx.Err()
+		return context.Cause(ctx)
 	}
 }
 

--- a/controller/pb/path.go
+++ b/controller/pb/path.go
@@ -153,7 +153,6 @@ func ResolveOptionPaths(options *BuildOptions) (_ *BuildOptions, err error) {
 				}
 			}
 			ps = append(ps, p)
-
 		}
 		s.Paths = ps
 		ssh = append(ssh, s)

--- a/controller/pb/progress.go
+++ b/controller/pb/progress.go
@@ -22,9 +22,7 @@ func (w *writer) Write(status *client.SolveStatus) {
 	w.ch <- ToControlStatus(status)
 }
 
-func (w *writer) WriteBuildRef(target string, ref string) {
-	return
-}
+func (w *writer) WriteBuildRef(target string, ref string) {}
 
 func (w *writer) ValidateLogSource(digest.Digest, interface{}) bool {
 	return true

--- a/controller/remote/controller.go
+++ b/controller/remote/controller.go
@@ -62,9 +62,10 @@ func NewRemoteBuildxController(ctx context.Context, dockerCli command.Cli, opts 
 	serverRoot := filepath.Join(rootDir, "shared")
 
 	// connect to buildx server if it is already running
-	ctx2, cancel := context.WithTimeout(ctx, 1*time.Second)
+	ctx2, cancel := context.WithCancelCause(ctx)
+	ctx2, _ = context.WithTimeoutCause(ctx2, 1*time.Second, errors.WithStack(context.DeadlineExceeded))
 	c, err := newBuildxClientAndCheck(ctx2, filepath.Join(serverRoot, defaultSocketFilename))
-	cancel()
+	cancel(errors.WithStack(context.Canceled))
 	if err != nil {
 		if !errors.Is(err, context.DeadlineExceeded) {
 			return nil, errors.Wrap(err, "cannot connect to the buildx server")
@@ -90,9 +91,10 @@ func NewRemoteBuildxController(ctx context.Context, dockerCli command.Cli, opts 
 		go wait()
 
 		// wait for buildx server to be ready
-		ctx2, cancel = context.WithTimeout(ctx, 10*time.Second)
+		ctx2, cancel = context.WithCancelCause(ctx)
+		ctx2, _ = context.WithTimeoutCause(ctx2, 10*time.Second, errors.WithStack(context.DeadlineExceeded))
 		c, err = newBuildxClientAndCheck(ctx2, filepath.Join(serverRoot, defaultSocketFilename))
-		cancel()
+		cancel(errors.WithStack(context.Canceled))
 		if err != nil {
 			return errors.Wrap(err, "cannot connect to the buildx server")
 		}

--- a/controller/remote/io.go
+++ b/controller/remote/io.go
@@ -302,7 +302,6 @@ func attachIO(ctx context.Context, stream msgStream, initMessage *pb.InitMessage
 					out = cfg.stderr
 				default:
 					return errors.Errorf("unsupported fd %d", file.Fd)
-
 				}
 				if out == nil {
 					logrus.Warnf("attachIO: no writer for fd %d", file.Fd)

--- a/controller/remote/io.go
+++ b/controller/remote/io.go
@@ -344,7 +344,7 @@ func receive(ctx context.Context, stream msgStream) (*pb.Message, error) {
 	case err := <-errCh:
 		return nil, err
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return nil, context.Cause(ctx)
 	}
 }
 

--- a/driver/docker-container/driver.go
+++ b/driver/docker-container/driver.go
@@ -177,7 +177,6 @@ func (d *Driver) create(ctx context.Context, l progress.SubLogger) error {
 					break
 				}
 			}
-
 		}
 		_, err := d.DockerAPI.ContainerCreate(ctx, cfg, hc, &network.NetworkingConfig{}, nil, d.Name)
 		if err != nil && !errdefs.IsConflict(err) {

--- a/driver/docker-container/driver.go
+++ b/driver/docker-container/driver.go
@@ -212,7 +212,7 @@ func (d *Driver) wait(ctx context.Context, l progress.SubLogger) error {
 			}
 			select {
 			case <-ctx.Done():
-				return ctx.Err()
+				return context.Cause(ctx)
 			case <-time.After(time.Duration(try*120) * time.Millisecond):
 				try++
 				continue

--- a/driver/docker/version.go
+++ b/driver/docker/version.go
@@ -176,11 +176,6 @@ func resolveBuildKitVersion(ver string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		//if _, errs := c.Validate(mobyVersion); len(errs) > 0 {
-		//	for _, err := range errs {
-		//		fmt.Printf("%s: %v\n", m.MobyVersionConstraint, err)
-		//	}
-		//}
 		if !c.Check(mobyVersion) {
 			continue
 		}

--- a/driver/kubernetes/driver.go
+++ b/driver/kubernetes/driver.go
@@ -112,7 +112,7 @@ func (d *Driver) wait(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return context.Cause(ctx)
 		case <-timeoutChan:
 			return err
 		case <-ticker.C:

--- a/driver/remote/driver.go
+++ b/driver/remote/driver.go
@@ -47,8 +47,9 @@ func (d *Driver) Bootstrap(ctx context.Context, l progress.Logger) error {
 		return err
 	}
 	return progress.Wrap("[internal] waiting for connection", l, func(_ progress.SubLogger) error {
-		ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
-		defer cancel()
+		cancelCtx, cancel := context.WithCancelCause(ctx)
+		ctx, _ := context.WithTimeoutCause(cancelCtx, 20*time.Second, errors.WithStack(context.DeadlineExceeded))
+		defer func() { cancel(errors.WithStack(context.Canceled)) }()
 		return c.Wait(ctx)
 	})
 }

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -326,7 +326,7 @@ func (m *monitor) invoke(ctx context.Context, pid string, cfg *controllerapi.Inv
 	if m.AttachedSessionID() == "" {
 		return nil
 	}
-	invokeCtx, invokeCancel := context.WithCancel(ctx)
+	invokeCtx, invokeCancel := context.WithCancelCause(ctx)
 
 	containerIn, containerOut := ioset.Pipe()
 	m.invokeIO.SetOut(&containerOut)
@@ -336,7 +336,7 @@ func (m *monitor) invoke(ctx context.Context, pid string, cfg *controllerapi.Inv
 		cancelOnce.Do(func() {
 			containerIn.Close()
 			m.invokeIO.SetOut(nil)
-			invokeCancel()
+			invokeCancel(errors.WithStack(context.Canceled))
 		})
 		<-waitInvokeDoneCh
 	}

--- a/tests/bake.go
+++ b/tests/bake.go
@@ -978,7 +978,6 @@ func testBakeMultiPlatform(t *testing.T, sb integration.Sandbox) {
 		require.NotNil(t, img)
 		img = imgs.Find("linux/arm64")
 		require.NotNil(t, img)
-
 	} else {
 		require.Error(t, err, string(out))
 		require.Contains(t, string(out), "Multi-platform build is not supported")
@@ -1468,7 +1467,7 @@ target "third" {
 			fstest.CreateFile("docker-bake.hcl", bakefile, 0600),
 		)
 
-		dockerfilePathFirst := filepath.Join("Dockerfile")
+		dockerfilePathFirst := "Dockerfile"
 		dockerfilePathSecond := filepath.Join("subdir", "Dockerfile")
 		dockerfilePathThird := filepath.Join("subdir", "subsubdir", "Dockerfile")
 

--- a/tests/build.go
+++ b/tests/build.go
@@ -649,7 +649,6 @@ func testBuildMultiPlatform(t *testing.T, sb integration.Sandbox) {
 		require.NotNil(t, img)
 		img = imgs.Find("linux/arm64")
 		require.NotNil(t, img)
-
 	} else {
 		require.Error(t, err, string(out))
 		require.Contains(t, string(out), "Multi-platform build is not supported")

--- a/util/buildflags/export.go
+++ b/util/buildflags/export.go
@@ -138,7 +138,6 @@ func ParseAnnotations(inp []string) (map[exptypes.AnnotationKey]string, error) {
 			}
 			annotations[ak] = v
 		}
-
 	}
 	return annotations, nil
 }

--- a/util/dockerutil/client.go
+++ b/util/dockerutil/client.go
@@ -41,7 +41,6 @@ func (c *Client) LoadImage(ctx context.Context, name string, status progress.Wri
 	pr, pw := io.Pipe()
 	done := make(chan struct{})
 
-	ctx, cancel := context.WithCancel(ctx)
 	var w *waitingWriter
 	w = &waitingWriter{
 		PipeWriter: pw,
@@ -67,8 +66,7 @@ func (c *Client) LoadImage(ctx context.Context, name string, status progress.Wri
 				handleErr(err)
 			}
 		},
-		done:   done,
-		cancel: cancel,
+		done: done,
 	}
 	return w, func() {
 		pr.Close()
@@ -101,12 +99,11 @@ func (c *Client) features(ctx context.Context, name string) map[Feature]bool {
 
 type waitingWriter struct {
 	*io.PipeWriter
-	f      func()
-	once   sync.Once
-	mu     sync.Mutex
-	err    error
-	done   chan struct{}
-	cancel func()
+	f    func()
+	once sync.Once
+	mu   sync.Mutex
+	err  error
+	done chan struct{}
 }
 
 func (w *waitingWriter) Write(dt []byte) (int, error) {

--- a/util/dockerutil/progress.go
+++ b/util/dockerutil/progress.go
@@ -55,7 +55,7 @@ func fromReader(l progress.SubLogger, rc io.ReadCloser) error {
 				Started: &now,
 			}
 		}
-		timeDelta := time.Now().Sub(st.Timestamp)
+		timeDelta := time.Since(st.Timestamp)
 		if timeDelta < minTimeDelta {
 			continue
 		}

--- a/util/gitutil/testutilserve.go
+++ b/util/gitutil/testutilserve.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,7 +26,7 @@ func WithAccessToken(token string) GitServeOpt {
 func GitServeHTTP(c *Git, t testing.TB, opts ...GitServeOpt) (url string) {
 	t.Helper()
 	gitUpdateServerInfo(c, t)
-	ctx, cancel := context.WithCancel(context.TODO())
+	ctx, cancel := context.WithCancelCause(context.TODO())
 
 	gs := &gitServe{}
 	for _, opt := range opts {
@@ -38,7 +39,7 @@ func GitServeHTTP(c *Git, t testing.TB, opts ...GitServeOpt) (url string) {
 	name := "test.git"
 	dir, err := c.GitDir()
 	if err != nil {
-		cancel()
+		cancel(err)
 	}
 
 	var addr string
@@ -84,7 +85,7 @@ func GitServeHTTP(c *Git, t testing.TB, opts ...GitServeOpt) (url string) {
 	<-ready
 
 	t.Cleanup(func() {
-		cancel()
+		cancel(errors.Errorf("cleanup"))
 		<-done
 	})
 	return fmt.Sprintf("http://%s/%s", addr, name)

--- a/util/imagetools/imagetools_helpers_test.go
+++ b/util/imagetools/imagetools_helpers_test.go
@@ -47,7 +47,6 @@ func (f mockFetcher) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.Rea
 		reader := io.NopCloser(strings.NewReader(desc.Annotations["test_content"]))
 		return reader, nil
 	}
-
 }
 
 func (r mockResolver) Resolve(ctx context.Context, ref string) (name string, desc ocispec.Descriptor, err error) {

--- a/util/waitmap/waitmap.go
+++ b/util/waitmap/waitmap.go
@@ -61,7 +61,7 @@ func (m *Map) Get(ctx context.Context, keys ...string) (map[string]interface{}, 
 		m.mu.Unlock()
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, context.Cause(ctx)
 		case <-ch:
 			m.mu.Lock()
 		}

--- a/util/waitmap/waitmap_test.go
+++ b/util/waitmap/waitmap_test.go
@@ -34,7 +34,7 @@ func TestTimeout(t *testing.T) {
 
 	m.Set("foo", "bar")
 
-	ctx, cancel := context.WithTimeout(context.TODO(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeoutCause(context.TODO(), 100*time.Millisecond, nil)
 	defer cancel()
 
 	_, err := m.Get(ctx, "bar")


### PR DESCRIPTION
Brings in more linter validations similar to what is already enabled in buildkit.

The biggest missing component is testifylint that is big enough for own PR. I have my previous tooling for auto-fixing some common testify errors, so nobody should attempt it manually.

Intentionally not updating golangci itself as already part of go1.23 PR.