### PR TITLE
ci: fix bin-image job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -424,6 +424,9 @@ jobs:
           large-packages: true
           swap-storage: true
       -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       -
@@ -456,9 +459,10 @@ jobs:
         name: Build and push image
         uses: docker/bake-action@v6
         with:
+          source: .
           files: |
             ./docker-bake.hcl
-            cwd://${{ steps.meta.outputs.bake-file }}
+            ${{ steps.meta.outputs.bake-file }}
           targets: image-cross
           push: ${{ github.event_name != 'pull_request' }}
           sbom: true


### PR DESCRIPTION
relates to https://github.com/docker/actions-toolkit/pull/677#issuecomment-2826750069

Switch from git context to path context for bin-image job to fix buildx version. We can get back to git context when https://github.com/moby/buildkit/pull/5903 is released and necessary changes made in actions-toolkit.