### PR TITLE
dockerfiles: pin alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1
 
 ARG GO_VERSION=1.23
+ARG ALPINE_VERSION=3.21
 ARG XX_VERSION=1.6.1
 
 # for testing
@@ -13,7 +14,7 @@ ARG BUILDKIT_VERSION=v0.18.1
 ARG UNDOCK_VERSION=0.8.0
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
-FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS golatest
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS golatest
 FROM moby/moby-bin:$DOCKER_VERSION AS docker-engine
 FROM dockereng/cli-bin:$DOCKER_CLI_VERSION AS docker-cli
 FROM moby/moby-bin:$DOCKER_VERSION_ALT_26 AS docker-engine-alt
@@ -138,7 +139,7 @@ FROM integration-test-base AS integration-test
 COPY . .
 
 # Release
-FROM --platform=$BUILDPLATFORM alpine AS releaser
+FROM --platform=$BUILDPLATFORM alpine:${ALPINE_VERSION} AS releaser
 WORKDIR /work
 ARG TARGETPLATFORM
 RUN --mount=from=binaries \
@@ -153,7 +154,7 @@ COPY --from=releaser /out/ /
 
 # Shell
 FROM docker:$DOCKER_VERSION AS dockerd-release
-FROM alpine AS shell
+FROM alpine:${ALPINE_VERSION} AS shell
 RUN apk add --no-cache iptables tmux git vim less openssh
 RUN mkdir -p /usr/local/lib/docker/cli-plugins && ln -s /usr/local/bin/buildx /usr/local/lib/docker/cli-plugins/docker-buildx
 COPY ./hack/demo-env/entrypoint.sh /usr/local/bin

--- a/hack/dockerfiles/authors.Dockerfile
+++ b/hack/dockerfiles/authors.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG ALPINE_VERSION=3.20
+ARG ALPINE_VERSION=3.21
 
 FROM alpine:${ALPINE_VERSION} AS gen
 RUN apk add --no-cache git

--- a/hack/dockerfiles/docs.Dockerfile
+++ b/hack/dockerfiles/docs.Dockerfile
@@ -1,15 +1,17 @@
 # syntax=docker/dockerfile:1
 
 ARG GO_VERSION=1.23
+ARG ALPINE_VERSION=3.21
+
 ARG FORMATS=md,yaml
 
-FROM golang:${GO_VERSION}-alpine AS docsgen
+FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS docsgen
 WORKDIR /src
 RUN --mount=target=. \
   --mount=target=/root/.cache,type=cache \
   go build -mod=vendor -o /out/docsgen ./docs/generate.go
 
-FROM alpine AS gen
+FROM alpine:${ALPINE_VERSION} AS gen
 RUN apk add --no-cache rsync git
 WORKDIR /src
 COPY --from=docsgen /out/docsgen /usr/bin

--- a/hack/dockerfiles/govulncheck.Dockerfile
+++ b/hack/dockerfiles/govulncheck.Dockerfile
@@ -1,10 +1,12 @@
 # syntax=docker/dockerfile:1
 
 ARG GO_VERSION=1.23
+ARG ALPINE_VERSION=3.21
+
 ARG GOVULNCHECK_VERSION=v1.1.3
 ARG FORMAT="text"
 
-FROM golang:${GO_VERSION}-alpine AS base
+FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS base
 WORKDIR /go/src/github.com/docker/buildx
 RUN apk add --no-cache jq moreutils
 ARG GOVULNCHECK_VERSION

--- a/hack/dockerfiles/lint.Dockerfile
+++ b/hack/dockerfiles/lint.Dockerfile
@@ -1,7 +1,9 @@
 # syntax=docker/dockerfile:1
 
 ARG GO_VERSION=1.23
-ARG XX_VERSION=1.5.0
+ARG ALPINE_VERSION=3.21
+ARG XX_VERSION=1.6.1
+
 ARG GOLANGCI_LINT_VERSION=1.62.0
 ARG GOPLS_VERSION=v0.26.0
 # disabled: deprecated unusedvariable simplifyrange
@@ -9,7 +11,7 @@ ARG GOPLS_ANALYZERS="embeddirective fillreturns infertypeargs nonewvars norangeo
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
 
-FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS golang-base
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS golang-base
 RUN apk add --no-cache git gcc musl-dev
 
 FROM golang-base AS lint-base

--- a/hack/dockerfiles/vendor.Dockerfile
+++ b/hack/dockerfiles/vendor.Dockerfile
@@ -1,9 +1,11 @@
 # syntax=docker/dockerfile:1
 
 ARG GO_VERSION=1.23
+ARG ALPINE_VERSION=3.21
+
 ARG MODOUTDATED_VERSION=v0.9.0
 
-FROM golang:${GO_VERSION}-alpine AS base
+FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS base
 RUN apk add --no-cache git rsync
 WORKDIR /src
 


### PR DESCRIPTION
Similar to what we have on buildkit repo so we avoid side effects like https://github.com/docker/buildx/pull/2830#issuecomment-2528706259. Also bump alpine and xx version on remaining dockerfiles.