### PR TITLE
bake: replace --list-targets and --list-variables flags with --list flag

### DIFF
--- a/bake/hclparser/hclparser.go
+++ b/bake/hclparser/hclparser.go
@@ -579,9 +579,9 @@ func (p *parser) validateVariables(vars map[string]*variable, ectx *hcl.EvalCont
 }
 
 type Variable struct {
-	Name        string
-	Description string
-	Value       *string
+	Name        string  `json:"name"`
+	Description string  `json:"description,omitempty"`
+	Value       *string `json:"value,omitempty"`
 }
 
 type ParseMeta struct {

--- a/commands/bake.go
+++ b/commands/bake.go
@@ -125,6 +125,10 @@ func runBake(ctx context.Context, dockerCli command.Cli, targets []string, in ba
 	var nodes []builder.Node
 	var progressConsoleDesc, progressTextDesc string
 
+	if in.print && in.list != "" {
+		return errors.New("--print and --list are mutually exclusive")
+	}
+
 	// instance only needed for reading remote bake files or building
 	var driverType string
 	if url != "" || !(in.print || in.list != "") {

--- a/docs/reference/buildx_bake.md
+++ b/docs/reference/buildx_bake.md
@@ -21,6 +21,7 @@ Build from a file
 | [`--check`](#check)                 | `bool`        |         | Shorthand for `--call=check`                                                                        |
 | `-D`, `--debug`                     | `bool`        |         | Enable debug logging                                                                                |
 | [`-f`](#file), [`--file`](#file)    | `stringArray` |         | Build definition file                                                                               |
+| `--list`                            | `string`      |         | List targets or variables                                                                           |
 | `--load`                            | `bool`        |         | Shorthand for `--set=*.output=type=docker`                                                          |
 | [`--metadata-file`](#metadata-file) | `string`      |         | Write build result metadata to a file                                                               |
 | [`--no-cache`](#no-cache)           | `bool`        |         | Do not use cache when building the image                                                            |

--- a/tests/bake.go
+++ b/tests/bake.go
@@ -1504,7 +1504,7 @@ target "abc" {
 	out, err := bakeCmd(
 		sb,
 		withDir(dir),
-		withArgs("--list-targets"),
+		withArgs("--list=targets"),
 	)
 	require.NoError(t, err, out)
 
@@ -1533,7 +1533,7 @@ target "default" {
 	out, err := bakeCmd(
 		sb,
 		withDir(dir),
-		withArgs("--list-variables"),
+		withArgs("--list=variables"),
 	)
 	require.NoError(t, err, out)
 


### PR DESCRIPTION
follow-up https://github.com/docker/buildx/pull/2556#pullrequestreview-2151553029

* Replace `--list-targets` and `--list-variables` flags with `--list` flag and put it out of experimental.
* `--print` and `--list` are now mutually exclusive.
* Add `json` format support for `--list` flag.

```
$ docker buildx bake --list=targets
#1 [internal] load local bake definitions
#1 reading docker-bake.hcl 4.97kB / 4.97kB done
#1 DONE 0.0s
TARGET                          DESCRIPTION
binaries
binaries-cross
default                         binaries
govulncheck
image
image-cross
image-local
integration-test
integration-test-base
lint
lint-gopls
meta-helper
mod-outdated
release
test
update-authors
update-docs
update-generated-files
update-vendor
validate                        lint, lint-gopls, validate-docs, validate-golangci, validate-vendor
validate-authors
validate-docs
validate-generated-files
validate-golangci               Validate .golangci.yml schema (does not run Go linter)
validate-vendor
```

```
$ docker buildx bake --list=variables
#1 [internal] load local bake definitions
#1 reading docker-bake.hcl 4.97kB / 4.97kB done
#1 DONE 0.0s
VARIABLE                        VALUE   DESCRIPTION
DESTDIR                         ./bin
DOCS_FORMATS                    md
GOLANGCI_LINT_MULTIPLATFORM
GOVULNCHECK_FORMAT              <null>
GO_VERSION                      <null>
HTTPS_PROXY
HTTP_PROXY
NO_PROXY
TEST_BUILDKIT_TAG               <null>
TEST_COVERAGE                   <null>
```

```
$ docker buildx bake --list=type=targets,format=json
#1 [internal] load local bake definitions
#1 reading docker-bake.hcl 4.97kB / 4.97kB done
#1 DONE 0.0s
[
  {
    "name": "binaries"
  },
  {
    "name": "binaries-cross"
  },
  {
    "name": "default",
    "description": "binaries",
    "group": true
  },
  {
    "name": "govulncheck"
  },
  {
    "name": "image"
  },
  {
    "name": "image-cross"
  },
  {
    "name": "image-local"
  },
  {
    "name": "integration-test"
  },
  {
    "name": "integration-test-base"
  },
  {
    "name": "lint"
  },
  {
    "name": "lint-gopls"
  },
  {
    "name": "meta-helper"
  },
  {
    "name": "mod-outdated"
  },
  {
    "name": "release"
  },
  {
    "name": "test"
  },
  {
    "name": "update-authors"
  },
  {
    "name": "update-docs"
  },
  {
    "name": "update-generated-files"
  },
  {
    "name": "update-vendor"
  },
  {
    "name": "validate",
    "description": "lint, lint-gopls, validate-docs, validate-golangci, validate-vendor",
    "group": true
  },
  {
    "name": "validate-authors"
  },
  {
    "name": "validate-docs"
  },
  {
    "name": "validate-generated-files"
  },
  {
    "name": "validate-golangci",
    "description": "Validate .golangci.yml schema (does not run Go linter)"
  },
  {
    "name": "validate-vendor"
  }
]
```

```
$ docker buildx bake --list=type=variables,format=json
#1 [internal] load local bake definitions
#1 reading docker-bake.hcl 4.97kB / 4.97kB done
#1 DONE 0.0s
[
  {
    "name": "DESTDIR",
    "value": "./bin"
  },
  {
    "name": "DOCS_FORMATS",
    "value": "md"
  },
  {
    "name": "GOLANGCI_LINT_MULTIPLATFORM",
    "value": ""
  },
  {
    "name": "GOVULNCHECK_FORMAT"
  },
  {
    "name": "GO_VERSION"
  },
  {
    "name": "HTTPS_PROXY",
    "value": ""
  },
  {
    "name": "HTTP_PROXY",
    "value": ""
  },
  {
    "name": "NO_PROXY",
    "value": ""
  },
  {
    "name": "TEST_BUILDKIT_TAG"
  },
  {
    "name": "TEST_COVERAGE"
  }
]
```