### PR TITLE
history: allow index based inspect of builds

### DIFF
--- a/commands/history/inspect.go
+++ b/commands/history/inspect.go
@@ -173,6 +173,16 @@ func runInspect(ctx context.Context, dockerCli command.Cli, opts inspectOptions)
 		}
 	}
 
+	var offset *int
+	if strings.HasPrefix(opts.ref, "^") {
+		off, err := strconv.Atoi(opts.ref[1:])
+		if err != nil {
+			return errors.Wrapf(err, "invalid offset %q", opts.ref)
+		}
+		offset = &off
+		opts.ref = ""
+	}
+
 	recs, err := queryRecords(ctx, opts.ref, nodes)
 	if err != nil {
 		return err
@@ -185,13 +195,25 @@ func runInspect(ctx context.Context, dockerCli command.Cli, opts inspectOptions)
 		return errors.Errorf("no record found for ref %q", opts.ref)
 	}
 
+	var rec *historyRecord
 	if opts.ref == "" {
 		slices.SortFunc(recs, func(a, b historyRecord) int {
 			return b.CreatedAt.AsTime().Compare(a.CreatedAt.AsTime())
 		})
+		for _, r := range recs {
+			if offset != nil {
+				if *offset > 0 {
+					*offset--
+					continue
+				}
+			}
+			rec = &r
+			break
+		}
+		if offset != nil && *offset > 0 {
+			return errors.Errorf("no completed build found with offset %d", *offset)
+		}
 	}
-
-	rec := &recs[0]
 
 	c, err := rec.node.Driver.Client(ctx)
 	if err != nil {


### PR DESCRIPTION
Allows specifying ref as `^offset` for `buildx history inspect` (default is equivalent to `^0`). Same format was already supported for `history trace`.