### PR TITLE
bake: fix entitlement test when running from symlink temp

### DIFF
--- a/bake/entitlements_test.go
+++ b/bake/entitlements_test.go
@@ -180,10 +180,18 @@ func TestValidateEntitlements(t *testing.T) {
 	dir2, err := osutil.GetLongPathName(t.TempDir())
 	require.NoError(t, err)
 
+	// the paths returned by entitlements validation will have symlinks resolved
+	expDir1, err := filepath.EvalSymlinks(dir1)
+	require.NoError(t, err)
+	expDir2, err := filepath.EvalSymlinks(dir2)
+	require.NoError(t, err)
+
 	escapeLink := filepath.Join(dir1, "escape_link")
 	require.NoError(t, os.Symlink("../../aa", escapeLink))
 
 	wd := osutil.GetWd()
+	expWd, err := filepath.EvalSymlinks(wd)
+	require.NoError(t, err)
 
 	tcases := []struct {
 		name     string
@@ -208,7 +216,7 @@ func TestValidateEntitlements(t *testing.T) {
 			},
 			expected: EntitlementConf{
 				NetworkHost: true,
-				FSRead:      []string{wd},
+				FSRead:      []string{expWd},
 			},
 		},
 		{
@@ -222,7 +230,7 @@ func TestValidateEntitlements(t *testing.T) {
 				},
 			},
 			expected: EntitlementConf{
-				FSRead: []string{wd},
+				FSRead: []string{expWd},
 			},
 		},
 		{
@@ -236,7 +244,7 @@ func TestValidateEntitlements(t *testing.T) {
 			expected: EntitlementConf{
 				NetworkHost:      true,
 				SecurityInsecure: true,
-				FSRead:           []string{wd},
+				FSRead:           []string{expWd},
 			},
 		},
 		{
@@ -252,7 +260,7 @@ func TestValidateEntitlements(t *testing.T) {
 			},
 			expected: EntitlementConf{
 				SecurityInsecure: true,
-				FSRead:           []string{wd},
+				FSRead:           []string{expWd},
 			},
 		},
 		{
@@ -266,7 +274,7 @@ func TestValidateEntitlements(t *testing.T) {
 			},
 			expected: EntitlementConf{
 				SSH:    true,
-				FSRead: []string{wd},
+				FSRead: []string{expWd},
 			},
 		},
 		{
@@ -295,11 +303,11 @@ func TestValidateEntitlements(t *testing.T) {
 			},
 			expected: EntitlementConf{
 				FSWrite: func() []string {
-					exp := []string{dir1, dir2}
+					exp := []string{expDir1, expDir2}
 					slices.Sort(exp)
 					return exp
 				}(),
-				FSRead: []string{wd},
+				FSRead: []string{expWd},
 			},
 		},
 		{
@@ -328,7 +336,7 @@ func TestValidateEntitlements(t *testing.T) {
 				FSRead: []string{wd, dir1},
 			},
 			expected: EntitlementConf{
-				FSRead: []string{filepath.Join(dir1, "../..")},
+				FSRead: []string{filepath.Join(expDir1, "../..")},
 			},
 		},
 		{

--- a/bake/entitlements_test.go
+++ b/bake/entitlements_test.go
@@ -175,10 +175,8 @@ func TestDedupePaths(t *testing.T) {
 }
 
 func TestValidateEntitlements(t *testing.T) {
-	dir1, err := osutil.GetLongPathName(t.TempDir())
-	require.NoError(t, err)
-	dir2, err := osutil.GetLongPathName(t.TempDir())
-	require.NoError(t, err)
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
 
 	// the paths returned by entitlements validation will have symlinks resolved
 	expDir1, err := filepath.EvalSymlinks(dir1)
@@ -189,7 +187,8 @@ func TestValidateEntitlements(t *testing.T) {
 	escapeLink := filepath.Join(dir1, "escape_link")
 	require.NoError(t, os.Symlink("../../aa", escapeLink))
 
-	wd := osutil.GetWd()
+	wd, err := os.Getwd()
+	require.NoError(t, err)
 	expWd, err := filepath.EvalSymlinks(wd)
 	require.NoError(t, err)
 


### PR DESCRIPTION
As the paths returned by validator have the symlinks resolved, the test needs to resolve the symlinks also in the expected values. Previously this would fail if t.TempDir() or os.GetWd() returned a path that contained a symlink.

The issue was purely in the test and not in the entitlements validation logic.