### PR TITLE
ci: infer go version from workflow for bsd tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -254,6 +254,10 @@ jobs:
         name: Prepare
         run: |
           echo "VAGRANT_FILE=hack/Vagrantfile.${{ matrix.os }}" >> $GITHUB_ENV
+          
+          # Sets semver Go version to be able to download tarball during vagrant setup
+          goVersion=$(curl --silent "https://go.dev/dl/?mode=json&include=all" | jq -r '.[].files[].version' | uniq | sed -e 's/go//' | sort -V | grep $GO_VERSION | tail -1)
+          echo "GO_VERSION=$goVersion" >> $GITHUB_ENV
       -
         name: Checkout
         uses: actions/checkout@v4

--- a/hack/Vagrantfile.freebsd
+++ b/hack/Vagrantfile.freebsd
@@ -9,10 +9,13 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision "init", type: "shell", run: "once" do |sh|
     sh.inline = <<~SHELL
+      set -x
       pkg bootstrap
-      pkg install -y go123 git
-      ln -s /usr/local/bin/go123 /usr/local/bin/go
-      go install gotest.tools/gotestsum@#{ENV['GOTESTSUM_VERSION']}
+      pkg install -y git
+
+      fetch https://go.dev/dl/go#{ENV['GO_VERSION']}.freebsd-amd64.tar.gz
+      tar -C /usr/local -xzf go#{ENV['GO_VERSION']}.freebsd-amd64.tar.gz
+      ln -s /usr/local/go/bin/go /usr/local/bin/go
     SHELL
   end
 end

--- a/hack/Vagrantfile.openbsd
+++ b/hack/Vagrantfile.openbsd
@@ -10,12 +10,12 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision "init", type: "shell", run: "once" do |sh|
     sh.inline = <<~SHELL
+      set -x
       pkg_add -x git
 
-      ftp https://go.dev/dl/go1.23.3.openbsd-amd64.tar.gz
-      tar -C /usr/local -xzf go1.23.3.openbsd-amd64.tar.gz
+      ftp https://go.dev/dl/go#{ENV['GO_VERSION']}.openbsd-amd64.tar.gz
+      tar -C /usr/local -xzf go#{ENV['GO_VERSION']}.openbsd-amd64.tar.gz
       ln -s /usr/local/go/bin/go /usr/local/bin/go
-      go install gotest.tools/gotestsum@#{ENV['GOTESTSUM_VERSION']}
     SHELL
   end
 end


### PR DESCRIPTION
To be consistent with go version used in our workflows.