### PR TITLE
bake: fix entitlements check for default SSH socket

### DIFF
--- a/bake/entitlements.go
+++ b/bake/entitlements.go
@@ -145,7 +145,9 @@ func (c EntitlementConf) check(bo build.Options, expected *EntitlementConf) erro
 			roPaths[p] = struct{}{}
 		}
 		if len(ssh.Paths) == 0 {
-			expected.SSH = true
+			if !c.SSH {
+				expected.SSH = true
+			}
 		}
 	}
 


### PR DESCRIPTION
There was a mixup between fs.read and ssh entitlements check.

Corrected behavior is that if bake definition requires default SSH forwarding then "ssh" entitlement is needed. If it requires SSH forwarding via fixed file path then "fs.read" entitlement is needed for that path.