### PR TITLE
progress: fix race on pausing progress on debug shell

### DIFF
--- a/util/progress/printer.go
+++ b/util/progress/printer.go
@@ -122,6 +122,7 @@ func NewPrinter(ctx context.Context, out console.File, mode progressui.DisplayMo
 		for {
 			pw.status = make(chan *client.SolveStatus)
 			pw.done = make(chan struct{})
+			pw.closeOnce = sync.Once{}
 
 			pw.logMu.Lock()
 			pw.logSourceMap = map[digest.Digest]interface{}{}


### PR DESCRIPTION
Current progress writer has a logic of pausing/unpausing the printer and internally recreating internal channels.

This conflicts with a change that added sync.Once to Wait to allow it being called multiple times without erroring.

In debug shell this could mean that new progress printer showed up in debug shell because it was not closed.

cc097db675b439e99d0ebb7e524e16ba22f92a6f 