### PR TITLE
command: runBuild, runBake: remove uses of DockerCLI.MeterProvider

### DIFF
--- a/commands/bake.go
+++ b/commands/bake.go
@@ -38,6 +38,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/tonistiigi/go-csvvalue"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 )
 
@@ -64,7 +65,7 @@ type bakeOptions struct {
 }
 
 func runBake(ctx context.Context, dockerCli command.Cli, targets []string, in bakeOptions, cFlags commonFlags) (err error) {
-	mp := dockerCli.MeterProvider()
+	mp := otel.GetMeterProvider()
 
 	ctx, end, err := tracing.TraceCurrentCommand(ctx, append([]string{"bake"}, targets...),
 		attribute.String("builder", in.builder),

--- a/commands/build.go
+++ b/commands/build.go
@@ -59,6 +59,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/tonistiigi/go-csvvalue"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"google.golang.org/grpc/codes"
@@ -284,7 +285,7 @@ func (o *buildOptionsHash) String() string {
 }
 
 func runBuild(ctx context.Context, dockerCli command.Cli, options buildOptions) (err error) {
-	mp := dockerCli.MeterProvider()
+	mp := otel.GetMeterProvider()
 
 	ctx, end, err := tracing.TraceCurrentCommand(ctx, []string{"build", options.contextPath},
 		attribute.String("builder", options.builder),


### PR DESCRIPTION
- relates to https://github.com/docker/cli/commit/02537eac596a6e1bab435c8d2445603990445678 / https://github.com/docker/cli/pull/5067


The [DockerCli.MeterProvider] (and [DockerCli.TracerProvider]) methods have no direct connection with the CLI itself and are wrappers for `otel.GetMeterProvider()` and `otel.GetTracerProvider()`.

Remove the use of the CLI method, and use the otel functions directly.

[DockerCli.MeterProvider]: https://github.com/docker/cli/blob/91cbde67c509c8702417ee1cd64cd5d845ccd254/cli/command/telemetry.go#L62-L64
[DockerCli.TracerProvider]: https://github.com/docker/cli/blob/91cbde67c509c8702417ee1cd64cd5d845ccd254/cli/command/telemetry.go#L58-L60