### PR TITLE
correctly remove duplicated secrets and ssh keys

### DIFF
--- a/util/buildflags/secrets.go
+++ b/util/buildflags/secrets.go
@@ -27,7 +27,7 @@ func (s Secrets) Normalize() Secrets {
 	if len(s) == 0 {
 		return nil
 	}
-	return removeDupes(s)
+	return removeSecretDupes(s)
 }
 
 func (s Secrets) ToPB() []*controllerapi.Secret {
@@ -154,4 +154,18 @@ func parseSecret(value string) (*controllerapi.Secret, error) {
 		return nil, err
 	}
 	return s.ToPB(), nil
+}
+
+func removeSecretDupes(s []*Secret) []*Secret {
+	var res []*Secret
+	m := map[string]int{}
+	for _, sec := range s {
+		if i, ok := m[sec.ID]; ok {
+			res[i] = sec
+		} else {
+			m[sec.ID] = len(res)
+			res = append(res, sec)
+		}
+	}
+	return res
 }

--- a/util/buildflags/secrets_test.go
+++ b/util/buildflags/secrets_test.go
@@ -81,4 +81,17 @@ func TestSecrets(t *testing.T) {
 		result := actual.Equals(expected)
 		require.True(t, result.True())
 	})
+
+	t.Run("RemoveDupes", func(t *testing.T) {
+		secrets := Secrets{
+			{ID: "mysecret", Env: "FOO"},
+			{ID: "mysecret", Env: "BAR"},
+			{ID: "mysecret2", Env: "BAZ"},
+		}.Normalize()
+
+		expected := `[{"id":"mysecret","env":"BAR"},{"id":"mysecret2","env":"BAZ"}]`
+		actual, err := json.Marshal(secrets)
+		require.NoError(t, err)
+		require.JSONEq(t, expected, string(actual))
+	})
 }

--- a/util/buildflags/ssh.go
+++ b/util/buildflags/ssh.go
@@ -28,7 +28,7 @@ func (s SSHKeys) Normalize() SSHKeys {
 	if len(s) == 0 {
 		return nil
 	}
-	return removeDupes(s)
+	return removeSSHDupes(s)
 }
 
 func (s SSHKeys) ToPB() []*controllerapi.SSH {
@@ -130,4 +130,18 @@ func IsGitSSH(repo string) bool {
 		return false
 	}
 	return url.Scheme == gitutil.SSHProtocol
+}
+
+func removeSSHDupes(s []*SSH) []*SSH {
+	var res []*SSH
+	m := map[string]int{}
+	for _, ssh := range s {
+		if i, ok := m[ssh.ID]; ok {
+			res[i] = ssh
+		} else {
+			m[ssh.ID] = len(res)
+			res = append(res, ssh)
+		}
+	}
+	return res
 }

--- a/util/buildflags/ssh_test.go
+++ b/util/buildflags/ssh_test.go
@@ -82,4 +82,17 @@ func TestSSHKeys(t *testing.T) {
 		result := actual.Equals(expected)
 		require.True(t, result.True())
 	})
+
+	t.Run("RemoveDupes", func(t *testing.T) {
+		sshkeys := SSHKeys{
+			{ID: "default"},
+			{ID: "key", Paths: []string{"path/to/foo"}},
+			{ID: "key", Paths: []string{"path/to/bar"}},
+		}.Normalize()
+
+		expected := `[{"id":"default"},{"id":"key","paths":["path/to/bar"]}]`
+		actual, err := json.Marshal(sshkeys)
+		require.NoError(t, err)
+		require.JSONEq(t, expected, string(actual))
+	})
 }


### PR DESCRIPTION
* follow-up https://github.com/docker/buildx/pull/3031#discussion_r1975283999

```hcl
target "default" {
  secret = [
    "id=FOO,env=FOO",
    "id=FOO,env=BAR",
    "id=BAR,env=BAZ"
  ]
}
```

Currently:

```
$ docker buildx bake --print
#1 [internal] load local bake definitions
#1 reading docker-bake.hcl 103B / 103B done
#1 DONE 0.0s
{
  "group": {
    "default": {
      "targets": [
        "default"
      ]
    }
  },
  "target": {
    "default": {
      "context": ".",
      "dockerfile": "Dockerfile",
      "secret": [
        {
          "id": "FOO",
          "env": "FOO"
        },
        {
          "id": "FOO",
          "env": "BAR"
        },
        {
          "id": "BAR",
          "env": "BAZ"
        }
      ]
    }
  }
}
```

With this change:

```
$ docker buildx bake --print
#1 [internal] load local bake definitions
#1 reading docker-bake.hcl 103B / 103B done
#1 DONE 0.0s
{
  "group": {
    "default": {
      "targets": [
        "default"
      ]
    }
  },
  "target": {
    "default": {
      "context": ".",
      "dockerfile": "Dockerfile",
      "secret": [
        {
          "id": "FOO",
          "env": "BAR"
        },
        {
          "id": "BAR",
          "env": "BAZ"
        }
      ]
    }
  }
}
```