### PR TITLE
bake: fix context from target platform matching

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -515,8 +514,8 @@ func (c Config) loadLinks(name string, t *Target, m map[string]*Target, o map[st
 			}
 
 			if len(t.Platforms) > 1 && len(t2.Platforms) > 1 {
-				if !sliceEqual(t.Platforms, t2.Platforms) {
-					return errors.Errorf("target %s can't be used by %s because it is defined for different platforms %v and %v", target, name, t2.Platforms, t.Platforms)
+				if !isSubset(t.Platforms, t2.Platforms) {
+					return errors.Errorf("target %s can't be used by %s because its platforms %v are not a subset of %v", target, name, t.Platforms, t2.Platforms)
 				}
 			}
 		}
@@ -1516,14 +1515,9 @@ func sanitizeTargetName(target string) string {
 	return strings.ReplaceAll(target, ".", "_")
 }
 
-func sliceEqual(s1, s2 []string) bool {
-	if len(s1) != len(s2) {
-		return false
-	}
-	sort.Strings(s1)
-	sort.Strings(s2)
-	for i := range s1 {
-		if s1[i] != s2[i] {
+func isSubset(s1, s2 []string) bool {
+	for _, item := range s1 {
+		if !slices.Contains(s2, item) {
 			return false
 		}
 	}

--- a/bake/bake_test.go
+++ b/bake/bake_test.go
@@ -910,7 +910,28 @@ func TestReadContextFromTargetInvalidPlatforms(t *testing.T) {
 	}
 	_, _, err := ReadTargets(ctx, []File{fp}, []string{"app"}, []string{}, nil, &EntitlementConf{})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "defined for different platforms")
+	require.Contains(t, err.Error(), "are not a subset of")
+}
+
+func TestReadContextFromTargetSubsetPlatforms(t *testing.T) {
+	ctx := context.TODO()
+	fp := File{
+		Name: "docker-bake.hcl",
+		Data: []byte(`
+		target "mid" {
+			output = ["foo"]
+			platforms = ["linux/amd64", "linux/riscv64", "linux/arm64"]
+		}
+		target "app" {
+			contexts = {
+				bar: "target:mid"
+			}
+			platforms = ["linux/amd64", "linux/arm64"]
+		}
+		`),
+	}
+	_, _, err := ReadTargets(ctx, []File{fp}, []string{"app"}, []string{}, nil, &EntitlementConf{})
+	require.NoError(t, err)
 }
 
 func TestReadTargetsDefault(t *testing.T) {


### PR DESCRIPTION
Updates the context from target platform validation, allowing a subset of the target platforms.

cc @tonistiigi 

Closes https://github.com/docker/buildx/issues/2486