### PR TITLE
history: generalize query loading

### DIFF
--- a/commands/history/inspect_attachment.go
+++ b/commands/history/inspect_attachment.go
@@ -3,7 +3,6 @@ package history
 import (
 	"context"
 	"io"
-	"slices"
 
 	"github.com/containerd/containerd/v2/core/content/proxy"
 	"github.com/containerd/platforms"
@@ -42,7 +41,7 @@ func runAttachment(ctx context.Context, dockerCli command.Cli, opts attachmentOp
 		}
 	}
 
-	recs, err := queryRecords(ctx, opts.ref, nodes)
+	recs, err := queryRecords(ctx, opts.ref, nodes, nil)
 	if err != nil {
 		return err
 	}
@@ -52,12 +51,6 @@ func runAttachment(ctx context.Context, dockerCli command.Cli, opts attachmentOp
 			return errors.New("no records found")
 		}
 		return errors.Errorf("no record found for ref %q", opts.ref)
-	}
-
-	if opts.ref == "" {
-		slices.SortFunc(recs, func(a, b historyRecord) int {
-			return b.CreatedAt.AsTime().Compare(a.CreatedAt.AsTime())
-		})
 	}
 
 	rec := &recs[0]

--- a/commands/history/logs.go
+++ b/commands/history/logs.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io"
 	"os"
-	"slices"
 
 	"github.com/docker/buildx/builder"
 	"github.com/docker/buildx/util/cobrautil/completion"
@@ -39,7 +38,7 @@ func runLogs(ctx context.Context, dockerCli command.Cli, opts logsOptions) error
 		}
 	}
 
-	recs, err := queryRecords(ctx, opts.ref, nodes)
+	recs, err := queryRecords(ctx, opts.ref, nodes, nil)
 	if err != nil {
 		return err
 	}
@@ -49,12 +48,6 @@ func runLogs(ctx context.Context, dockerCli command.Cli, opts logsOptions) error
 			return errors.New("no records found")
 		}
 		return errors.Errorf("no record found for ref %q", opts.ref)
-	}
-
-	if opts.ref == "" {
-		slices.SortFunc(recs, func(a, b historyRecord) int {
-			return b.CreatedAt.AsTime().Compare(a.CreatedAt.AsTime())
-		})
 	}
 
 	rec := &recs[0]

--- a/commands/history/ls.go
+++ b/commands/history/ls.go
@@ -56,7 +56,7 @@ func runLs(ctx context.Context, dockerCli command.Cli, opts lsOptions) error {
 		}
 	}
 
-	out, err := queryRecords(ctx, "", nodes)
+	out, err := queryRecords(ctx, "", nodes, nil)
 	if err != nil {
 		return err
 	}

--- a/commands/history/open.go
+++ b/commands/history/open.go
@@ -3,7 +3,6 @@ package history
 import (
 	"context"
 	"fmt"
-	"slices"
 
 	"github.com/docker/buildx/builder"
 	"github.com/docker/buildx/util/cobrautil/completion"
@@ -35,7 +34,7 @@ func runOpen(ctx context.Context, dockerCli command.Cli, opts openOptions) error
 		}
 	}
 
-	recs, err := queryRecords(ctx, opts.ref, nodes)
+	recs, err := queryRecords(ctx, opts.ref, nodes, nil)
 	if err != nil {
 		return err
 	}
@@ -45,12 +44,6 @@ func runOpen(ctx context.Context, dockerCli command.Cli, opts openOptions) error
 			return errors.New("no records found")
 		}
 		return errors.Errorf("no record found for ref %q", opts.ref)
-	}
-
-	if opts.ref == "" {
-		slices.SortFunc(recs, func(a, b historyRecord) int {
-			return b.CreatedAt.AsTime().Compare(a.CreatedAt.AsTime())
-		})
 	}
 
 	rec := &recs[0]


### PR DESCRIPTION
Some commands (logs/open) were still missing offset handling. Now all commands use the same reference parsing/sort.