### PR TITLE
bake: test empty attribute

### DIFF
--- a/bake/bake_test.go
+++ b/bake/bake_test.go
@@ -2019,6 +2019,24 @@ target "app" {
 	})
 }
 
+// https://github.com/docker/buildx/pull/428
+// https://github.com/docker/buildx/issues/2822
+func TestEmptyAttribute(t *testing.T) {
+	fp := File{
+		Name: "docker-bake.hcl",
+		Data: []byte(`
+target "app" {
+  output = [""]
+}
+`),
+	}
+
+	ctx := context.TODO()
+
+	_, _, err := ReadTargets(ctx, []File{fp}, []string{"app"}, nil, nil)
+	require.NoError(t, err)
+}
+
 func stringify[V fmt.Stringer](values []V) []string {
 	s := make([]string, len(values))
 	for i, v := range values {


### PR DESCRIPTION
relates to:
* https://github.com/docker/buildx/issues/2822

fixes https://github.com/docker/buildx/issues/2825

Expected to fail currently:

https://github.com/docker/buildx/actions/runs/12066463568/job/33647355827?pr=2826#step:6:1322

```
=== FAIL: bake TestEmptyAttribute (0.00s)
    bake_test.go:2037: 
        	Error Trace:	/home/runner/work/buildx/buildx/bake/bake_test.go:2037
        	Error:      	Received unexpected error:
        	            	docker-bake.hcl:3,12-13: Unsuitable value type; Unsuitable value: EOF
        	Test:       	TestEmptyAttribute
```
