### PR TITLE
driver: request gpu when creating container builder

### DIFF
--- a/driver/docker-container/factory.go
+++ b/driver/docker-container/factory.go
@@ -51,6 +51,12 @@ func (f *factory) New(ctx context.Context, cfg driver.InitConfig) (driver.Driver
 		InitConfig:    cfg,
 		restartPolicy: rp,
 	}
+	var gpus dockeropts.GpuOpts
+	if err := gpus.Set("all"); err == nil {
+		if v := gpus.Value(); len(v) > 0 {
+			d.gpus = v
+		}
+	}
 	for k, v := range cfg.DriverOpts {
 		switch {
 		case k == "network":


### PR DESCRIPTION
With CDI support added in BuildKit https://github.com/moby/buildkit/pull/4056, we need to request GPUs when creating a container builder.

This is necessary on WSL for Nvidia GPUs because there is no linux drivers available that we could install in BuildKit container during `OnDemand` setup. Mounting `/usr/lib/wsl` works https://github.com/docker/buildx/compare/master...crazy-max:buildx:driver-ctn-mount-wsl-lib?expand=1 but this is not desired and could be error prone if a remote context/builder is used. So instead we can make a device request when creating the container builder.

Can be tested by creating a BuildKit container with ubuntu base:

```
$ EXPORT_BASE=ubuntu PLATFORMS=linux/amd64,linux/arm64 ./hack/images ubuntu crazymax/buildkit push
```

You can use `crazymax/buildkit:ubuntu` for testing on WSL with Nvidia GPU:

```
$ docker buildx create --name testgpu --bootstrap --driver-opt "image=crazymax/buildkit:ubuntu"
#1 [internal] booting buildkit
#1 pulling image crazymax/buildkit:ubuntu
#1 pulling image crazymax/buildkit:ubuntu 5.3s done
#1 creating container buildx_buildkit_testgpu0
#1 creating container buildx_buildkit_testgpu0 1.9s done
#1 DONE 7.2s
testgpu
```

```
$ docker exec -it buildx_buildkit_testgpu0 nvidia-smi
Thu Mar 13 15:41:39 2025       
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 570.124.06             Driver Version: 572.70         CUDA Version: 12.8     |
|-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA GeForce RTX 3060 Ti     On  |   00000000:2A:00.0  On |                  N/A |
|  0%   55C    P8             23W /  200W |    2955MiB /   8192MiB |     13%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+

+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|    0   N/A  N/A              23      G   /Xwayland                             N/A      |
|    0   N/A  N/A              25      G   /Xwayland                             N/A      |
|    0   N/A  N/A              35      G   /Xwayland                             N/A      |
+-----------------------------------------------------------------------------------------+
```