### PR TITLE
builder: return error if a node fails to boot

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -200,7 +200,7 @@ func (b *Builder) Boot(ctx context.Context) (bool, error) {
 		err = err1
 	}
 
-	if err == nil && len(errCh) == len(toBoot) {
+	if err == nil && len(errCh) > 0 {
 		return false, <-errCh
 	}
 	return true, err


### PR DESCRIPTION
fixes https://github.com/docker/buildx/issues/2730

With https://github.com/docker/buildx/pull/1869 we return an error only if all nodes fail to boot but that's not a correct pattern and we should return an error if any node fails.