### PR TITLE
bake: fix entitlements path checks for local outputs

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -194,7 +194,7 @@ func ListTargets(files []File) ([]string, error) {
 	return dedupSlice(targets), nil
 }
 
-func ReadTargets(ctx context.Context, files []File, targets, overrides []string, defaults map[string]string) (map[string]*Target, map[string]*Group, error) {
+func ReadTargets(ctx context.Context, files []File, targets, overrides []string, defaults map[string]string, ent *EntitlementConf) (map[string]*Target, map[string]*Group, error) {
 	c, _, err := ParseFiles(files, defaults)
 	if err != nil {
 		return nil, nil, err
@@ -213,7 +213,7 @@ func ReadTargets(ctx context.Context, files []File, targets, overrides []string,
 	for _, target := range targets {
 		ts, gs := c.ResolveGroup(target)
 		for _, tname := range ts {
-			t, err := c.ResolveTarget(tname, o)
+			t, err := c.ResolveTarget(tname, o, ent)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -245,7 +245,7 @@ func ReadTargets(ctx context.Context, files []File, targets, overrides []string,
 	}
 
 	for name, t := range m {
-		if err := c.loadLinks(name, t, m, o, nil); err != nil {
+		if err := c.loadLinks(name, t, m, o, nil, ent); err != nil {
 			return nil, nil, err
 		}
 	}
@@ -477,7 +477,7 @@ func (c Config) expandTargets(pattern string) ([]string, error) {
 	return names, nil
 }
 
-func (c Config) loadLinks(name string, t *Target, m map[string]*Target, o map[string]map[string]Override, visited []string) error {
+func (c Config) loadLinks(name string, t *Target, m map[string]*Target, o map[string]map[string]Override, visited []string, ent *EntitlementConf) error {
 	visited = append(visited, name)
 	for _, v := range t.Contexts {
 		if strings.HasPrefix(v, "target:") {
@@ -493,7 +493,7 @@ func (c Config) loadLinks(name string, t *Target, m map[string]*Target, o map[st
 			t2, ok := m[target]
 			if !ok {
 				var err error
-				t2, err = c.ResolveTarget(target, o)
+				t2, err = c.ResolveTarget(target, o, ent)
 				if err != nil {
 					return err
 				}
@@ -503,7 +503,7 @@ func (c Config) loadLinks(name string, t *Target, m map[string]*Target, o map[st
 				t2.linked = true
 				m[target] = t2
 			}
-			if err := c.loadLinks(target, t2, m, o, visited); err != nil {
+			if err := c.loadLinks(target, t2, m, o, visited, ent); err != nil {
 				return err
 			}
 
@@ -630,8 +630,8 @@ func (c Config) group(name string, visited map[string]visit) ([]string, []string
 	return targets, groups
 }
 
-func (c Config) ResolveTarget(name string, overrides map[string]map[string]Override) (*Target, error) {
-	t, err := c.target(name, map[string]*Target{}, overrides)
+func (c Config) ResolveTarget(name string, overrides map[string]map[string]Override, ent *EntitlementConf) (*Target, error) {
+	t, err := c.target(name, map[string]*Target{}, overrides, ent)
 	if err != nil {
 		return nil, err
 	}
@@ -647,7 +647,7 @@ func (c Config) ResolveTarget(name string, overrides map[string]map[string]Overr
 	return t, nil
 }
 
-func (c Config) target(name string, visited map[string]*Target, overrides map[string]map[string]Override) (*Target, error) {
+func (c Config) target(name string, visited map[string]*Target, overrides map[string]map[string]Override, ent *EntitlementConf) (*Target, error) {
 	if t, ok := visited[name]; ok {
 		return t, nil
 	}
@@ -664,7 +664,7 @@ func (c Config) target(name string, visited map[string]*Target, overrides map[st
 	}
 	tt := &Target{}
 	for _, name := range t.Inherits {
-		t, err := c.target(name, visited, overrides)
+		t, err := c.target(name, visited, overrides, ent)
 		if err != nil {
 			return nil, err
 		}
@@ -676,7 +676,7 @@ func (c Config) target(name string, visited map[string]*Target, overrides map[st
 	m.Merge(tt)
 	m.Merge(t)
 	tt = m
-	if err := tt.AddOverrides(overrides[name]); err != nil {
+	if err := tt.AddOverrides(overrides[name], ent); err != nil {
 		return nil, err
 	}
 	tt.normalize()
@@ -859,7 +859,7 @@ func (t *Target) Merge(t2 *Target) {
 	t.Inherits = append(t.Inherits, t2.Inherits...)
 }
 
-func (t *Target) AddOverrides(overrides map[string]Override) error {
+func (t *Target) AddOverrides(overrides map[string]Override, ent *EntitlementConf) error {
 	for key, o := range overrides {
 		value := o.Value
 		keys := strings.SplitN(key, ".", 2)
@@ -900,12 +900,26 @@ func (t *Target) AddOverrides(overrides map[string]Override) error {
 				return err
 			}
 			t.CacheFrom = cacheFrom
+			for _, c := range t.CacheFrom {
+				if c.Type == "local" {
+					if v, ok := c.Attrs["src"]; ok {
+						ent.FSRead = append(ent.FSRead, v)
+					}
+				}
+			}
 		case "cache-to":
 			cacheTo, err := parseCacheArrValues(o.ArrValue)
 			if err != nil {
 				return err
 			}
 			t.CacheTo = cacheTo
+			for _, c := range t.CacheTo {
+				if c.Type == "local" {
+					if v, ok := c.Attrs["dest"]; ok {
+						ent.FSWrite = append(ent.FSWrite, v)
+					}
+				}
+			}
 		case "target":
 			t.Target = &value
 		case "call":
@@ -916,12 +930,20 @@ func (t *Target) AddOverrides(overrides map[string]Override) error {
 				return errors.Wrap(err, "invalid value for outputs")
 			}
 			t.Secrets = secrets
+			for _, s := range t.Secrets {
+				if s.FilePath != "" {
+					ent.FSRead = append(ent.FSRead, s.FilePath)
+				}
+			}
 		case "ssh":
 			ssh, err := parseArrValue[buildflags.SSH](o.ArrValue)
 			if err != nil {
 				return errors.Wrap(err, "invalid value for outputs")
 			}
 			t.SSH = ssh
+			for _, s := range t.SSH {
+				ent.FSRead = append(ent.FSRead, s.Paths...)
+			}
 		case "platform":
 			t.Platforms = o.ArrValue
 		case "output":
@@ -930,8 +952,20 @@ func (t *Target) AddOverrides(overrides map[string]Override) error {
 				return errors.Wrap(err, "invalid value for outputs")
 			}
 			t.Outputs = outputs
+			for _, o := range t.Outputs {
+				if o.Destination != "" {
+					ent.FSWrite = append(ent.FSWrite, o.Destination)
+				}
+			}
 		case "entitlements":
 			t.Entitlements = append(t.Entitlements, o.ArrValue...)
+			for _, v := range o.ArrValue {
+				if v == string(EntitlementKeyNetworkHost) {
+					ent.NetworkHost = true
+				} else if v == string(EntitlementKeySecurityInsecure) {
+					ent.SecurityInsecure = true
+				}
+			}
 		case "annotations":
 			t.Annotations = append(t.Annotations, o.ArrValue...)
 		case "attest":

--- a/bake/bake.go
+++ b/bake/bake.go
@@ -1355,7 +1355,7 @@ func toBuildOpt(t *Target, inp *Input) (*build.Options, error) {
 		outputs[i] = output.ToPB()
 	}
 
-	bo.Exports, err = controllerapi.CreateExports(outputs)
+	bo.Exports, bo.ExportsLocalPathsTemporary, err = controllerapi.CreateExports(outputs)
 	if err != nil {
 		return nil, err
 	}

--- a/bake/entitlements.go
+++ b/bake/entitlements.go
@@ -113,17 +113,8 @@ func (c EntitlementConf) check(bo build.Options, expected *EntitlementConf) erro
 		roPaths[p] = struct{}{}
 	}
 
-	for _, out := range bo.Exports {
-		if out.Type == "local" {
-			if dest, ok := out.Attrs["dest"]; ok {
-				rwPaths[dest] = struct{}{}
-			}
-		}
-		if out.Type == "tar" {
-			if dest, ok := out.Attrs["dest"]; ok && dest != "-" {
-				rwPaths[dest] = struct{}{}
-			}
-		}
+	for _, p := range bo.ExportsLocalPathsTemporary {
+		rwPaths[p] = struct{}{}
 	}
 
 	for _, ce := range bo.CacheTo {

--- a/bake/entitlements_test.go
+++ b/bake/entitlements_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/docker/buildx/build"
 	"github.com/docker/buildx/controller/pb"
 	"github.com/docker/buildx/util/osutil"
-	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/util/entitlements"
 	"github.com/stretchr/testify/require"
@@ -279,25 +278,10 @@ func TestValidateEntitlements(t *testing.T) {
 		{
 			name: "ExportLocal",
 			opt: build.Options{
-				Exports: []client.ExportEntry{
-					{
-						Type: "local",
-						Attrs: map[string]string{
-							"dest": dir1,
-						},
-					},
-					{
-						Type: "local",
-						Attrs: map[string]string{
-							"dest": filepath.Join(dir1, "subdir"),
-						},
-					},
-					{
-						Type: "local",
-						Attrs: map[string]string{
-							"dest": dir2,
-						},
-					},
+				ExportsLocalPathsTemporary: []string{
+					dir1,
+					filepath.Join(dir1, "subdir"),
+					dir2,
 				},
 			},
 			expected: EntitlementConf{

--- a/build/build.go
+++ b/build/build.go
@@ -62,27 +62,28 @@ const (
 type Options struct {
 	Inputs Inputs
 
-	Ref           string
-	Allow         []entitlements.Entitlement
-	Attests       map[string]*string
-	BuildArgs     map[string]string
-	CacheFrom     []client.CacheOptionsEntry
-	CacheTo       []client.CacheOptionsEntry
-	CgroupParent  string
-	Exports       []client.ExportEntry
-	ExtraHosts    []string
-	Labels        map[string]string
-	NetworkMode   string
-	NoCache       bool
-	NoCacheFilter []string
-	Platforms     []specs.Platform
-	Pull          bool
-	SecretSpecs   []*controllerapi.Secret
-	SSHSpecs      []*controllerapi.SSH
-	ShmSize       opts.MemBytes
-	Tags          []string
-	Target        string
-	Ulimits       *opts.UlimitOpt
+	Ref                        string
+	Allow                      []entitlements.Entitlement
+	Attests                    map[string]*string
+	BuildArgs                  map[string]string
+	CacheFrom                  []client.CacheOptionsEntry
+	CacheTo                    []client.CacheOptionsEntry
+	CgroupParent               string
+	Exports                    []client.ExportEntry
+	ExportsLocalPathsTemporary []string // should be removed after client.ExportEntry update in buildkit v0.19.0
+	ExtraHosts                 []string
+	Labels                     map[string]string
+	NetworkMode                string
+	NoCache                    bool
+	NoCacheFilter              []string
+	Platforms                  []specs.Platform
+	Pull                       bool
+	SecretSpecs                []*controllerapi.Secret
+	SSHSpecs                   []*controllerapi.SSH
+	ShmSize                    opts.MemBytes
+	Tags                       []string
+	Target                     string
+	Ulimits                    *opts.UlimitOpt
 
 	Session                []session.Attachable
 	Linked                 bool // Linked marks this target as exclusively linked (not requested by the user).

--- a/commands/bake.go
+++ b/commands/bake.go
@@ -199,7 +199,7 @@ func runBake(ctx context.Context, dockerCli command.Cli, targets []string, in ba
 		}
 	}
 
-	tgts, grps, err := bake.ReadTargets(ctx, files, targets, overrides, defaults)
+	tgts, grps, err := bake.ReadTargets(ctx, files, targets, overrides, defaults, &ent)
 	if err != nil {
 		return err
 	}

--- a/controller/build/build.go
+++ b/controller/build/build.go
@@ -93,7 +93,7 @@ func RunBuild(ctx context.Context, dockerCli command.Cli, in *controllerapi.Buil
 	}
 	opts.Session = append(opts.Session, ssh)
 
-	outputs, err := controllerapi.CreateExports(in.Exports)
+	outputs, _, err := controllerapi.CreateExports(in.Exports)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/controller/pb/export.go
+++ b/controller/pb/export.go
@@ -10,15 +10,16 @@ import (
 	"github.com/pkg/errors"
 )
 
-func CreateExports(entries []*ExportEntry) ([]client.ExportEntry, error) {
+func CreateExports(entries []*ExportEntry) ([]client.ExportEntry, []string, error) {
 	var outs []client.ExportEntry
+	var localPaths []string
 	if len(entries) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 	var stdoutUsed bool
 	for _, entry := range entries {
 		if entry.Type == "" {
-			return nil, errors.Errorf("type is required for output")
+			return nil, nil, errors.Errorf("type is required for output")
 		}
 
 		out := client.ExportEntry{
@@ -50,20 +51,21 @@ func CreateExports(entries []*ExportEntry) ([]client.ExportEntry, error) {
 
 		if supportDir {
 			if entry.Destination == "" {
-				return nil, errors.Errorf("dest is required for %s exporter", out.Type)
+				return nil, nil, errors.Errorf("dest is required for %s exporter", out.Type)
 			}
 			if entry.Destination == "-" {
-				return nil, errors.Errorf("dest cannot be stdout for %s exporter", out.Type)
+				return nil, nil, errors.Errorf("dest cannot be stdout for %s exporter", out.Type)
 			}
 
 			fi, err := os.Stat(entry.Destination)
 			if err != nil && !os.IsNotExist(err) {
-				return nil, errors.Wrapf(err, "invalid destination directory: %s", entry.Destination)
+				return nil, nil, errors.Wrapf(err, "invalid destination directory: %s", entry.Destination)
 			}
 			if err == nil && !fi.IsDir() {
-				return nil, errors.Errorf("destination directory %s is a file", entry.Destination)
+				return nil, nil, errors.Errorf("destination directory %s is a file", entry.Destination)
 			}
 			out.OutputDir = entry.Destination
+			localPaths = append(localPaths, entry.Destination)
 		}
 		if supportFile {
 			if entry.Destination == "" && out.Type != client.ExporterDocker {
@@ -71,32 +73,33 @@ func CreateExports(entries []*ExportEntry) ([]client.ExportEntry, error) {
 			}
 			if entry.Destination == "-" {
 				if stdoutUsed {
-					return nil, errors.Errorf("multiple outputs configured to write to stdout")
+					return nil, nil, errors.Errorf("multiple outputs configured to write to stdout")
 				}
 				if _, err := console.ConsoleFromFile(os.Stdout); err == nil {
-					return nil, errors.Errorf("dest file is required for %s exporter. refusing to write to console", out.Type)
+					return nil, nil, errors.Errorf("dest file is required for %s exporter. refusing to write to console", out.Type)
 				}
 				out.Output = wrapWriteCloser(os.Stdout)
 				stdoutUsed = true
 			} else if entry.Destination != "" {
 				fi, err := os.Stat(entry.Destination)
 				if err != nil && !os.IsNotExist(err) {
-					return nil, errors.Wrapf(err, "invalid destination file: %s", entry.Destination)
+					return nil, nil, errors.Wrapf(err, "invalid destination file: %s", entry.Destination)
 				}
 				if err == nil && fi.IsDir() {
-					return nil, errors.Errorf("destination file %s is a directory", entry.Destination)
+					return nil, nil, errors.Errorf("destination file %s is a directory", entry.Destination)
 				}
 				f, err := os.Create(entry.Destination)
 				if err != nil {
-					return nil, errors.Errorf("failed to open %s", err)
+					return nil, nil, errors.Errorf("failed to open %s", err)
 				}
 				out.Output = wrapWriteCloser(f)
+				localPaths = append(localPaths, entry.Destination)
 			}
 		}
 
 		outs = append(outs, out)
 	}
-	return outs, nil
+	return outs, localPaths, nil
 }
 
 func wrapWriteCloser(wc io.WriteCloser) func(map[string]string) (io.WriteCloser, error) {


### PR DESCRIPTION
Previous check based on dest attributes was not correct as the attributes already get converted before validation happens.

Because the local path is not preserved for single-file outputs and gets replaced by io.Writer, a temporary array variable was needed. This value should instead be added to ExportEntry struct in BuildKit in future revision.