### PR TITLE
cache: enable gha cache backend if cache service v2 detected

### DIFF
--- a/util/buildflags/cache.go
+++ b/util/buildflags/cache.go
@@ -207,6 +207,7 @@ func addGithubToken(ci *controllerapi.CacheOptionsEntry) {
 	}
 	version, ok := ci.Attrs["version"]
 	if !ok {
+		// https://github.com/actions/toolkit/blob/2b08dc18f261b9fdd978b70279b85cbef81af8bc/packages/cache/src/internal/config.ts#L19
 		if v, ok := os.LookupEnv("ACTIONS_CACHE_SERVICE_V2"); ok {
 			if b, err := strconv.ParseBool(v); err == nil && b {
 				version = "2"
@@ -218,15 +219,18 @@ func addGithubToken(ci *controllerapi.CacheOptionsEntry) {
 			ci.Attrs["token"] = v
 		}
 	}
+	if _, ok := ci.Attrs["url_v2"]; !ok && version == "2" {
+		// https://github.com/actions/toolkit/blob/2b08dc18f261b9fdd978b70279b85cbef81af8bc/packages/cache/src/internal/config.ts#L34-L35
+		if v, ok := os.LookupEnv("ACTIONS_RESULTS_URL"); ok {
+			ci.Attrs["url_v2"] = v
+		}
+	}
 	if _, ok := ci.Attrs["url"]; !ok {
-		if version == "2" {
-			if v, ok := os.LookupEnv("ACTIONS_RESULTS_URL"); ok {
-				ci.Attrs["url_v2"] = v
-			}
-		} else {
-			if v, ok := os.LookupEnv("ACTIONS_CACHE_URL"); ok {
-				ci.Attrs["url"] = v
-			}
+		// https://github.com/actions/toolkit/blob/2b08dc18f261b9fdd978b70279b85cbef81af8bc/packages/cache/src/internal/config.ts#L28-L33
+		if v, ok := os.LookupEnv("ACTIONS_CACHE_URL"); ok {
+			ci.Attrs["url"] = v
+		} else if v, ok := os.LookupEnv("ACTIONS_RESULTS_URL"); ok {
+			ci.Attrs["url"] = v
 		}
 	}
 }

--- a/util/buildflags/cache.go
+++ b/util/buildflags/cache.go
@@ -266,5 +266,5 @@ func isActive(pb *controllerapi.CacheOptionsEntry) bool {
 	if pb.Type != "gha" {
 		return true
 	}
-	return pb.Attrs["token"] != "" && pb.Attrs["url"] != ""
+	return pb.Attrs["token"] != "" && (pb.Attrs["url"] != "" || pb.Attrs["url_v2"] != "")
 }


### PR DESCRIPTION
After testing latest RC, gha cache backend is always disabled when cache service v2 is detected. We forgot to check if `url_v2` is set in https://github.com/docker/buildx/pull/2983.

Also fixes gha cache url handling to always set both `url` and `url_v2` if possible to match fallback of github actions tookit.