### PR TITLE
go.mod: downgrade minimum go version to go1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/docker/buildx
 
-go 1.23.0
+go 1.22.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1


### PR DESCRIPTION
- relates to https://github.com/docker/buildx/pull/2965#discussion_r1949182858

This was updated in abc85c38f8b7f451c38cdce83fbc9a406cfa474a, but looks to have been unintentional.