### PR TITLE
Dockerfile: update to docker v28.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,16 @@ jobs:
           - worker: docker+containerd  # same as docker, but with containerd snapshotter
             pkg: ./tests
             mode: experimental
+          - worker: "docker@27.5"
+            pkg: ./tests
+          - worker: "docker+containerd@27.5"  # same as docker, but with containerd snapshotter
+            pkg: ./tests
+          - worker: "docker@27.5"
+            pkg: ./tests
+            mode: experimental
+          - worker: "docker+containerd@27.5"  # same as docker, but with containerd snapshotter
+            pkg: ./tests
+            mode: experimental
           - worker: "docker@26.1"
             pkg: ./tests
           - worker: "docker+containerd@26.1"  # same as docker, but with containerd snapshotter

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ ARG ALPINE_VERSION=3.21
 ARG XX_VERSION=1.6.1
 
 # for testing
-ARG DOCKER_VERSION=28.0.0-rc.1
+ARG DOCKER_VERSION=28.0.0
+ARG DOCKER_VERSION_ALT_27=27.5.1
 ARG DOCKER_VERSION_ALT_26=26.1.3
 ARG DOCKER_CLI_VERSION=${DOCKER_VERSION}
 ARG GOTESTSUM_VERSION=v1.12.0
@@ -17,8 +18,10 @@ FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS golatest
 FROM moby/moby-bin:$DOCKER_VERSION AS docker-engine
 FROM dockereng/cli-bin:$DOCKER_CLI_VERSION AS docker-cli
-FROM moby/moby-bin:$DOCKER_VERSION_ALT_26 AS docker-engine-alt
-FROM dockereng/cli-bin:$DOCKER_VERSION_ALT_26 AS docker-cli-alt
+FROM moby/moby-bin:$DOCKER_VERSION_ALT_27 AS docker-engine-alt27
+FROM moby/moby-bin:$DOCKER_VERSION_ALT_26 AS docker-engine-alt26
+FROM dockereng/cli-bin:$DOCKER_VERSION_ALT_27 AS docker-cli-alt27
+FROM dockereng/cli-bin:$DOCKER_VERSION_ALT_26 AS docker-cli-alt26
 FROM registry:$REGISTRY_VERSION AS registry
 FROM moby/buildkit:$BUILDKIT_VERSION AS buildkit
 FROM crazymax/undock:$UNDOCK_VERSION AS undock
@@ -127,13 +130,15 @@ COPY --link --from=gotestsum /out /usr/bin/
 COPY --link --from=registry /bin/registry /usr/bin/
 COPY --link --from=docker-engine / /usr/bin/
 COPY --link --from=docker-cli / /usr/bin/
-COPY --link --from=docker-engine-alt / /opt/docker-alt-26/
-COPY --link --from=docker-cli-alt / /opt/docker-alt-26/
+COPY --link --from=docker-engine-alt27 / /opt/docker-alt-27/
+COPY --link --from=docker-engine-alt26 / /opt/docker-alt-26/
+COPY --link --from=docker-cli-alt27 / /opt/docker-alt-27/
+COPY --link --from=docker-cli-alt26 / /opt/docker-alt-26/
 COPY --link --from=buildkit /usr/bin/buildkitd /usr/bin/
 COPY --link --from=buildkit /usr/bin/buildctl /usr/bin/
 COPY --link --from=undock /usr/local/bin/undock /usr/bin/
 COPY --link --from=binaries /buildx /usr/bin/
-ENV TEST_DOCKER_EXTRA="docker@26.1=/opt/docker-alt-26"
+ENV TEST_DOCKER_EXTRA="docker@27.5=/opt/docker-alt-27,docker@26.1=/opt/docker-alt-26"
 
 FROM integration-test-base AS integration-test
 COPY . .


### PR DESCRIPTION
closes #3009

Also adds alt for previous Docker 27 release.