### PR TITLE
avoid import to testing helpers outside of tests

### DIFF
--- a/build/git_test.go
+++ b/build/git_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/docker/buildx/util/gitutil"
+	"github.com/docker/buildx/util/gitutil/gittestutil"
 	"github.com/moby/buildkit/client"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
@@ -16,18 +17,18 @@ import (
 )
 
 func setupTest(tb testing.TB) {
-	gitutil.Mktmp(tb)
+	gittestutil.Mktmp(tb)
 
 	c, err := gitutil.New()
 	require.NoError(tb, err)
-	gitutil.GitInit(c, tb)
+	gittestutil.GitInit(c, tb)
 
 	df := []byte("FROM alpine:latest\n")
 	require.NoError(tb, os.WriteFile("Dockerfile", df, 0644))
 
-	gitutil.GitAdd(c, tb, "Dockerfile")
-	gitutil.GitCommit(c, tb, "initial commit")
-	gitutil.GitSetRemote(c, tb, "origin", "git@github.com:docker/buildx.git")
+	gittestutil.GitAdd(c, tb, "Dockerfile")
+	gittestutil.GitCommit(c, tb, "initial commit")
+	gittestutil.GitSetRemote(c, tb, "origin", "git@github.com:docker/buildx.git")
 }
 
 func TestGetGitAttributesNotGitRepo(t *testing.T) {
@@ -188,19 +189,19 @@ func TestLocalDirs(t *testing.T) {
 }
 
 func TestLocalDirsSub(t *testing.T) {
-	gitutil.Mktmp(t)
+	gittestutil.Mktmp(t)
 
 	c, err := gitutil.New()
 	require.NoError(t, err)
-	gitutil.GitInit(c, t)
+	gittestutil.GitInit(c, t)
 
 	df := []byte("FROM alpine:latest\n")
 	require.NoError(t, os.MkdirAll("app", 0755))
 	require.NoError(t, os.WriteFile("app/Dockerfile", df, 0644))
 
-	gitutil.GitAdd(c, t, "app/Dockerfile")
-	gitutil.GitCommit(c, t, "initial commit")
-	gitutil.GitSetRemote(c, t, "origin", "git@github.com:docker/buildx.git")
+	gittestutil.GitAdd(c, t, "app/Dockerfile")
+	gittestutil.GitCommit(c, t, "initial commit")
+	gittestutil.GitSetRemote(c, t, "origin", "git@github.com:docker/buildx.git")
 
 	so := &client.SolveOpt{
 		FrontendAttrs: map[string]string{},

--- a/tests/bake.go
+++ b/tests/bake.go
@@ -17,6 +17,7 @@ import (
 	"github.com/containerd/continuity/fs/fstest"
 	"github.com/docker/buildx/bake"
 	"github.com/docker/buildx/util/gitutil"
+	"github.com/docker/buildx/util/gitutil/gittestutil"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/frontend/subrequests/lint"
 	"github.com/moby/buildkit/identity"
@@ -415,10 +416,10 @@ EOT
 	git, err := gitutil.New(gitutil.WithWorkingDir(dir))
 	require.NoError(t, err)
 
-	gitutil.GitInit(git, t)
-	gitutil.GitAdd(git, t, "docker-bake.hcl", "foo")
-	gitutil.GitCommit(git, t, "initial commit")
-	addr := gitutil.GitServeHTTP(git, t)
+	gittestutil.GitInit(git, t)
+	gittestutil.GitAdd(git, t, "docker-bake.hcl", "foo")
+	gittestutil.GitCommit(git, t, "initial commit")
+	addr := gittestutil.GitServeHTTP(git, t)
 
 	out, err := bakeCmd(sb, withDir(dir), withArgs(addr, "--set", "*.output=type=local,dest="+dirDest))
 	require.NoError(t, err, out)
@@ -445,12 +446,12 @@ EOT
 	git, err := gitutil.New(gitutil.WithWorkingDir(dir))
 	require.NoError(t, err)
 
-	gitutil.GitInit(git, t)
-	gitutil.GitAdd(git, t, "docker-bake.hcl", "foo")
-	gitutil.GitCommit(git, t, "initial commit")
+	gittestutil.GitInit(git, t)
+	gittestutil.GitAdd(git, t, "docker-bake.hcl", "foo")
+	gittestutil.GitCommit(git, t, "initial commit")
 
 	token := identity.NewID()
-	addr := gitutil.GitServeHTTP(git, t, gitutil.WithAccessToken(token))
+	addr := gittestutil.GitServeHTTP(git, t, gittestutil.WithAccessToken(token))
 
 	out, err := bakeCmd(sb, withDir(dir),
 		withEnv("BUILDX_BAKE_GIT_AUTH_TOKEN="+token),
@@ -492,10 +493,10 @@ EOT
 	git, err := gitutil.New(gitutil.WithWorkingDir(dirSpec))
 	require.NoError(t, err)
 
-	gitutil.GitInit(git, t)
-	gitutil.GitAdd(git, t, "docker-bake.hcl", "bar")
-	gitutil.GitCommit(git, t, "initial commit")
-	addr := gitutil.GitServeHTTP(git, t)
+	gittestutil.GitInit(git, t)
+	gittestutil.GitAdd(git, t, "docker-bake.hcl", "bar")
+	gittestutil.GitCommit(git, t, "initial commit")
+	addr := gittestutil.GitServeHTTP(git, t)
 
 	out, err := bakeCmd(sb, withDir(dirSrc), withArgs(addr, "--file", "cwd://local-docker-bake.hcl", "--set", "*.output=type=local,dest="+dirDest))
 	require.NoError(t, err, out)
@@ -561,10 +562,10 @@ EOT
 	git, err := gitutil.New(gitutil.WithWorkingDir(dirSpec))
 	require.NoError(t, err)
 
-	gitutil.GitInit(git, t)
-	gitutil.GitAdd(git, t, "docker-bake.hcl")
-	gitutil.GitCommit(git, t, "initial commit")
-	addr := gitutil.GitServeHTTP(git, t)
+	gittestutil.GitInit(git, t)
+	gittestutil.GitAdd(git, t, "docker-bake.hcl")
+	gittestutil.GitCommit(git, t, "initial commit")
+	addr := gittestutil.GitServeHTTP(git, t)
 
 	out, err := bakeCmd(sb, withDir(dirSrc), withArgs(addr, "--set", "*.output=type=local,dest="+dirDest))
 	require.NoError(t, err, out)
@@ -594,17 +595,17 @@ EOT
 
 	gitSpec, err := gitutil.New(gitutil.WithWorkingDir(dirSpec))
 	require.NoError(t, err)
-	gitutil.GitInit(gitSpec, t)
-	gitutil.GitAdd(gitSpec, t, "docker-bake.hcl")
-	gitutil.GitCommit(gitSpec, t, "initial commit")
-	addrSpec := gitutil.GitServeHTTP(gitSpec, t)
+	gittestutil.GitInit(gitSpec, t)
+	gittestutil.GitAdd(gitSpec, t, "docker-bake.hcl")
+	gittestutil.GitCommit(gitSpec, t, "initial commit")
+	addrSpec := gittestutil.GitServeHTTP(gitSpec, t)
 
 	gitSrc, err := gitutil.New(gitutil.WithWorkingDir(dirSrc))
 	require.NoError(t, err)
-	gitutil.GitInit(gitSrc, t)
-	gitutil.GitAdd(gitSrc, t, "foo")
-	gitutil.GitCommit(gitSrc, t, "initial commit")
-	addrSrc := gitutil.GitServeHTTP(gitSrc, t)
+	gittestutil.GitInit(gitSrc, t)
+	gittestutil.GitAdd(gitSrc, t, "foo")
+	gittestutil.GitCommit(gitSrc, t, "initial commit")
+	addrSrc := gittestutil.GitServeHTTP(gitSrc, t)
 
 	out, err := bakeCmd(sb, withDir("/tmp"), withArgs(addrSpec, addrSrc, "--set", "*.output=type=local,dest="+dirDest))
 	require.NoError(t, err, out)
@@ -635,10 +636,10 @@ COPY super-cool.txt /
 
 	git, err := gitutil.New(gitutil.WithWorkingDir(dir))
 	require.NoError(t, err)
-	gitutil.GitInit(git, t)
-	gitutil.GitAdd(git, t, "docker-bake.hcl", "bar")
-	gitutil.GitCommit(git, t, "initial commit")
-	addr := gitutil.GitServeHTTP(git, t)
+	gittestutil.GitInit(git, t)
+	gittestutil.GitAdd(git, t, "docker-bake.hcl", "bar")
+	gittestutil.GitCommit(git, t, "initial commit")
+	addr := gittestutil.GitServeHTTP(git, t)
 
 	out, err := bakeCmd(sb, withDir("/tmp"), withArgs(addr, "--set", "*.output=type=local,dest="+dirDest))
 	require.NoError(t, err, out)
@@ -676,10 +677,10 @@ EOT
 	git, err := gitutil.New(gitutil.WithWorkingDir(dirSpec))
 	require.NoError(t, err)
 
-	gitutil.GitInit(git, t)
-	gitutil.GitAdd(git, t, "docker-bake.hcl")
-	gitutil.GitCommit(git, t, "initial commit")
-	addr := gitutil.GitServeHTTP(git, t)
+	gittestutil.GitInit(git, t)
+	gittestutil.GitAdd(git, t, "docker-bake.hcl")
+	gittestutil.GitCommit(git, t, "initial commit")
+	addr := gittestutil.GitServeHTTP(git, t)
 
 	out, err := bakeCmd(
 		sb,
@@ -724,10 +725,10 @@ EOT
 	git, err := gitutil.New(gitutil.WithWorkingDir(dirSpec))
 	require.NoError(t, err)
 
-	gitutil.GitInit(git, t)
-	gitutil.GitAdd(git, t, "docker-bake.hcl")
-	gitutil.GitCommit(git, t, "initial commit")
-	addr := gitutil.GitServeHTTP(git, t)
+	gittestutil.GitInit(git, t)
+	gittestutil.GitAdd(git, t, "docker-bake.hcl")
+	gittestutil.GitCommit(git, t, "initial commit")
+	addr := gittestutil.GitServeHTTP(git, t)
 
 	out, err := bakeCmd(
 		sb,
@@ -780,13 +781,13 @@ COPY foo /foo
 	git, err := gitutil.New(gitutil.WithWorkingDir(dirSpec))
 	require.NoError(t, err)
 
-	gitutil.GitInit(git, t)
-	gitutil.GitAdd(git, t, "docker-bake.hcl")
-	gitutil.GitAdd(git, t, "Dockerfile")
-	gitutil.GitAdd(git, t, "foo")
-	gitutil.GitAdd(git, t, "bar")
-	gitutil.GitCommit(git, t, "initial commit")
-	addr := gitutil.GitServeHTTP(git, t)
+	gittestutil.GitInit(git, t)
+	gittestutil.GitAdd(git, t, "docker-bake.hcl")
+	gittestutil.GitAdd(git, t, "Dockerfile")
+	gittestutil.GitAdd(git, t, "foo")
+	gittestutil.GitAdd(git, t, "bar")
+	gittestutil.GitCommit(git, t, "initial commit")
+	addr := gittestutil.GitServeHTTP(git, t)
 
 	out, err := bakeCmd(
 		sb,
@@ -832,10 +833,10 @@ COPY foo /foo
 	git, err := gitutil.New(gitutil.WithWorkingDir(dirSpec))
 	require.NoError(t, err)
 
-	gitutil.GitInit(git, t)
-	gitutil.GitAdd(git, t, "docker-bake.hcl")
-	gitutil.GitCommit(git, t, "initial commit")
-	addr := gitutil.GitServeHTTP(git, t)
+	gittestutil.GitInit(git, t)
+	gittestutil.GitAdd(git, t, "docker-bake.hcl")
+	gittestutil.GitCommit(git, t, "initial commit")
+	addr := gittestutil.GitServeHTTP(git, t)
 
 	out, err := bakeCmd(
 		sb,

--- a/tests/build.go
+++ b/tests/build.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/buildx/localstate"
 	"github.com/docker/buildx/util/confutil"
 	"github.com/docker/buildx/util/gitutil"
+	"github.com/docker/buildx/util/gitutil/gittestutil"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/frontend/subrequests/lint"
 	"github.com/moby/buildkit/frontend/subrequests/outline"
@@ -126,10 +127,10 @@ COPY foo /foo
 	git, err := gitutil.New(gitutil.WithWorkingDir(dir))
 	require.NoError(t, err)
 
-	gitutil.GitInit(git, t)
-	gitutil.GitAdd(git, t, "Dockerfile", "foo")
-	gitutil.GitCommit(git, t, "initial commit")
-	addr := gitutil.GitServeHTTP(git, t)
+	gittestutil.GitInit(git, t)
+	gittestutil.GitAdd(git, t, "Dockerfile", "foo")
+	gittestutil.GitCommit(git, t, "initial commit")
+	addr := gittestutil.GitServeHTTP(git, t)
 
 	out, err := buildCmd(sb, withDir(dir), withArgs("--output=type=local,dest="+dirDest, addr))
 	require.NoError(t, err, out)
@@ -238,10 +239,10 @@ COPY foo /foo
 	git, err := gitutil.New(gitutil.WithWorkingDir(dir))
 	require.NoError(t, err)
 
-	gitutil.GitInit(git, t)
-	gitutil.GitAdd(git, t, "build.Dockerfile", "foo")
-	gitutil.GitCommit(git, t, "initial commit")
-	addr := gitutil.GitServeHTTP(git, t)
+	gittestutil.GitInit(git, t)
+	gittestutil.GitAdd(git, t, "build.Dockerfile", "foo")
+	gittestutil.GitCommit(git, t, "initial commit")
+	addr := gittestutil.GitServeHTTP(git, t)
 
 	out, err := buildCmd(sb, withDir(dir), withArgs(
 		"-f", "build.Dockerfile",

--- a/util/gitutil/credentials_test.go
+++ b/util/gitutil/credentials_test.go
@@ -1,0 +1,45 @@
+package gitutil
+
+import "testing"
+
+func TestStripCredentials(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "non-blank Password",
+			url:  "https://user:password@host.tld/this:that",
+			want: "https://host.tld/this:that",
+		},
+		{
+			name: "blank Password",
+			url:  "https://user@host.tld/this:that",
+			want: "https://host.tld/this:that",
+		},
+		{
+			name: "blank Username",
+			url:  "https://:password@host.tld/this:that",
+			want: "https://host.tld/this:that",
+		},
+		{
+			name: "blank Username, blank Password",
+			url:  "https://host.tld/this:that",
+			want: "https://host.tld/this:that",
+		},
+		{
+			name: "invalid URL",
+			url:  "1https://foo.com",
+			want: "1https://foo.com",
+		},
+	}
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			if g, w := stripCredentials(tt.url), tt.want; g != w {
+				t.Fatalf("got: %q\nwant: %q", g, w)
+			}
+		})
+	}
+}

--- a/util/gitutil/gittestutil/testutil.go
+++ b/util/gitutil/gittestutil/testutil.go
@@ -1,14 +1,15 @@
-package gitutil
+package gittestutil
 
 import (
 	"os"
 	"strings"
 	"testing"
 
+	"github.com/docker/buildx/util/gitutil"
 	"github.com/stretchr/testify/require"
 )
 
-func GitInit(c *Git, tb testing.TB) {
+func GitInit(c *gitutil.Git, tb testing.TB) {
 	tb.Helper()
 	out, err := fakeGit(c, "init")
 	require.NoError(tb, err)
@@ -18,41 +19,41 @@ func GitInit(c *Git, tb testing.TB) {
 	_, _ = fakeGit(c, "branch", "-D", "master")
 }
 
-func GitCommit(c *Git, tb testing.TB, msg string) {
+func GitCommit(c *gitutil.Git, tb testing.TB, msg string) {
 	tb.Helper()
 	out, err := fakeGit(c, "commit", "--allow-empty", "-m", msg)
 	require.NoError(tb, err)
 	require.Contains(tb, out, "main", msg)
 }
 
-func GitTag(c *Git, tb testing.TB, tag string) {
+func GitTag(c *gitutil.Git, tb testing.TB, tag string) {
 	tb.Helper()
 	out, err := fakeGit(c, "tag", tag)
 	require.NoError(tb, err)
 	require.Empty(tb, out)
 }
 
-func GitCheckoutBranch(c *Git, tb testing.TB, name string) {
+func GitCheckoutBranch(c *gitutil.Git, tb testing.TB, name string) {
 	tb.Helper()
 	out, err := fakeGit(c, "checkout", "-b", name)
 	require.NoError(tb, err)
 	require.Empty(tb, out)
 }
 
-func GitAdd(c *Git, tb testing.TB, files ...string) {
+func GitAdd(c *gitutil.Git, tb testing.TB, files ...string) {
 	tb.Helper()
 	args := append([]string{"add"}, files...)
 	_, err := fakeGit(c, args...)
 	require.NoError(tb, err)
 }
 
-func GitSetRemote(c *Git, tb testing.TB, name string, url string) {
+func GitSetRemote(c *gitutil.Git, tb testing.TB, name string, url string) {
 	tb.Helper()
 	_, err := fakeGit(c, "remote", "add", name, url)
 	require.NoError(tb, err)
 }
 
-func GitSetMainUpstream(c *Git, tb testing.TB, remote, target string) {
+func GitSetMainUpstream(c *gitutil.Git, tb testing.TB, remote, target string) {
 	tb.Helper()
 	_, err := fakeGit(c, "fetch", "--depth", "1", remote, target)
 	require.NoError(tb, err)
@@ -73,7 +74,7 @@ func Mktmp(tb testing.TB) string {
 	return folder
 }
 
-func fakeGit(c *Git, args ...string) (string, error) {
+func fakeGit(c *gitutil.Git, args ...string) (string, error) {
 	allArgs := []string{
 		"-c", "user.name=buildx",
 		"-c", "user.email=buildx@docker.com",
@@ -82,7 +83,7 @@ func fakeGit(c *Git, args ...string) (string, error) {
 		"-c", "log.showSignature=false",
 	}
 	allArgs = append(allArgs, args...)
-	return c.clean(c.run(allArgs...))
+	return c.Run(allArgs...)
 }
 
 func IsAmbiguousArgument(err error) bool {

--- a/util/gitutil/gittestutil/testutilserve.go
+++ b/util/gitutil/gittestutil/testutilserve.go
@@ -1,4 +1,4 @@
-package gitutil
+package gittestutil
 
 import (
 	"context"
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/docker/buildx/util/gitutil"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -23,7 +24,7 @@ func WithAccessToken(token string) GitServeOpt {
 	}
 }
 
-func GitServeHTTP(c *Git, t testing.TB, opts ...GitServeOpt) (url string) {
+func GitServeHTTP(c *gitutil.Git, t testing.TB, opts ...GitServeOpt) (url string) {
 	t.Helper()
 	gitUpdateServerInfo(c, t)
 	ctx, cancel := context.WithCancelCause(context.TODO())
@@ -91,7 +92,7 @@ func GitServeHTTP(c *Git, t testing.TB, opts ...GitServeOpt) (url string) {
 	return fmt.Sprintf("http://%s/%s", addr, name)
 }
 
-func gitUpdateServerInfo(c *Git, tb testing.TB) {
+func gitUpdateServerInfo(c *gitutil.Git, tb testing.TB) {
 	tb.Helper()
 	_, err := fakeGit(c, "update-server-info")
 	require.NoError(tb, err)

--- a/util/gitutil/gitutil.go
+++ b/util/gitutil/gitutil.go
@@ -57,17 +57,17 @@ func New(opts ...Option) (*Git, error) {
 }
 
 func (c *Git) IsInsideWorkTree() bool {
-	out, err := c.clean(c.run("rev-parse", "--is-inside-work-tree"))
+	out, err := c.Run("rev-parse", "--is-inside-work-tree")
 	return out == "true" && err == nil
 }
 
 func (c *Git) IsDirty() bool {
-	out, err := c.run("status", "--porcelain", "--ignored")
+	out, err := c.Run("status", "--porcelain", "--ignored")
 	return strings.TrimSpace(out) != "" || err != nil
 }
 
 func (c *Git) RootDir() (string, error) {
-	root, err := c.clean(c.run("rev-parse", "--show-toplevel"))
+	root, err := c.Run("rev-parse", "--show-toplevel")
 	if err != nil {
 		return "", err
 	}
@@ -127,6 +127,10 @@ func (c *Git) Tag() (string, error) {
 	return tag, err
 }
 
+func (c *Git) Run(args ...string) (string, error) {
+	return c.clean(c.run(args...))
+}
+
 func (c *Git) run(args ...string) (string, error) {
 	var extraArgs = []string{
 		"-c", "log.showSignature=false",
@@ -161,7 +165,7 @@ func (c *Git) clean(out string, err error) (string, error) {
 }
 
 func (c *Git) currentRemote() (string, error) {
-	symref, err := c.clean(c.run("symbolic-ref", "-q", "HEAD"))
+	symref, err := c.Run("symbolic-ref", "-q", "HEAD")
 	if err != nil {
 		return "", err
 	}
@@ -169,7 +173,7 @@ func (c *Git) currentRemote() (string, error) {
 		return "", nil
 	}
 	// git for-each-ref --format='%(upstream:remotename)'
-	remote, err := c.clean(c.run("for-each-ref", "--format=%(upstream:remotename)", symref))
+	remote, err := c.Run("for-each-ref", "--format=%(upstream:remotename)", symref)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
These utilities should not be included in the main build.

This only has a minimal 2.5KB binary size difference atm as there is still import to "testing" via containerd libs atm https://github.com/containerd/containerd/pull/11666 . Removing that one releases more.