### PR TITLE
bake: change evaluation of entitlement paths

### DIFF
--- a/bake/entitlements_test.go
+++ b/bake/entitlements_test.go
@@ -89,7 +89,7 @@ func TestEvaluateToExistingPath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := evaluateToExistingPath(tt.input)
+			result, _, err := evaluateToExistingPath(tt.input)
 
 			if tt.expectErr {
 				require.Error(t, err)
@@ -341,7 +341,7 @@ func TestValidateEntitlements(t *testing.T) {
 						return nil
 					}
 					// if not, then escapeLink is not allowed
-					exp, err := evaluateToExistingPath(escapeLink)
+					exp, _, err := evaluateToExistingPath(escapeLink)
 					require.NoError(t, err)
 					exp, err = filepath.EvalSymlinks(exp)
 					require.NoError(t, err)

--- a/bake/entitlements_test.go
+++ b/bake/entitlements_test.go
@@ -363,6 +363,48 @@ func TestValidateEntitlements(t *testing.T) {
 			},
 			expected: EntitlementConf{},
 		},
+		{
+			name: "NonExistingAllowedPathSubpath",
+			opt: build.Options{
+				ExportsLocalPathsTemporary: []string{
+					dir1,
+				},
+			},
+			conf: EntitlementConf{
+				FSRead:  []string{wd},
+				FSWrite: []string{filepath.Join(dir1, "not/exists")},
+			},
+			expected: EntitlementConf{
+				FSWrite: []string{expDir1}, // dir1 is still needed as only subpath was allowed
+			},
+		},
+		{
+			name: "NonExistingAllowedPathMatches",
+			opt: build.Options{
+				ExportsLocalPathsTemporary: []string{
+					filepath.Join(dir1, "not/exists"),
+				},
+			},
+			conf: EntitlementConf{
+				FSRead:  []string{wd},
+				FSWrite: []string{filepath.Join(dir1, "not/exists")},
+			},
+			expected: EntitlementConf{
+				FSWrite: []string{expDir1}, // dir1 is still needed as build also needs to write not/exists directory
+			},
+		},
+		{
+			name: "NonExistingBuildPath",
+			opt: build.Options{
+				ExportsLocalPathsTemporary: []string{
+					filepath.Join(dir1, "not/exists"),
+				},
+			},
+			conf: EntitlementConf{
+				FSRead:  []string{wd},
+				FSWrite: []string{dir1},
+			},
+		},
 	}
 
 	for _, tc := range tcases {


### PR DESCRIPTION
Currently, to compare the local path used by bake against the paths allowed by entitlements, symlinks were evaluated for path normalization so that the local path used by build was allowed to not exist while the path allowed by entitlement needed to exist. If the path used by the build did not exist, then the deepest existing parent path was used instead. This was concistent with entitlement rules as that parent path would be the actual path access is needed.

This raised an issue with `--set` if one provides a non-existing path as an argument, as these paths are supposed to be allowed automatically. With the above restrictions set to allowed paths, this meant the build would fail as it can't grant entitlement to the non-existing paths.

This changes the evaluation logic for allowing paths so that they do not need to exist. If such a case appears, then the path is evaluated to the last component that exists, and then the rest of the path is appended as is.

This means that for example, if `output = /tmp/out/foo/` is set in HCL and `/tmp` is the last component that exists then invoking build with `--allow fs.write=/tmp/out/foo` will not fail with stat error anymore but will fail in entitlements validation as build would also need to write `/tmp/out` that is not inside the allowed `/tmp/out/foo` path. The same would apply to `--set` as well so that if it points to a non-existing path, then an additional `--allow` rule is needed providing access to writing to the last existing component of that path. This may or may not be unexpected.