### PR TITLE
bake: fix platforms field in compose yaml

### DIFF
--- a/bake/compose.go
+++ b/bake/compose.go
@@ -177,6 +177,7 @@ func ParseCompose(cfgs []composetypes.ConfigFile, envs map[string]string) (*Conf
 				CacheFrom:   cacheFrom,
 				CacheTo:     cacheTo,
 				NetworkMode: networkModeP,
+				Platforms:   s.Build.Platforms,
 				SSH:         ssh,
 				Secrets:     secrets,
 				ShmSize:     shmSize,

--- a/bake/compose_test.go
+++ b/bake/compose_test.go
@@ -463,6 +463,21 @@ services:
 	require.NoError(t, err)
 }
 
+func TestPlatforms(t *testing.T) {
+	dt := []byte(`
+services:
+  foo:
+    build:
+      context: .
+      platforms:
+        - linux/amd64
+        - linux/arm64
+`)
+	c, err := ParseCompose([]composetypes.ConfigFile{{Content: dt}}, nil)
+	require.NoError(t, err)
+	require.Equal(t, []string{"linux/amd64", "linux/arm64"}, c.Targets[0].Platforms)
+}
+
 func newBool(val bool) *bool {
 	b := val
 	return &b


### PR DESCRIPTION
fix #3086

Another example of `x-bake` field becoming native field but implemented via JSON conversion or API wrapper in compose instead of native support in `bake`.