### PR TITLE
build: set the frontend attributes for callfunc earlier

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -375,6 +375,15 @@ func BuildWithResultHandler(ctx context.Context, nodes []builder.Node, opts map[
 					}
 				}
 
+				if opt.CallFunc != nil {
+					if _, ok := so.FrontendAttrs["frontend.caps"]; !ok {
+						so.FrontendAttrs["frontend.caps"] = "moby.buildkit.frontend.subrequests+forward"
+					} else {
+						so.FrontendAttrs["frontend.caps"] += ",moby.buildkit.frontend.subrequests+forward"
+					}
+					so.FrontendAttrs["requestid"] = "frontend." + opt.CallFunc.Name
+				}
+
 				pw := progress.WithPrefix(w, k, multiTarget)
 
 				c, err := dp.Client(ctx)
@@ -444,15 +453,6 @@ func BuildWithResultHandler(ctx context.Context, nodes []builder.Node, opts map[
 					cc := c
 					var callRes map[string][]byte
 					buildFunc := func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
-						if opt.CallFunc != nil {
-							if _, ok := req.FrontendOpt["frontend.caps"]; !ok {
-								req.FrontendOpt["frontend.caps"] = "moby.buildkit.frontend.subrequests+forward"
-							} else {
-								req.FrontendOpt["frontend.caps"] += ",moby.buildkit.frontend.subrequests+forward"
-							}
-							req.FrontendOpt["requestid"] = "frontend." + opt.CallFunc.Name
-						}
-
 						res, err := c.Solve(ctx, req)
 						if err != nil {
 							req, ok := fallbackPrintError(err, req)


### PR DESCRIPTION
The frontend attributes that were set when `CallFunc` was set were not set early enough and it prevented buildkit from seeing the `requestid`.

The `requestid` would only be seen by the `LLBBridgeClient` and it was not set yet when the `Controller.Solve` method was invoked.

This also had a side effect that the linter could not see that it was being invoked and the image verifier could not know it shouldn't run.

Fixes https://github.com/moby/buildkit/issues/5693.