### PR TITLE
history(inspect): print build name

### DIFF
--- a/commands/history/inspect.go
+++ b/commands/history/inspect.go
@@ -109,6 +109,8 @@ func runInspect(ctx context.Context, dockerCli command.Cli, opts inspectOptions)
 		delete(attrs, k)
 	}
 
+	fmt.Fprintf(tw, "Name:\t%s\n", buildName(rec.FrontendAttrs, st))
+
 	var context string
 	var dockerfile string
 	if st != nil {


### PR DESCRIPTION
Prints build name for `history inspect` command so it can relate with the `history ls` one.