### PR TITLE
don't warn user about missing --allows when running with progress=rawjson

### DIFF
--- a/commands/bake.go
+++ b/commands/bake.go
@@ -271,8 +271,10 @@ func runBake(ctx context.Context, dockerCli command.Cli, targets []string, in ba
 	if err != nil {
 		return err
 	}
-	if err := exp.Prompt(ctx, url != "", &syncWriter{w: dockerCli.Err(), wait: printer.Wait}); err != nil {
-		return err
+	if progressMode != progressui.RawJSONMode {
+		if err := exp.Prompt(ctx, url != "", &syncWriter{w: dockerCli.Err(), wait: printer.Wait}); err != nil {
+			return err
+		}
 	}
 	if printer.IsDone() {
 		// init new printer as old one was stopped to show the prompt


### PR DESCRIPTION
When ran with `rawjson` progress mode, client only expect output to contain json messages. warning about missing `--allow` should then be skipped.