### PR TITLE
debug: fix invoke on error

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -466,7 +466,7 @@ func runControllerBuild(ctx context.Context, dockerCli command.Cli, opts *contro
 	if err != nil {
 		var be *controllererrors.BuildError
 		if errors.As(err, &be) {
-			ref = be.Ref
+			ref = be.SessionID
 			retErr = err
 			// We can proceed to monitor
 		} else {

--- a/monitor/commands/reload.go
+++ b/monitor/commands/reload.go
@@ -66,7 +66,7 @@ func (cm *ReloadCmd) Exec(ctx context.Context, args []string) error {
 	if err != nil {
 		var be *controllererrors.BuildError
 		if errors.As(err, &be) {
-			ref = be.Ref
+			ref = be.SessionID
 			resultUpdated = true
 		} else {
 			fmt.Printf("failed to reload: %v\n", err)


### PR DESCRIPTION
fixes https://github.com/docker/buildx/issues/2943

This is a regression from https://github.com/docker/buildx/pull/2722/commits/eb15c667b9e24f7c722b8ccb068854aa6e08d47b when renaming ref to sessionID. Forgot to update other places to take this change into account.