### PR TITLE
bake: support setting the context to null in bake

### DIFF
--- a/bake/compose.go
+++ b/bake/compose.go
@@ -72,10 +72,10 @@ func ParseCompose(cfgs []composetypes.ConfigFile, envs map[string]string) (*Conf
 				return nil, errors.Wrapf(err, "invalid service name %q", targetName)
 			}
 
-			var contextPathP *string
+			var contextPathP **string
 			if s.Build.Context != "" {
-				contextPath := s.Build.Context
-				contextPathP = &contextPath
+				ptr := &s.Build.Context
+				contextPathP = &ptr
 			}
 			var dockerfilePathP *string
 			if s.Build.Dockerfile != "" {

--- a/bake/compose_test.go
+++ b/bake/compose_test.go
@@ -65,11 +65,11 @@ secrets:
 		return c.Targets[i].Name < c.Targets[j].Name
 	})
 	require.Equal(t, "db", c.Targets[0].Name)
-	require.Equal(t, "db", *c.Targets[0].Context)
+	require.Equal(t, "db", *c.Targets[0].ContextPath())
 	require.Equal(t, []string{"docker.io/tonistiigi/db"}, c.Targets[0].Tags)
 
 	require.Equal(t, "webapp", c.Targets[1].Name)
-	require.Equal(t, "dir", *c.Targets[1].Context)
+	require.Equal(t, "dir", *c.Targets[1].ContextPath())
 	require.Equal(t, map[string]string{"foo": "bar"}, c.Targets[1].Contexts)
 	require.Equal(t, "Dockerfile-alternate", *c.Targets[1].Dockerfile)
 	require.Equal(t, 1, len(c.Targets[1].Args))
@@ -84,7 +84,7 @@ secrets:
 	}, stringify(c.Targets[1].Secrets))
 
 	require.Equal(t, "webapp2", c.Targets[2].Name)
-	require.Equal(t, "dir", *c.Targets[2].Context)
+	require.Equal(t, "dir", *c.Targets[2].ContextPath())
 	require.Equal(t, "FROM alpine\n", *c.Targets[2].DockerfileInline)
 }
 

--- a/bake/hcl_test.go
+++ b/bake/hcl_test.go
@@ -54,7 +54,7 @@ func TestHCLBasic(t *testing.T) {
 
 	require.Equal(t, 4, len(c.Targets))
 	require.Equal(t, "db", c.Targets[0].Name)
-	require.Equal(t, "./db", *c.Targets[0].Context)
+	require.Equal(t, "./db", *c.Targets[0].ContextPath())
 
 	require.Equal(t, "webapp", c.Targets[1].Name)
 	require.Equal(t, 1, len(c.Targets[1].Args))
@@ -114,7 +114,7 @@ func TestHCLBasicInJSON(t *testing.T) {
 
 	require.Equal(t, 4, len(c.Targets))
 	require.Equal(t, "db", c.Targets[0].Name)
-	require.Equal(t, "./db", *c.Targets[0].Context)
+	require.Equal(t, "./db", *c.Targets[0].ContextPath())
 
 	require.Equal(t, "webapp", c.Targets[1].Name)
 	require.Equal(t, 1, len(c.Targets[1].Args))
@@ -516,11 +516,11 @@ func TestHCLTargetAttrs(t *testing.T) {
 	require.Equal(t, "bar", c.Targets[1].Name)
 
 	require.Equal(t, "xxx", *c.Targets[0].Dockerfile)
-	require.Equal(t, "yyy", *c.Targets[0].Context)
+	require.Equal(t, "yyy", *c.Targets[0].ContextPath())
 	require.Equal(t, "xxx", *c.Targets[0].Target)
 
 	require.Equal(t, "xxx", *c.Targets[1].Dockerfile)
-	require.Equal(t, "yyy", *c.Targets[1].Context)
+	require.Equal(t, "yyy", *c.Targets[1].ContextPath())
 	require.Equal(t, "yyy", *c.Targets[1].Target)
 }
 
@@ -576,8 +576,7 @@ func TestHCLTargetAttrEmptyChain(t *testing.T) {
 
 	require.Equal(t, 1, len(c.Targets))
 	require.Equal(t, "foo", c.Targets[0].Name)
-	require.Nil(t, c.Targets[0].Dockerfile)
-	require.Nil(t, c.Targets[0].Context)
+	require.Nil(t, c.Targets[0].ContextPath())
 	require.Nil(t, c.Targets[0].Target)
 }
 
@@ -963,7 +962,7 @@ func TestHCLRenameMultiFile(t *testing.T) {
 	require.Equal(t, "z", *c.Targets[0].Target)
 
 	require.Equal(t, "foo", c.Targets[1].Name)
-	require.Equal(t, "y", *c.Targets[1].Context)
+	require.Equal(t, "y", *c.Targets[1].ContextPath())
 }
 
 func TestHCLMatrixBasic(t *testing.T) {
@@ -1365,7 +1364,7 @@ services:
 	require.Equal(t, "app", c.Targets[0].Name)
 	require.Equal(t, ptrstr("foo"), c.Targets[0].Args["v1"])
 	require.Equal(t, ptrstr("bar"), c.Targets[0].Args["v2"])
-	require.Equal(t, "dir", *c.Targets[0].Context)
+	require.Equal(t, "dir", *c.Targets[0].ContextPath())
 	require.Equal(t, "Dockerfile-alternate", *c.Targets[0].Dockerfile)
 }
 
@@ -1386,7 +1385,7 @@ func TestHCLBuiltinVars(t *testing.T) {
 
 	require.Equal(t, 1, len(c.Targets))
 	require.Equal(t, "app", c.Targets[0].Name)
-	require.Equal(t, "foo", *c.Targets[0].Context)
+	require.Equal(t, "foo", *c.Targets[0].ContextPath())
 	require.Equal(t, "test", *c.Targets[0].Dockerfile)
 }
 
@@ -1458,11 +1457,11 @@ target "b" {
 	require.Equal(t, []string{"app/b:1.0.0", "app/b:latest"}, c.Targets[1].Tags)
 
 	require.Equal(t, "a", c.Targets[2].Name)
-	require.Equal(t, ".", *c.Targets[2].Context)
+	require.Equal(t, ".", *c.Targets[2].ContextPath())
 	require.Equal(t, "a", *c.Targets[2].Target)
 
 	require.Equal(t, "b", c.Targets[3].Name)
-	require.Equal(t, ".", *c.Targets[3].Context)
+	require.Equal(t, ".", *c.Targets[3].ContextPath())
 	require.Equal(t, "b", *c.Targets[3].Target)
 }
 

--- a/tests/bake.go
+++ b/tests/bake.go
@@ -38,6 +38,7 @@ func bakeCmd(sb integration.Sandbox, opts ...cmdOpt) (string, error) {
 var bakeTests = []func(t *testing.T, sb integration.Sandbox){
 	testBakePrint,
 	testBakePrintSensitive,
+	testBakePrintNullContext,
 	testBakeLocal,
 	testBakeLocalMulti,
 	testBakeRemote,
@@ -140,7 +141,7 @@ RUN echo "Hello ${HELLO}"
 			require.Equal(t, []string{"build"}, def.Group["default"].Targets)
 			require.Len(t, def.Target, 1)
 			require.Contains(t, def.Target, "build")
-			require.Equal(t, ".", *def.Target["build"].Context)
+			require.Equal(t, ".", *def.Target["build"].ContextPath())
 			require.Equal(t, "Dockerfile", *def.Target["build"].Dockerfile)
 			require.Equal(t, map[string]*string{"HELLO": ptrstr("foo")}, def.Target["build"].Args)
 
@@ -245,7 +246,7 @@ RUN echo "Hello ${HELLO}"
 			require.Equal(t, []string{"build"}, def.Group["default"].Targets)
 			require.Len(t, def.Target, 1)
 			require.Contains(t, def.Target, "build")
-			require.Equal(t, ".", *def.Target["build"].Context)
+			require.Equal(t, ".", *def.Target["build"].ContextPath())
 			require.Equal(t, "Dockerfile", *def.Target["build"].Dockerfile)
 			require.Equal(t, map[string]*string{"HELLO": ptrstr("foo")}, def.Target["build"].Args)
 			require.NotNil(t, def.Target["build"].CacheFrom)
@@ -278,6 +279,90 @@ RUN echo "Hello ${HELLO}"
           "name": "my_image"
         }
       ]
+    }
+  }
+}
+`, stdout.String())
+		})
+	}
+}
+
+func testBakePrintNullContext(t *testing.T, sb integration.Sandbox) {
+	testCases := []struct {
+		name string
+		f    string
+		dt   []byte
+	}{
+		{
+			"HCL",
+			"docker-bake.hcl",
+			[]byte(`
+target "build" {
+  context = null
+}
+`),
+		},
+		{
+			"JSON",
+			"docker-bake.json",
+			[]byte(`
+{
+  "target": {
+    "build": {
+      "context": null
+    }
+  }
+}
+`),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := tmpdir(
+				t,
+				fstest.CreateFile(tc.f, tc.dt, 0600),
+				fstest.CreateFile("Dockerfile", []byte(`
+FROM busybox
+ARG HELLO
+RUN echo "Hello ${HELLO}"
+	`), 0600),
+			)
+
+			cmd := buildxCmd(sb, withDir(dir), withArgs("bake", "--print", "build"))
+			stdout := bytes.Buffer{}
+			stderr := bytes.Buffer{}
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+			require.NoError(t, cmd.Run(), stdout.String(), stderr.String())
+
+			var def struct {
+				Group  map[string]*bake.Group  `json:"group,omitempty"`
+				Target map[string]*bake.Target `json:"target"`
+			}
+			require.NoError(t, json.Unmarshal(stdout.Bytes(), &def))
+
+			require.Len(t, def.Group, 1)
+			require.Contains(t, def.Group, "default")
+
+			require.Equal(t, []string{"build"}, def.Group["default"].Targets)
+			require.Len(t, def.Target, 1)
+			require.Contains(t, def.Target, "build")
+			require.Nil(t, def.Target["build"].Context)
+			require.Equal(t, "Dockerfile", *def.Target["build"].Dockerfile)
+
+			require.JSONEq(t, `{
+  "group": {
+    "default": {
+      "targets": [
+        "build"
+      ]
+    }
+  },
+  "target": {
+    "build": {
+      "context": null,
+      "dockerfile": "Dockerfile"
     }
   }
 }
@@ -871,6 +956,7 @@ target "default" {
 		})
 	}
 }
+
 func testBakeSetNonExistingOutsideNoParallel(t *testing.T, sb integration.Sandbox) {
 	for _, ent := range []bool{true, false} {
 		t.Run(fmt.Sprintf("ent=%v", ent), func(t *testing.T) {


### PR DESCRIPTION
Setting the context to null in bake will cause the dockerfile to be sent over stdin to the build and will prevent using the default context of "." similar to how this would be used on the command line.

When the JSON is printed from bake, it will reproduce the null so subsequent uses can keep the value.

Fixes #2611.