### PR TITLE
progress: fix missing last progress from loading layers

### DIFF
--- a/util/dockerutil/progress.go
+++ b/util/dockerutil/progress.go
@@ -55,19 +55,21 @@ func fromReader(l progress.SubLogger, rc io.ReadCloser) error {
 				Started: &now,
 			}
 		}
-		timeDelta := time.Since(st.Timestamp)
-		if timeDelta < minTimeDelta {
-			continue
-		}
-		st.Timestamp = time.Now()
 		if jm.Status == "Loading layer" {
 			st.Current = jm.Progress.Current
 			st.Total = jm.Progress.Total
 		}
+		now := time.Now()
 		if jm.Error != nil {
-			now := time.Now()
 			st.Completed = &now
+		} else {
+			timeDelta := time.Since(st.Timestamp)
+			if timeDelta < minTimeDelta {
+				started[id] = st
+				continue
+			}
 		}
+		st.Timestamp = now
 		started[id] = st
 		l.SetStatus(&st)
 	}


### PR DESCRIPTION
Because of the bugs in the logic of how layer progress is throttled the last event may never be written, leaving behind incomplete output like

```
 => importing to docker                                                                                   0.9s
 => => loading layer f0074c45c2c0 190B / 190B                                                             0.9s
 => => loading layer 0e8819756174 393.22kB / 38.08MB                                                      0.8s
 => => loading layer 63ec8d9b4ac7 144B / 144B                                                             0.0s
```

Fix by always updating the current values, even if an event is initially throttled and not shown, plus make sure it always gets updated in the map.