### PR TITLE
buildflags: make work on go 1.22 by reverting rangefunc usage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/docker/buildx
 
-go 1.23.0
+go 1.22.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1

--- a/util/buildflags/attests_cty.go
+++ b/util/buildflags/attests_cty.go
@@ -22,16 +22,19 @@ func (e *Attests) FromCtyValue(in cty.Value, p cty.Path) error {
 	return p.NewErrorf("%s", convert.MismatchMessage(got, want))
 }
 
-func (e *Attests) fromCtyValue(in cty.Value, p cty.Path) error {
+func (e *Attests) fromCtyValue(in cty.Value, p cty.Path) (retErr error) {
 	*e = make([]*Attest, 0, in.LengthInt())
-	for value := range eachElement(in) {
+
+	yield := func(value cty.Value) bool {
 		entry := &Attest{}
-		if err := entry.FromCtyValue(value, p); err != nil {
-			return err
+		if retErr = entry.FromCtyValue(value, p); retErr != nil {
+			return false
 		}
 		*e = append(*e, entry)
+		return true
 	}
-	return nil
+	eachElement(in)(yield)
+	return retErr
 }
 
 func (e Attests) ToCtyValue() cty.Value {

--- a/util/buildflags/export_cty.go
+++ b/util/buildflags/export_cty.go
@@ -21,16 +21,19 @@ func (e *Exports) FromCtyValue(in cty.Value, p cty.Path) error {
 	return p.NewErrorf("%s", convert.MismatchMessage(got, want))
 }
 
-func (e *Exports) fromCtyValue(in cty.Value, p cty.Path) error {
+func (e *Exports) fromCtyValue(in cty.Value, p cty.Path) (retErr error) {
 	*e = make([]*ExportEntry, 0, in.LengthInt())
-	for value := range eachElement(in) {
+
+	yield := func(value cty.Value) bool {
 		entry := &ExportEntry{}
-		if err := entry.FromCtyValue(value, p); err != nil {
-			return err
+		if retErr = entry.FromCtyValue(value, p); retErr != nil {
+			return false
 		}
 		*e = append(*e, entry)
+		return true
 	}
-	return nil
+	eachElement(in)(yield)
+	return retErr
 }
 
 func (e Exports) ToCtyValue() cty.Value {

--- a/util/buildflags/secrets_cty.go
+++ b/util/buildflags/secrets_cty.go
@@ -28,16 +28,19 @@ func (s *Secrets) FromCtyValue(in cty.Value, p cty.Path) error {
 	return p.NewErrorf("%s", convert.MismatchMessage(got, want))
 }
 
-func (s *Secrets) fromCtyValue(in cty.Value, p cty.Path) error {
+func (s *Secrets) fromCtyValue(in cty.Value, p cty.Path) (retErr error) {
 	*s = make([]*Secret, 0, in.LengthInt())
-	for value := range eachElement(in) {
+
+	yield := func(value cty.Value) bool {
 		entry := &Secret{}
-		if err := entry.FromCtyValue(value, p); err != nil {
-			return err
+		if retErr = entry.FromCtyValue(value, p); retErr != nil {
+			return false
 		}
 		*s = append(*s, entry)
+		return true
 	}
-	return nil
+	eachElement(in)(yield)
+	return retErr
 }
 
 func (s Secrets) ToCtyValue() cty.Value {

--- a/util/buildflags/ssh_cty.go
+++ b/util/buildflags/ssh_cty.go
@@ -28,16 +28,19 @@ func (s *SSHKeys) FromCtyValue(in cty.Value, p cty.Path) error {
 	return p.NewErrorf("%s", convert.MismatchMessage(got, want))
 }
 
-func (s *SSHKeys) fromCtyValue(in cty.Value, p cty.Path) error {
+func (s *SSHKeys) fromCtyValue(in cty.Value, p cty.Path) (retErr error) {
 	*s = make([]*SSH, 0, in.LengthInt())
-	for value := range eachElement(in) {
+
+	yield := func(value cty.Value) bool {
 		entry := &SSH{}
-		if err := entry.FromCtyValue(value, p); err != nil {
-			return err
+		if retErr = entry.FromCtyValue(value, p); retErr != nil {
+			return false
 		}
 		*s = append(*s, entry)
+		return true
 	}
-	return nil
+	eachElement(in)(yield)
+	return retErr
 }
 
 func (s SSHKeys) ToCtyValue() cty.Value {

--- a/util/buildflags/utils.go
+++ b/util/buildflags/utils.go
@@ -1,8 +1,6 @@
 package buildflags
 
 import (
-	"iter"
-
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
 )
@@ -57,7 +55,12 @@ func isEmptyOrUnknown(v cty.Value) bool {
 	return !v.IsKnown() || (v.Type() == cty.String && v.AsString() == "")
 }
 
-func eachElement(in cty.Value) iter.Seq[cty.Value] {
+// Seq is a temporary definition of iter.Seq until we are able to migrate
+// to using go1.23 as our minimum version. This can be removed when go1.24
+// is released and usages can be changed to use rangefunc.
+type Seq[V any] func(yield func(V) bool)
+
+func eachElement(in cty.Value) Seq[cty.Value] {
 	return func(yield func(v cty.Value) bool) {
 		for elem := in.ElementIterator(); elem.Next(); {
 			_, value := elem.Element()


### PR DESCRIPTION
- supersedes / closes https://github.com/docker/buildx/pull/2977

Reverts the usage of rangefunc and attempts to keep the foundation of it in for when we move to go 1.23. We have downstream dependencies that aren't ready to move to go 1.23. We can likely move after go 1.24 is released.

Related to https://github.com/docker/buildx/pull/2965#discussion_r1949182858.