### PR TITLE
avoid double pushing with docker driver with containerd

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -539,7 +539,7 @@ func BuildWithResultHandler(ctx context.Context, nodes []builder.Node, opts map[
 					node := dp.Node().Driver
 					if node.IsMobyDriver() {
 						for _, e := range so.Exports {
-							if e.Type == "moby" && e.Attrs["push"] != "" {
+							if e.Type == "moby" && e.Attrs["push"] != "" && !node.Features(ctx)[driver.DirectPush] {
 								if ok, _ := strconv.ParseBool(e.Attrs["push"]); ok {
 									pushNames = e.Attrs["name"]
 									if pushNames == "" {

--- a/driver/docker-container/driver.go
+++ b/driver/docker-container/driver.go
@@ -420,6 +420,7 @@ func (d *Driver) Features(ctx context.Context) map[driver.Feature]bool {
 		driver.DockerExporter: true,
 		driver.CacheExport:    true,
 		driver.MultiPlatform:  true,
+		driver.DirectPush:     true,
 		driver.DefaultLoad:    d.defaultLoad,
 	}
 }

--- a/driver/docker/driver.go
+++ b/driver/docker/driver.go
@@ -93,6 +93,7 @@ func (d *Driver) Features(ctx context.Context) map[driver.Feature]bool {
 			driver.DockerExporter: useContainerdSnapshotter,
 			driver.CacheExport:    useContainerdSnapshotter,
 			driver.MultiPlatform:  useContainerdSnapshotter,
+			driver.DirectPush:     useContainerdSnapshotter,
 			driver.DefaultLoad:    true,
 		}
 	})

--- a/driver/features.go
+++ b/driver/features.go
@@ -7,5 +7,6 @@ const DockerExporter Feature = "Docker exporter"
 
 const CacheExport Feature = "Cache export"
 const MultiPlatform Feature = "Multi-platform build"
+const DirectPush Feature = "Direct push"
 
 const DefaultLoad Feature = "Automatically load images to the Docker Engine image store"

--- a/driver/kubernetes/driver.go
+++ b/driver/kubernetes/driver.go
@@ -238,6 +238,7 @@ func (d *Driver) Features(_ context.Context) map[driver.Feature]bool {
 		driver.DockerExporter: d.DockerAPI != nil,
 		driver.CacheExport:    true,
 		driver.MultiPlatform:  true, // Untested (needs multiple Driver instances)
+		driver.DirectPush:     true,
 		driver.DefaultLoad:    d.defaultLoad,
 	}
 }

--- a/driver/remote/driver.go
+++ b/driver/remote/driver.go
@@ -164,6 +164,7 @@ func (d *Driver) Features(ctx context.Context) map[driver.Feature]bool {
 		driver.DockerExporter: true,
 		driver.CacheExport:    true,
 		driver.MultiPlatform:  true,
+		driver.DirectPush:     true,
 		driver.DefaultLoad:    d.defaultLoad,
 	}
 }


### PR DESCRIPTION
In this mode buildkit can push directly so pushing manually with docker would result in pushing image twice.