### PR TITLE
ls: fix duplicated builders for json format

### DIFF
--- a/commands/ls.go
+++ b/commands/ls.go
@@ -159,6 +159,9 @@ func lsPrint(dockerCli command.Cli, current *store.NodeGroup, builders []*builde
 				}
 				continue
 			}
+			if ctx.Format.IsJSON() {
+				continue
+			}
 			for _, n := range b.Nodes() {
 				if n.Err != nil {
 					if ctx.Format.IsTable() {


### PR DESCRIPTION
fixes #2969 

JSON format for `ls` command without Go template (`--format json`) should not set nodes in formatter context.