### PR TITLE
fix: strip path from usage output and shell-completion scripts

### DIFF
--- a/cmd/buildx/main.go
+++ b/cmd/buildx/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/docker/buildx/commands"
 	controllererrors "github.com/docker/buildx/controller/errdefs"
@@ -41,7 +42,8 @@ func runStandalone(cmd *command.DockerCli) error {
 	}
 	defer flushMetrics(cmd)
 
-	rootCmd := commands.NewRootCmd(os.Args[0], false, cmd)
+	executable := os.Args[0]
+	rootCmd := commands.NewRootCmd(filepath.Base(executable), false, cmd)
 	return rootCmd.Execute()
 }
 


### PR DESCRIPTION
Before this patch, both "usage" and shell-completion scripts would preserve
the path of the invoked command, which was especially problematic for the
completion-scripts, because Cobra's completion depends on Command.Name()
for this (see [1], [2]);

```bash
./bin/build/buildx --help | head -n 5
Extended build capabilities with BuildKit

Usage:
  ./bin/build/buildx
  ./bin/build/buildx [command]

./bin/build/buildx completion bash | head -n 3
# bash completion V2 for ./bin/build/buildx                   -*- shell-script -*-

__./bin/build/buildx_debug()
```

This would also be problematic if the path contained a space, for example;

```bash
ln -s $(pwd)/bin/build $(pwd)/bin/Program\ Files

./bin/Program\ Files/buildx completion bash | head -n 3
# bash completion V2 for ./bin/Program                        -*- shell-script -*-

__./bin/Program_debug()
```

With this patch, the path is stripped to prevent this issue;

```bash
make

./bin/build/buildx --help | head -n 5
Extended build capabilities with BuildKit

Usage:
  buildx
  buildx [command]

./bin/build/buildx completion bash | head -n 3
# bash completion V2 for buildx                               -*- shell-script -*-

__buildx_debug()

./bin/Program\ Files/buildx completion bash | head -n 3
# bash completion V2 for buildx                               -*- shell-script -*-

__buildx_debug()
```

It's worth noting that this patch only fixes these basic issues. Other cases
are not yet addressed, and may need fixes in Cobra because (especially for
the completion scripts) it should likely not conflate "Name" with "executable".

For example, command.Name() does not handle situations where the executable
itself has a space in its name:

```bash
ln -s $(pwd)/bin/build/buildx $(pwd)/bin/build/hello\ world

./bin/build/hello\ world completion bash | head -n 3
# bash completion V2 for hello                                -*- shell-script -*-

__hello_debug()
```

Other, less problematic, issues to address are case-insensitive filesystems,
where the binary can be invoked with any case;

```bash
./bin/build/bUiLdX --help | head -n 5
Extended build capabilities with BuildKit

Usage:
  bUiLdX
  bUiLdX [command]

./bin/build/bUiLdX completion bash | head -n 3
# bash completion V2 for bUiLdX                               -*- shell-script -*-

__bUiLdX_debug()
```

[1]: https://github.com/spf13/cobra/blob/v1.8.1/bash_completionsV2.go#L24-L39
[2]: https://github.com/spf13/cobra/blob/v1.8.1/command.go#L1502-L1510

