### PR TITLE
Add BUILDKIT_SYNTAX option handling

### DIFF
--- a/build/opt.go
+++ b/build/opt.go
@@ -109,6 +109,11 @@ func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt *O
 		so.FrontendAttrs["cgroup-parent"] = opt.CgroupParent
 	}
 
+	if v, ok := opt.BuildArgs["BUILDKIT_SYNTAX"]; ok {
+		so.Frontend = "gateway.v0"
+		so.FrontendAttrs["source"] = v
+	}
+
 	if v, ok := opt.BuildArgs["BUILDKIT_MULTI_PLATFORM"]; ok {
 		if v, _ := strconv.ParseBool(v); v {
 			so.FrontendAttrs["multi-platform"] = "true"


### PR DESCRIPTION
This fix allows building with a remote builder where frontend.dockerfile.v0 enabled = false in the buildkitd yaml file.

Note that this change only allows the usage of BUILDKIT_SYNTAX with a custom frontend image, and using the #syntax directive in this case will still fail.

Resolves: docker#3077