### PR TITLE
bake: allow annotations to be set on the command line

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -556,9 +556,9 @@ func (c Config) newOverrides(v []string) (map[string]map[string]Override, error)
 			o := t[kk[1]]
 
 			// IMPORTANT: if you add more fields here, do not forget to update
-			// docs/bake-reference.md and https://docs.docker.com/build/bake/overrides/
+			// docs/reference/buildx_bake.md (--set) and https://docs.docker.com/build/bake/overrides/
 			switch keys[1] {
-			case "output", "cache-to", "cache-from", "tags", "platform", "secrets", "ssh", "attest", "entitlements", "network":
+			case "output", "cache-to", "cache-from", "tags", "platform", "secrets", "ssh", "attest", "entitlements", "network", "annotations":
 				if len(parts) == 2 {
 					o.ArrValue = append(o.ArrValue, parts[1])
 				}

--- a/bake/bake_test.go
+++ b/bake/bake_test.go
@@ -34,6 +34,9 @@ target "webapp" {
 	args = {
 		VAR_BOTH = "webapp"
 	}
+	annotations = [
+		"index,manifest:org.opencontainers.image.authors=dvdksn"
+	]
 	inherits = ["webDEP"]
 }`),
 	}
@@ -113,6 +116,15 @@ target "webapp" {
 			require.Equal(t, 1, len(g))
 			require.Equal(t, []string{"webapp"}, g["default"].Targets)
 		})
+	})
+
+	t.Run("AnnotationsOverrides", func(t *testing.T) {
+		t.Parallel()
+		m, g, err := ReadTargets(ctx, []File{fp}, []string{"webapp"}, []string{"webapp.annotations=index,manifest:org.opencontainers.image.vendor=docker"}, nil, &EntitlementConf{})
+		require.NoError(t, err)
+		require.Equal(t, []string{"index,manifest:org.opencontainers.image.authors=dvdksn", "index,manifest:org.opencontainers.image.vendor=docker"}, m["webapp"].Annotations)
+		require.Equal(t, 1, len(g))
+		require.Equal(t, []string{"webapp"}, g["default"].Targets)
 	})
 
 	t.Run("ContextOverride", func(t *testing.T) {

--- a/docs/reference/buildx_bake.md
+++ b/docs/reference/buildx_bake.md
@@ -354,6 +354,7 @@ $ docker buildx bake --set foo*.no-cache              # bypass caching only for 
 
 You can override the following fields:
 
+* `annotations`
 * `args`
 * `cache-from`
 * `cache-to`


### PR DESCRIPTION
Annotations were not merged correctly. The overrides in `ArrValue` would be merged, but the section of code setting them from the command line did not include `annotations` in the list of available attributes so the command line option was completely discarded.

Fixes https://github.com/docker/buildx/issues/2989.