### PR TITLE
buildflags: handle unknown values from cty

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/docker/buildx
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1

--- a/hack/dockerfiles/lint.Dockerfile
+++ b/hack/dockerfiles/lint.Dockerfile
@@ -7,7 +7,7 @@ ARG XX_VERSION=1.6.1
 ARG GOLANGCI_LINT_VERSION=1.62.0
 ARG GOPLS_VERSION=v0.26.0
 # disabled: deprecated unusedvariable simplifyrange
-ARG GOPLS_ANALYZERS="embeddirective fillreturns infertypeargs nonewvars norangeoverfunc noresultvalues simplifycompositelit simplifyslice undeclaredname unusedparams useany"
+ARG GOPLS_ANALYZERS="embeddirective fillreturns infertypeargs nonewvars noresultvalues simplifycompositelit simplifyslice undeclaredname unusedparams useany"
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
 

--- a/util/buildflags/attests_cty.go
+++ b/util/buildflags/attests_cty.go
@@ -24,9 +24,7 @@ func (e *Attests) FromCtyValue(in cty.Value, p cty.Path) error {
 
 func (e *Attests) fromCtyValue(in cty.Value, p cty.Path) error {
 	*e = make([]*Attest, 0, in.LengthInt())
-	for elem := in.ElementIterator(); elem.Next(); {
-		_, value := elem.Element()
-
+	for value := range eachElement(in) {
 		entry := &Attest{}
 		if err := entry.FromCtyValue(value, p); err != nil {
 			return err
@@ -64,6 +62,10 @@ func (e *Attest) FromCtyValue(in cty.Value, p cty.Path) error {
 	e.Attrs = map[string]string{}
 	for it := conv.ElementIterator(); it.Next(); {
 		k, v := it.Element()
+		if !v.IsKnown() {
+			continue
+		}
+
 		switch key := k.AsString(); key {
 		case "type":
 			e.Type = v.AsString()

--- a/util/buildflags/cache_cty.go
+++ b/util/buildflags/cache_cty.go
@@ -23,13 +23,7 @@ func (o *CacheOptions) FromCtyValue(in cty.Value, p cty.Path) error {
 
 func (o *CacheOptions) fromCtyValue(in cty.Value, p cty.Path) error {
 	*o = make([]*CacheOptionsEntry, 0, in.LengthInt())
-	for elem := in.ElementIterator(); elem.Next(); {
-		_, value := elem.Element()
-
-		if isEmpty(value) {
-			continue
-		}
-
+	for value := range eachElement(in) {
 		// Special handling for a string type to handle ref only format.
 		if value.Type() == cty.String {
 			entries, err := ParseCacheEntry([]string{value.AsString()})

--- a/util/buildflags/export_cty.go
+++ b/util/buildflags/export_cty.go
@@ -23,13 +23,7 @@ func (e *Exports) FromCtyValue(in cty.Value, p cty.Path) error {
 
 func (e *Exports) fromCtyValue(in cty.Value, p cty.Path) error {
 	*e = make([]*ExportEntry, 0, in.LengthInt())
-	for elem := in.ElementIterator(); elem.Next(); {
-		_, value := elem.Element()
-
-		if isEmpty(value) {
-			continue
-		}
-
+	for value := range eachElement(in) {
 		entry := &ExportEntry{}
 		if err := entry.FromCtyValue(value, p); err != nil {
 			return err

--- a/util/buildflags/secrets_cty.go
+++ b/util/buildflags/secrets_cty.go
@@ -30,13 +30,7 @@ func (s *Secrets) FromCtyValue(in cty.Value, p cty.Path) error {
 
 func (s *Secrets) fromCtyValue(in cty.Value, p cty.Path) error {
 	*s = make([]*Secret, 0, in.LengthInt())
-	for elem := in.ElementIterator(); elem.Next(); {
-		_, value := elem.Element()
-
-		if isEmpty(value) {
-			continue
-		}
-
+	for value := range eachElement(in) {
 		entry := &Secret{}
 		if err := entry.FromCtyValue(value, p); err != nil {
 			return err
@@ -71,13 +65,13 @@ func (e *Secret) FromCtyValue(in cty.Value, p cty.Path) error {
 		return err
 	}
 
-	if id := conv.GetAttr("id"); !id.IsNull() {
+	if id := conv.GetAttr("id"); !id.IsNull() && id.IsKnown() {
 		e.ID = id.AsString()
 	}
-	if src := conv.GetAttr("src"); !src.IsNull() {
+	if src := conv.GetAttr("src"); !src.IsNull() && src.IsKnown() {
 		e.FilePath = src.AsString()
 	}
-	if env := conv.GetAttr("env"); !env.IsNull() {
+	if env := conv.GetAttr("env"); !env.IsNull() && env.IsKnown() {
 		e.Env = env.AsString()
 	}
 	return nil

--- a/util/buildflags/ssh_cty.go
+++ b/util/buildflags/ssh_cty.go
@@ -30,13 +30,7 @@ func (s *SSHKeys) FromCtyValue(in cty.Value, p cty.Path) error {
 
 func (s *SSHKeys) fromCtyValue(in cty.Value, p cty.Path) error {
 	*s = make([]*SSH, 0, in.LengthInt())
-	for elem := in.ElementIterator(); elem.Next(); {
-		_, value := elem.Element()
-
-		if isEmpty(value) {
-			continue
-		}
-
+	for value := range eachElement(in) {
 		entry := &SSH{}
 		if err := entry.FromCtyValue(value, p); err != nil {
 			return err
@@ -71,10 +65,10 @@ func (e *SSH) FromCtyValue(in cty.Value, p cty.Path) error {
 		return err
 	}
 
-	if id := conv.GetAttr("id"); !id.IsNull() {
+	if id := conv.GetAttr("id"); !id.IsNull() && id.IsKnown() {
 		e.ID = id.AsString()
 	}
-	if paths := conv.GetAttr("paths"); !paths.IsNull() {
+	if paths := conv.GetAttr("paths"); !paths.IsNull() && paths.IsKnown() {
 		if err := gocty.FromCtyValue(paths, &e.Paths); err != nil {
 			return err
 		}


### PR DESCRIPTION
Update the buildflags cty code to handle unknown values. When hcl decodes a value with an invalid variable name, it appends a diagnostic for the error and then returns an unknown value so it can continue processing the file and finding more errors.

The iteration code has now been changed to use a rangefunc from go 1.23 and it skips empty or unknown values. Empty values are valid when they are skipped and unknown values will have a diagnostic for itself.

Fixes #2960.