### PR TITLE
[v0.19] bake: remove empty values set by --set

### DIFF
--- a/bake/bake_test.go
+++ b/bake/bake_test.go
@@ -2028,3 +2028,20 @@ target "app" {
 	_, _, err := ReadTargets(ctx, []File{fp}, []string{"app"}, nil, nil, &EntitlementConf{})
 	require.NoError(t, err)
 }
+
+// https://github.com/docker/buildx/issues/2858
+func TestOverrideEmpty(t *testing.T) {
+	fp := File{
+		Name: "docker-bake.hcl",
+		Data: []byte(`
+target "app" {
+  output = ["./bin"]
+}
+`),
+	}
+
+	ctx := context.TODO()
+
+	_, _, err := ReadTargets(ctx, []File{fp}, []string{"app"}, []string{"app.output="}, nil, &EntitlementConf{})
+	require.NoError(t, err)
+}

--- a/util/buildflags/cache.go
+++ b/util/buildflags/cache.go
@@ -14,6 +14,9 @@ import (
 func ParseCacheEntry(in []string) ([]*controllerapi.CacheOptionsEntry, error) {
 	outs := make([]*controllerapi.CacheOptionsEntry, 0, len(in))
 	for _, in := range in {
+		if in == "" {
+			continue
+		}
 		fields, err := csvvalue.Fields(in, nil)
 		if err != nil {
 			return nil, err

--- a/util/buildflags/export.go
+++ b/util/buildflags/export.go
@@ -19,6 +19,9 @@ func ParseExports(inp []string) ([]*controllerapi.ExportEntry, error) {
 		return nil, nil
 	}
 	for _, s := range inp {
+		if s == "" {
+			continue
+		}
 		fields, err := csvvalue.Fields(s, nil)
 		if err != nil {
 			return nil, err

--- a/util/buildflags/secrets.go
+++ b/util/buildflags/secrets.go
@@ -11,6 +11,9 @@ import (
 func ParseSecretSpecs(sl []string) ([]*controllerapi.Secret, error) {
 	fs := make([]*controllerapi.Secret, 0, len(sl))
 	for _, v := range sl {
+		if v == "" {
+			continue
+		}
 		s, err := parseSecret(v)
 		if err != nil {
 			return nil, err

--- a/util/buildflags/ssh.go
+++ b/util/buildflags/ssh.go
@@ -14,6 +14,9 @@ func ParseSSHSpecs(sl []string) ([]*controllerapi.SSH, error) {
 	}
 
 	for _, s := range sl {
+		if s == "" {
+			continue
+		}
 		parts := strings.SplitN(s, "=", 2)
 		out := controllerapi.SSH{
 			ID: parts[0],


### PR DESCRIPTION
regression from https://github.com/docker/buildx/pull/2846/commits/b2c0c26c26791019ffa0fc1153626d515553ca3d
fixes #2858 for v0.19

These parser functions are called for `--set` to
resolve entitlement paths that would be automatically added and will fail for empty value.

The empty values would already be ignored but in v0.19 is done after merging the `--set` values and then calling parse again.