### PR TITLE
hack: mount docker config on gha

### DIFF
--- a/hack/test
+++ b/hack/test
@@ -2,6 +2,8 @@
 
 set -eu -o pipefail
 
+: "${GITHUB_ACTIONS=}"
+
 : "${BUILDX_CMD=docker buildx}"
 
 : "${TEST_COVERAGE=}"
@@ -37,7 +39,15 @@ if [ "$TEST_COVERAGE" = "1" ]; then
   export GO_TEST_COVERPROFILE="/testreports/coverage-report$TEST_REPORT_SUFFIX.txt"
 fi
 
-cid=$(docker create --rm --privileged \
+dockerConfigMount=""
+if [ "$GITHUB_ACTIONS" = "true" ]; then
+  dockerConfigPath="$HOME/.docker/config.json"
+  if [ -f "$dockerConfigPath" ]; then
+    dockerConfigMount="-v $dockerConfigPath:/root/.docker/config.json:ro"
+  fi
+fi
+
+cid=$(docker create --rm --privileged $dockerConfigMount \
   -v /tmp $testReportsVol \
   --volumes-from=$cacheVolume \
   -e GITHUB_REF \


### PR DESCRIPTION
relates to https://github.com/docker/buildx/actions/runs/11954989788/job/33326387756#step:7:311

```
=== FAIL: tests TestIntegration (6.56s)
    run.go:272: copied docker.io/moby/buildkit:latest to local mirror localhost:46659/moby/buildkit:buildx-stable-1
time="2024-11-21T14:15:54Z" level=info msg="trying next host - response was http.StatusNotFound" host="localhost:46659"
    run.go:321: 
        	Error Trace:	/src/vendor/github.com/moby/buildkit/util/testutil/integration/run.go:321
        	            				/usr/local/go/src/sync/once.go:76
        	            				/usr/local/go/src/sync/once.go:67
        	            				/src/vendor/github.com/moby/buildkit/util/testutil/integration/run.go:319
        	            				/src/vendor/github.com/moby/buildkit/util/testutil/integration/run.go:203
        	Error:      	Received unexpected error:
        	            	httpReadSeeker: failed open: unexpected status code https://registry-1.docker.io/v2/amd64/busybox/manifests/sha256:023917ec6a886d0e8e15f28fb543515a5fcd8d938edb091e8147db4efed388ee: 429 Too Many Requests - Server message: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
        	            	github.com/moby/buildkit/util/contentutil.CopyChain
        	            		/src/vendor/github.com/moby/buildkit/util/contentutil/copy.go:87
        	            	github.com/moby/buildkit/util/testutil/integration.copyImagesLocal
        	            		/src/vendor/github.com/moby/buildkit/util/testutil/integration/run.go:269
        	            	github.com/moby/buildkit/util/testutil/integration.runMirror
        	            		/src/vendor/github.com/moby/buildkit/util/testutil/integration/run.go:358
        	            	github.com/moby/buildkit/util/testutil/integration.Run.lazyMirrorRunnerFunc.func3.1
        	            		/src/vendor/github.com/moby/buildkit/util/testutil/integration/run.go:320
        	            	sync.(*Once).doSlow
        	            		/usr/local/go/src/sync/once.go:76
        	            	sync.(*Once).Do
        	            		/usr/local/go/src/sync/once.go:67
        	            	github.com/moby/buildkit/util/testutil/integration.Run.lazyMirrorRunnerFunc.func3
        	            		/src/vendor/github.com/moby/buildkit/util/testutil/integration/run.go:319
        	            	github.com/moby/buildkit/util/testutil/integration.Run.func2.1
        	            		/src/vendor/github.com/moby/buildkit/util/testutil/integration/run.go:203
        	            	testing.tRunner
        	            		/usr/local/go/src/testing/testing.go:1690
        	            	runtime.goexit
        	            		/usr/local/go/src/runtime/asm_amd64.s:1700
        	Test:       	TestIntegration
```