### PR TITLE
bake: update lookup order for override

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -53,8 +53,8 @@ func defaultFilenames() []string {
 	names = append(names, composecli.DefaultFileNames...)
 	names = append(names, []string{
 		"docker-bake.json",
-		"docker-bake.override.json",
 		"docker-bake.hcl",
+		"docker-bake.override.json",
 		"docker-bake.override.hcl",
 	}...)
 	return names

--- a/docs/bake-reference.md
+++ b/docs/bake-reference.md
@@ -19,8 +19,8 @@ By default, Bake uses the following lookup order to find the configuration file:
 3. `docker-compose.yml`
 4. `docker-compose.yaml`
 5. `docker-bake.json`
-6. `docker-bake.override.json`
-7. `docker-bake.hcl`
+6. `docker-bake.hcl`
+7. `docker-bake.override.json`
 8. `docker-bake.override.hcl`
 
 You can specify the file location explicitly using the `--file` flag:


### PR DESCRIPTION
fixes #2873 

This change the lookup order for a bake definition by placing override files for both HCL and JSON at the lowest.

cc @jonapich