### PR TITLE
use filepath.IsAbs to support windows paths

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -1360,8 +1360,8 @@ func toBuildOpt(t *Target, inp *Input) (*build.Options, error) {
 	if strings.HasPrefix(bi.ContextPath, "cwd://") {
 		bi.ContextPath = path.Clean(strings.TrimPrefix(bi.ContextPath, "cwd://"))
 	}
-	if !build.IsRemoteURL(bi.ContextPath) && bi.ContextState == nil && !path.IsAbs(bi.DockerfilePath) {
-		bi.DockerfilePath = path.Join(bi.ContextPath, bi.DockerfilePath)
+	if !build.IsRemoteURL(bi.ContextPath) && bi.ContextState == nil && !filepath.IsAbs(bi.DockerfilePath) {
+		bi.DockerfilePath = filepath.Join(bi.ContextPath, bi.DockerfilePath)
 	}
 	for k, v := range bi.NamedContexts {
 		if strings.HasPrefix(v.Path, "cwd://") {

--- a/bake/bake_test.go
+++ b/bake/bake_test.go
@@ -692,7 +692,7 @@ func TestHCLContextCwdPrefix(t *testing.T) {
 	require.Contains(t, m, "app")
 	assert.Equal(t, "test", *m["app"].Dockerfile)
 	assert.Equal(t, "foo", *m["app"].Context)
-	assert.Equal(t, "foo/test", bo["app"].Inputs.DockerfilePath)
+	assert.Equal(t, filepath.Clean("foo/test"), bo["app"].Inputs.DockerfilePath)
 	assert.Equal(t, "foo", bo["app"].Inputs.ContextPath)
 }
 


### PR DESCRIPTION
`path.IsAbs` assumes Unix paths, prefer filepath so an absolute windows paths is well identified

fixes https://github.com/docker/compose/issues/12669