### PR TITLE
Output correct image ID when using Docker with the containerd snapshotter

### DIFF
--- a/driver/docker-container/driver.go
+++ b/driver/docker-container/driver.go
@@ -63,6 +63,20 @@ func (d *Driver) IsMobyDriver() bool {
 	return false
 }
 
+func (d *Driver) UsesContainerdSnapshotter(ctx context.Context) bool {
+	var containerdSnapshotter bool
+	if c, err := d.Client(ctx); err == nil {
+		workers, _ := c.ListWorkers(ctx)
+		for _, w := range workers {
+			if _, ok := w.Labels["org.mobyproject.buildkit.worker.snapshotter"]; ok {
+				containerdSnapshotter = true
+			}
+		}
+		c.Close()
+	}
+	return containerdSnapshotter
+}
+
 func (d *Driver) Config() driver.InitConfig {
 	return d.InitConfig
 }

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -74,6 +74,7 @@ type Driver interface {
 	Features(ctx context.Context) map[Feature]bool
 	HostGatewayIP(ctx context.Context) (net.IP, error)
 	IsMobyDriver() bool
+	UsesContainerdSnapshotter(ctx context.Context) bool
 	Config() InitConfig
 }
 

--- a/driver/kubernetes/driver.go
+++ b/driver/kubernetes/driver.go
@@ -59,6 +59,10 @@ func (d *Driver) IsMobyDriver() bool {
 	return false
 }
 
+func (d *Driver) UsesContainerdSnapshotter(ctx context.Context) bool {
+	return false
+}
+
 func (d *Driver) Config() driver.InitConfig {
 	return d.InitConfig
 }

--- a/driver/remote/driver.go
+++ b/driver/remote/driver.go
@@ -181,6 +181,10 @@ func (d *Driver) IsMobyDriver() bool {
 	return false
 }
 
+func (d *Driver) UsesContainerdSnapshotter(ctx context.Context) bool {
+	return false
+}
+
 func (d *Driver) Config() driver.InitConfig {
 	return d.InitConfig
 }

--- a/tests/build.go
+++ b/tests/build.go
@@ -399,18 +399,9 @@ func testImageIDOutput(t *testing.T, sb integration.Sandbox) {
 
 	require.Equal(t, dgst.String(), strings.TrimSpace(stdout.String()))
 
-	dt, err = os.ReadFile(filepath.Join(targetDir, "md.json"))
-	require.NoError(t, err)
-
-	type mdT struct {
-		ConfigDigest string `json:"containerimage.config.digest"`
-	}
-	var md mdT
-	err = json.Unmarshal(dt, &md)
-	require.NoError(t, err)
-
-	require.NotEmpty(t, md.ConfigDigest)
-	require.Equal(t, dgst, digest.Digest(md.ConfigDigest))
+	// verify the image ID is the correct one
+	cmd = dockerCmd(sb, withArgs("run", imageID))
+	require.NoError(t, cmd.Run())
 }
 
 func testBuildMobyFromLocalImage(t *testing.T, sb integration.Sandbox) {


### PR DESCRIPTION
Prior to this change, the following command emits the wrong image ID when using the "docker" driver and Docker is configured with the containerd snapshotter.

```
$ docker buildx build --load --iidfile=img.txt

$ docker run --rm "$(cat img.txt)" echo hello
docker: Error response from daemon: No such image: sha256:4ac37e81e00f242010e42f3251094e47de6100e01d25e9bd0feac6b8906976df. See 'docker run --help'.
```

The problem is that buildx is outputing the incorrect image ID in this scenario (it's outputing the container image config digest, instead of the container image digest, and the latter is needed to run the image with containerd).

This change fixes this.

See https://github.com/moby/moby/issues/45458.