### PR TITLE
bake: cache-from/cache-to options no longer print sensitive values

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -698,30 +698,30 @@ type Target struct {
 	// Inherits is the only field that cannot be overridden with --set
 	Inherits []string `json:"inherits,omitempty" hcl:"inherits,optional" cty:"inherits"`
 
-	Annotations      []string                        `json:"annotations,omitempty" hcl:"annotations,optional" cty:"annotations"`
-	Attest           []string                        `json:"attest,omitempty" hcl:"attest,optional" cty:"attest"`
-	Context          *string                         `json:"context,omitempty" hcl:"context,optional" cty:"context"`
-	Contexts         map[string]string               `json:"contexts,omitempty" hcl:"contexts,optional" cty:"contexts"`
-	Dockerfile       *string                         `json:"dockerfile,omitempty" hcl:"dockerfile,optional" cty:"dockerfile"`
-	DockerfileInline *string                         `json:"dockerfile-inline,omitempty" hcl:"dockerfile-inline,optional" cty:"dockerfile-inline"`
-	Args             map[string]*string              `json:"args,omitempty" hcl:"args,optional" cty:"args"`
-	Labels           map[string]*string              `json:"labels,omitempty" hcl:"labels,optional" cty:"labels"`
-	Tags             []string                        `json:"tags,omitempty" hcl:"tags,optional" cty:"tags"`
-	CacheFrom        []*buildflags.CacheOptionsEntry `json:"cache-from,omitempty"  hcl:"cache-from,optional" cty:"cache-from"`
-	CacheTo          []*buildflags.CacheOptionsEntry `json:"cache-to,omitempty"  hcl:"cache-to,optional" cty:"cache-to"`
-	Target           *string                         `json:"target,omitempty" hcl:"target,optional" cty:"target"`
-	Secrets          []*buildflags.Secret            `json:"secret,omitempty" hcl:"secret,optional" cty:"secret"`
-	SSH              []*buildflags.SSH               `json:"ssh,omitempty" hcl:"ssh,optional" cty:"ssh"`
-	Platforms        []string                        `json:"platforms,omitempty" hcl:"platforms,optional" cty:"platforms"`
-	Outputs          []*buildflags.ExportEntry       `json:"output,omitempty" hcl:"output,optional" cty:"output"`
-	Pull             *bool                           `json:"pull,omitempty" hcl:"pull,optional" cty:"pull"`
-	NoCache          *bool                           `json:"no-cache,omitempty" hcl:"no-cache,optional" cty:"no-cache"`
-	NetworkMode      *string                         `json:"network,omitempty" hcl:"network,optional" cty:"network"`
-	NoCacheFilter    []string                        `json:"no-cache-filter,omitempty" hcl:"no-cache-filter,optional" cty:"no-cache-filter"`
-	ShmSize          *string                         `json:"shm-size,omitempty" hcl:"shm-size,optional"`
-	Ulimits          []string                        `json:"ulimits,omitempty" hcl:"ulimits,optional"`
-	Call             *string                         `json:"call,omitempty" hcl:"call,optional" cty:"call"`
-	Entitlements     []string                        `json:"entitlements,omitempty" hcl:"entitlements,optional" cty:"entitlements"`
+	Annotations      []string                  `json:"annotations,omitempty" hcl:"annotations,optional" cty:"annotations"`
+	Attest           []string                  `json:"attest,omitempty" hcl:"attest,optional" cty:"attest"`
+	Context          *string                   `json:"context,omitempty" hcl:"context,optional" cty:"context"`
+	Contexts         map[string]string         `json:"contexts,omitempty" hcl:"contexts,optional" cty:"contexts"`
+	Dockerfile       *string                   `json:"dockerfile,omitempty" hcl:"dockerfile,optional" cty:"dockerfile"`
+	DockerfileInline *string                   `json:"dockerfile-inline,omitempty" hcl:"dockerfile-inline,optional" cty:"dockerfile-inline"`
+	Args             map[string]*string        `json:"args,omitempty" hcl:"args,optional" cty:"args"`
+	Labels           map[string]*string        `json:"labels,omitempty" hcl:"labels,optional" cty:"labels"`
+	Tags             []string                  `json:"tags,omitempty" hcl:"tags,optional" cty:"tags"`
+	CacheFrom        buildflags.CacheOptions   `json:"cache-from,omitempty"  hcl:"cache-from,optional" cty:"cache-from"`
+	CacheTo          buildflags.CacheOptions   `json:"cache-to,omitempty"  hcl:"cache-to,optional" cty:"cache-to"`
+	Target           *string                   `json:"target,omitempty" hcl:"target,optional" cty:"target"`
+	Secrets          []*buildflags.Secret      `json:"secret,omitempty" hcl:"secret,optional" cty:"secret"`
+	SSH              []*buildflags.SSH         `json:"ssh,omitempty" hcl:"ssh,optional" cty:"ssh"`
+	Platforms        []string                  `json:"platforms,omitempty" hcl:"platforms,optional" cty:"platforms"`
+	Outputs          []*buildflags.ExportEntry `json:"output,omitempty" hcl:"output,optional" cty:"output"`
+	Pull             *bool                     `json:"pull,omitempty" hcl:"pull,optional" cty:"pull"`
+	NoCache          *bool                     `json:"no-cache,omitempty" hcl:"no-cache,optional" cty:"no-cache"`
+	NetworkMode      *string                   `json:"network,omitempty" hcl:"network,optional" cty:"network"`
+	NoCacheFilter    []string                  `json:"no-cache-filter,omitempty" hcl:"no-cache-filter,optional" cty:"no-cache-filter"`
+	ShmSize          *string                   `json:"shm-size,omitempty" hcl:"shm-size,optional"`
+	Ulimits          []string                  `json:"ulimits,omitempty" hcl:"ulimits,optional"`
+	Call             *string                   `json:"call,omitempty" hcl:"call,optional" cty:"call"`
+	Entitlements     []string                  `json:"entitlements,omitempty" hcl:"entitlements,optional" cty:"entitlements"`
 	// IMPORTANT: if you add more fields here, do not forget to update newOverrides/AddOverrides and docs/bake-reference.md.
 
 	// linked is a private field to mark a target used as a linked one
@@ -742,8 +742,8 @@ func (t *Target) normalize() {
 	t.Secrets = removeDupes(t.Secrets)
 	t.SSH = removeDupes(t.SSH)
 	t.Platforms = removeDupesStr(t.Platforms)
-	t.CacheFrom = removeDupes(t.CacheFrom)
-	t.CacheTo = removeDupes(t.CacheTo)
+	t.CacheFrom = t.CacheFrom.Normalize()
+	t.CacheTo = t.CacheTo.Normalize()
 	t.Outputs = removeDupes(t.Outputs)
 	t.NoCacheFilter = removeDupesStr(t.NoCacheFilter)
 	t.Ulimits = removeDupesStr(t.Ulimits)
@@ -824,7 +824,7 @@ func (t *Target) Merge(t2 *Target) {
 		t.Platforms = t2.Platforms
 	}
 	if t2.CacheFrom != nil { // merge
-		t.CacheFrom = append(t.CacheFrom, t2.CacheFrom...)
+		t.CacheFrom = t.CacheFrom.Merge(t2.CacheFrom)
 	}
 	if t2.CacheTo != nil { // no merge
 		t.CacheTo = t2.CacheTo
@@ -1372,17 +1372,12 @@ func toBuildOpt(t *Target, inp *Input) (*build.Options, error) {
 		}
 	}
 
-	cacheImports := make([]*controllerapi.CacheOptionsEntry, len(t.CacheFrom))
-	for i, ci := range t.CacheFrom {
-		cacheImports[i] = ci.ToPB()
+	if t.CacheFrom != nil {
+		bo.CacheFrom = controllerapi.CreateCaches(t.CacheFrom.ToPB())
 	}
-	bo.CacheFrom = controllerapi.CreateCaches(cacheImports)
-
-	cacheExports := make([]*controllerapi.CacheOptionsEntry, len(t.CacheTo))
-	for i, ce := range t.CacheTo {
-		cacheExports[i] = ce.ToPB()
+	if t.CacheTo != nil {
+		bo.CacheTo = controllerapi.CreateCaches(t.CacheTo.ToPB())
 	}
-	bo.CacheTo = controllerapi.CreateCaches(cacheExports)
 
 	outputs := make([]*controllerapi.ExportEntry, len(t.Outputs))
 	for i, output := range t.Outputs {
@@ -1625,9 +1620,13 @@ func parseArrValue[T any, PT arrValue[T]](s []string) ([]*T, error) {
 	return outputs, nil
 }
 
-func parseCacheArrValues(s []string) ([]*buildflags.CacheOptionsEntry, error) {
-	outs := make([]*buildflags.CacheOptionsEntry, 0, len(s))
+func parseCacheArrValues(s []string) (buildflags.CacheOptions, error) {
+	var outs buildflags.CacheOptions
 	for _, in := range s {
+		if in == "" {
+			continue
+		}
+
 		if !strings.Contains(in, "=") {
 			// This is ref only format. Each field in the CSV is its own entry.
 			fields, err := csvvalue.Fields(in, nil)

--- a/bake/compose.go
+++ b/bake/compose.go
@@ -353,14 +353,14 @@ func (t *Target) composeExtTarget(exts map[string]interface{}) error {
 		if err != nil {
 			return err
 		}
-		t.CacheFrom = removeDupes(append(t.CacheFrom, cacheFrom...))
+		t.CacheFrom = t.CacheFrom.Merge(cacheFrom)
 	}
 	if len(xb.CacheTo) > 0 {
 		cacheTo, err := parseCacheArrValues(xb.CacheTo)
 		if err != nil {
 			return err
 		}
-		t.CacheTo = removeDupes(append(t.CacheTo, cacheTo...))
+		t.CacheTo = t.CacheTo.Merge(cacheTo)
 	}
 	if len(xb.Secrets) > 0 {
 		secrets, err := parseArrValue[buildflags.Secret](xb.Secrets)

--- a/bake/hcl_test.go
+++ b/bake/hcl_test.go
@@ -606,7 +606,7 @@ func TestHCLAttrsCapsuleType(t *testing.T) {
 	target "app" {
 		cache-from = [
 			{ type = "registry", ref = "user/app:cache" },
-			{ type = "local", src = "path/to/cache" },
+			"type=local,src=path/to/cache",
 		]
 
 		cache-to = [
@@ -649,7 +649,7 @@ func TestHCLAttrsCapsuleTypeVars(t *testing.T) {
 	target "app" {
 		cache-from = [
 			{ type = "registry", ref = "user/app:cache" },
-			{ type = "local", src = "path/to/cache" },
+			"type=local,src=path/to/cache",
 		]
 
 		cache-to = [ target.app.cache-from[0] ]
@@ -674,7 +674,7 @@ func TestHCLAttrsCapsuleTypeVars(t *testing.T) {
 		output = [ "type=oci,dest=../${foo}.tar" ]
 
 		secret = [
-			{ id = target.app.output[0].type, src = "/local/secret" },
+			{ id = target.app.output[0].type, src = "/${target.app.cache-from[1].type}/secret" },         
 		]
 	}
 	`)

--- a/tests/bake.go
+++ b/tests/bake.go
@@ -32,6 +32,7 @@ func bakeCmd(sb integration.Sandbox, opts ...cmdOpt) (string, error) {
 
 var bakeTests = []func(t *testing.T, sb integration.Sandbox){
 	testBakePrint,
+	testBakePrintSensitive,
 	testBakeLocal,
 	testBakeLocalMulti,
 	testBakeRemote,
@@ -77,7 +78,8 @@ target "build" {
     HELLO = "foo"
   }
 }
-`)},
+`),
+		},
 		{
 			"Compose",
 			"compose.yml",
@@ -88,7 +90,8 @@ services:
       context: .
       args:
         HELLO: foo
-`)},
+`),
+		},
 	}
 
 	for _, tc := range testCases {
@@ -141,6 +144,124 @@ RUN echo "Hello ${HELLO}"
       "args": {
         "HELLO": "foo"
       }
+    }
+  }
+}
+`, stdout.String())
+		})
+	}
+}
+
+func testBakePrintSensitive(t *testing.T, sb integration.Sandbox) {
+	testCases := []struct {
+		name string
+		f    string
+		dt   []byte
+	}{
+		{
+			"HCL",
+			"docker-bake.hcl",
+			[]byte(`
+target "build" {
+  args = {
+    HELLO = "foo"
+  }
+
+  cache-from = [
+    "type=gha",
+    "type=s3,region=us-west-2,bucket=my_bucket,name=my_image",
+  ]
+}
+`),
+		},
+		{
+			"Compose",
+			"compose.yml",
+			[]byte(`
+services:
+  build:
+    build:
+      context: .
+      args:
+        HELLO: foo
+      cache_from:
+        - type=gha
+        - type=s3,region=us-west-2,bucket=my_bucket,name=my_image
+`),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := tmpdir(
+				t,
+				fstest.CreateFile(tc.f, tc.dt, 0600),
+				fstest.CreateFile("Dockerfile", []byte(`
+FROM busybox
+ARG HELLO
+RUN echo "Hello ${HELLO}"
+	`), 0600),
+			)
+
+			cmd := buildxCmd(sb, withDir(dir), withArgs("bake", "--print", "build"),
+				withEnv(
+					"ACTIONS_RUNTIME_TOKEN=sensitive_token",
+					"ACTIONS_CACHE_URL=https://cache.github.com",
+					"AWS_ACCESS_KEY_ID=definitely_dont_look_here",
+					"AWS_SECRET_ACCESS_KEY=hackers_please_dont_steal",
+					"AWS_SESSION_TOKEN=not_a_mitm_attack",
+				),
+			)
+			stdout := bytes.Buffer{}
+			stderr := bytes.Buffer{}
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+			require.NoError(t, cmd.Run(), stdout.String(), stderr.String())
+
+			var def struct {
+				Group  map[string]*bake.Group  `json:"group,omitempty"`
+				Target map[string]*bake.Target `json:"target"`
+			}
+			require.NoError(t, json.Unmarshal(stdout.Bytes(), &def))
+
+			require.Len(t, def.Group, 1)
+			require.Contains(t, def.Group, "default")
+
+			require.Equal(t, []string{"build"}, def.Group["default"].Targets)
+			require.Len(t, def.Target, 1)
+			require.Contains(t, def.Target, "build")
+			require.Equal(t, ".", *def.Target["build"].Context)
+			require.Equal(t, "Dockerfile", *def.Target["build"].Dockerfile)
+			require.Equal(t, map[string]*string{"HELLO": ptrstr("foo")}, def.Target["build"].Args)
+			require.NotNil(t, def.Target["build"].CacheFrom)
+			require.Len(t, def.Target["build"].CacheFrom, 2)
+
+			require.JSONEq(t, `{
+  "group": {
+    "default": {
+      "targets": [
+        "build"
+      ]
+    }
+  },
+  "target": {
+    "build": {
+      "context": ".",
+      "dockerfile": "Dockerfile",
+      "args": {
+        "HELLO": "foo"
+      },
+      "cache-from": [
+        {
+          "type": "gha"
+        },
+        {
+          "type": "s3",
+          "region": "us-west-2",
+          "bucket": "my_bucket",
+          "name": "my_image"
+        }
+      ]
     }
   }
 }

--- a/util/buildflags/cache_cty.go
+++ b/util/buildflags/cache_cty.go
@@ -1,0 +1,82 @@
+package buildflags
+
+import (
+	"sync"
+
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
+)
+
+var cacheOptionsEntryType = sync.OnceValue(func() cty.Type {
+	return cty.Map(cty.String)
+})
+
+func (o *CacheOptions) FromCtyValue(in cty.Value, p cty.Path) error {
+	got := in.Type()
+	if got.IsTupleType() || got.IsListType() {
+		return o.fromCtyValue(in, p)
+	}
+
+	want := cty.List(cacheOptionsEntryType())
+	return p.NewErrorf("%s", convert.MismatchMessage(got, want))
+}
+
+func (o *CacheOptions) fromCtyValue(in cty.Value, p cty.Path) error {
+	*o = make([]*CacheOptionsEntry, 0, in.LengthInt())
+	for elem := in.ElementIterator(); elem.Next(); {
+		_, value := elem.Element()
+
+		entry := &CacheOptionsEntry{}
+		if err := entry.FromCtyValue(value, p); err != nil {
+			return err
+		}
+		*o = append(*o, entry)
+	}
+	return nil
+}
+
+func (o CacheOptions) ToCtyValue() cty.Value {
+	if len(o) == 0 {
+		return cty.ListValEmpty(cacheOptionsEntryType())
+	}
+
+	vals := make([]cty.Value, len(o))
+	for i, entry := range o {
+		vals[i] = entry.ToCtyValue()
+	}
+	return cty.ListVal(vals)
+}
+
+func (o *CacheOptionsEntry) FromCtyValue(in cty.Value, p cty.Path) error {
+	if in.Type() == cty.String {
+		if err := o.UnmarshalText([]byte(in.AsString())); err != nil {
+			return p.NewError(err)
+		}
+		return nil
+	}
+
+	conv, err := convert.Convert(in, cty.Map(cty.String))
+	if err != nil {
+		return err
+	}
+
+	m := conv.AsValueMap()
+	if err := getAndDelete(m, "type", &o.Type); err != nil {
+		return err
+	}
+	o.Attrs = asMap(m)
+	return o.validate(in)
+}
+
+func (o *CacheOptionsEntry) ToCtyValue() cty.Value {
+	if o == nil {
+		return cty.NullVal(cty.Map(cty.String))
+	}
+
+	vals := make(map[string]cty.Value, len(o.Attrs)+1)
+	for k, v := range o.Attrs {
+		vals[k] = cty.StringVal(v)
+	}
+	vals["type"] = cty.StringVal(o.Type)
+	return cty.MapVal(vals)
+}

--- a/util/buildflags/cache_test.go
+++ b/util/buildflags/cache_test.go
@@ -1,0 +1,39 @@
+package buildflags
+
+import (
+	"testing"
+
+	"github.com/docker/buildx/controller/pb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCacheOptions_DerivedVars(t *testing.T) {
+	t.Setenv("ACTIONS_RUNTIME_TOKEN", "sensitive_token")
+	t.Setenv("ACTIONS_CACHE_URL", "https://cache.github.com")
+	t.Setenv("AWS_ACCESS_KEY_ID", "definitely_dont_look_here")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "hackers_please_dont_steal")
+	t.Setenv("AWS_SESSION_TOKEN", "not_a_mitm_attack")
+
+	cacheFrom, err := ParseCacheEntry([]string{"type=gha", "type=s3,region=us-west-2,bucket=my_bucket,name=my_image"})
+	require.NoError(t, err)
+	require.Equal(t, []*pb.CacheOptionsEntry{
+		{
+			Type: "gha",
+			Attrs: map[string]string{
+				"token": "sensitive_token",
+				"url":   "https://cache.github.com",
+			},
+		},
+		{
+			Type: "s3",
+			Attrs: map[string]string{
+				"region":            "us-west-2",
+				"bucket":            "my_bucket",
+				"name":              "my_image",
+				"access_key_id":     "definitely_dont_look_here",
+				"secret_access_key": "hackers_please_dont_steal",
+				"session_token":     "not_a_mitm_attack",
+			},
+		},
+	}, cacheFrom)
+}

--- a/util/buildflags/cty.go
+++ b/util/buildflags/cty.go
@@ -9,32 +9,6 @@ import (
 	"github.com/zclconf/go-cty/cty/gocty"
 )
 
-func (e *CacheOptionsEntry) FromCtyValue(in cty.Value, p cty.Path) error {
-	conv, err := convert.Convert(in, cty.Map(cty.String))
-	if err == nil {
-		m := conv.AsValueMap()
-		if err := getAndDelete(m, "type", &e.Type); err != nil {
-			return err
-		}
-		e.Attrs = asMap(m)
-		return e.validate(in)
-	}
-	return unmarshalTextFallback(in, e, err)
-}
-
-func (e *CacheOptionsEntry) ToCtyValue() cty.Value {
-	if e == nil {
-		return cty.NullVal(cty.Map(cty.String))
-	}
-
-	vals := make(map[string]cty.Value, len(e.Attrs)+1)
-	for k, v := range e.Attrs {
-		vals[k] = cty.StringVal(v)
-	}
-	vals["type"] = cty.StringVal(e.Type)
-	return cty.MapVal(vals)
-}
-
 func (e *ExportEntry) FromCtyValue(in cty.Value, p cty.Path) error {
 	conv, err := convert.Convert(in, cty.Map(cty.String))
 	if err == nil {

--- a/util/buildflags/utils.go
+++ b/util/buildflags/utils.go
@@ -1,0 +1,29 @@
+package buildflags
+
+type comparable[E any] interface {
+	Equal(other E) bool
+}
+
+func removeDupes[E comparable[E]](s []E) []E {
+	// Move backwards through the slice.
+	// For each element, any elements after the current element are unique.
+	// If we find our current element conflicts with an existing element,
+	// then we swap the offender with the end of the slice and chop it off.
+
+	// Start at the second to last element.
+	// The last element is always unique.
+	for i := len(s) - 2; i >= 0; i-- {
+		elem := s[i]
+		// Check for duplicates after our current element.
+		for j := i + 1; j < len(s); j++ {
+			if elem.Equal(s[j]) {
+				// Found a duplicate, exchange the
+				// duplicate with the last element.
+				s[j], s[len(s)-1] = s[len(s)-1], s[j]
+				s = s[:len(s)-1]
+				break
+			}
+		}
+	}
+	return s
+}


### PR DESCRIPTION
This refactors how the cache-from/cache-to composable attributes work so they no longer print sensitive values that are automatically added.

This also expands the available syntax that works with the cache options. It is now possible to interleave the csv syntax with the object syntax without any problems. The canonical form is still the object syntax and variables are resolved according to that syntax.

`cache-from` and `cache-to` now correctly ignore empty string inputs so these can be used with variables.

Fixes https://github.com/docker/buildx/issues/2823.

Partial fix for https://github.com/docker/buildx/issues/2822.