### PR TITLE
bake: support compose service as build context

### DIFF
--- a/bake/compose.go
+++ b/bake/compose.go
@@ -3,7 +3,6 @@ package bake
 import (
 	"context"
 	"fmt"
-	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -92,7 +91,12 @@ func ParseCompose(cfgs []composetypes.ConfigFile, envs map[string]string) (*Conf
 			var additionalContexts map[string]string
 			if s.Build.AdditionalContexts != nil {
 				additionalContexts = map[string]string{}
-				maps.Copy(additionalContexts, s.Build.AdditionalContexts)
+				for k, v := range s.Build.AdditionalContexts {
+					if strings.HasPrefix(v, "service:") {
+						v = strings.Replace(v, "service:", "target:", 1)
+					}
+					additionalContexts[k] = v
+				}
 			}
 
 			var shmSize *string


### PR DESCRIPTION
fixes https://github.com/docker/buildx/issues/3074

The result of one target as a build context of another is supported with bake hcl/json definitions using `target:` prefix: https://docs.docker.com/build/bake/contexts/#using-a-target-as-a-build-context

But not directly with compose syntax where the target is defined as service using `service:` prefix: https://docs.docker.com/reference/compose-file/build/#additional_contexts