### PR TITLE
Allow variables to be explicitly typed (and enforced)

### DIFF
--- a/bake/hcl_test.go
+++ b/bake/hcl_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"runtime"
 	"testing"
 
 	hcl "github.com/hashicorp/hcl/v2"
@@ -2306,6 +2307,9 @@ func TestJSONOverridePriority(t *testing.T) {
 	})
 
 	t.Run("JSON override works with lowercase vars", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("Windows case-insensitivity")
+		}
 		dt := []byte(`
             variable "foo" {
                 type = number
@@ -2316,7 +2320,7 @@ func TestJSONOverridePriority(t *testing.T) {
                     bar = foo
                 }
             }`)
-		// may seem reasonable, but not supported
+		// may seem reasonable, but not supported (on case-sensitive systems)
 		t.Setenv("foo_json", "9000")
 		c, err := ParseFile(dt, "docker-bake.hcl")
 		require.NoError(t, err)

--- a/bake/hclparser/hclparser.go
+++ b/bake/hclparser/hclparser.go
@@ -373,6 +373,8 @@ func (p *parser) resolveValue(ectx *hcl.EvalContext, name string) (err error) {
 func (p *parser) valueHasOverride(name string, favorJSON bool) (string, bool, bool) {
 	jsonEnv := false
 	envv, hasEnv := p.opt.LookupVar(name)
+	// If no plain override exists (!hasEnv) or JSON overrides are explicitly favored (favorJSON),
+	// check for a JSON-specific override with the "_JSON" suffix.
 	if !hasEnv || favorJSON {
 		jsonVarName := name + jsonEnvOverrideSuffix
 		_, builtin := p.opt.Vars[jsonVarName]
@@ -1086,7 +1088,7 @@ func valueFromCSV(name, value string, target cty.Type) (cty.Value, error) {
 		for _, f := range fields {
 			kvSlice, err = p.Fields(f, kvSlice)
 			if err != nil {
-				return cty.NilVal, errors.Wrapf(err, "failed to parse %s as k/v", f)
+				return cty.NilVal, errors.Wrapf(err, "failed to parse %s as k/v for variable %s", f, name)
 			}
 			if len(kvSlice) != 2 {
 				return cty.NilVal, errors.Errorf("expected one k/v pair but got %d pieces from %s", len(kvSlice), f)

--- a/bake/hclparser/hclparser.go
+++ b/bake/hclparser/hclparser.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/ext/typeexpr"
 	"github.com/pkg/errors"
+	"github.com/tonistiigi/go-csvvalue"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/convert"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
@@ -325,6 +326,16 @@ func (p *parser) resolveValue(ectx *hcl.EvalContext, name string) (err error) {
 		switch {
 		case varType.Equals(cty.String): // don't parse as JSON; users don't expect to have to quote strings
 			vv = cty.StringVal(envv)
+		case varType.IsListType(), varType.IsSetType(), varType.IsTupleType(), varType.IsMapType(): // typing explicitly specified
+			// since CSV is being treated as the officially supported way, throw away (for now) any JSON errors
+			// in favor of CSV behavior and leave it the user to figure it out if they intended JSON
+			vv, err = ctyjson.Unmarshal([]byte(envv), varType)
+			if err != nil {
+				vv, err = valueFromCSV(name, envv, varType)
+				if err != nil {
+					return errors.Wrapf(err, "failed to convert variable %s", name)
+				}
+			}
 		case !varType.Equals(cty.DynamicPseudoType): // typing was explicitly specified
 			vv, err = ctyjson.Unmarshal([]byte(envv), varType)
 			if err != nil {
@@ -332,23 +343,13 @@ func (p *parser) resolveValue(ectx *hcl.EvalContext, name string) (err error) {
 			}
 		case def == nil: // no default from which to infer typing
 			vv = cty.StringVal(envv)
-		case vv.Type().Equals(cty.Bool):
-			b, err := strconv.ParseBool(envv)
-			if err != nil {
-				return errors.Wrapf(err, "failed to parse %s as bool", name)
-			}
-			vv = cty.BoolVal(b)
-		case vv.Type().Equals(cty.String), vv.Type().Equals(cty.DynamicPseudoType):
+		case vv.Type().Equals(cty.DynamicPseudoType):
 			vv = cty.StringVal(envv)
-		case vv.Type().Equals(cty.Number):
-			n, err := strconv.ParseFloat(envv, 64)
-			if err == nil && (math.IsNaN(n) || math.IsInf(n, 0)) {
-				err = errors.Errorf("invalid number value")
-			}
+		case vv.Type().Equals(cty.Bool), vv.Type().Equals(cty.String), vv.Type().Equals(cty.Number):
+			vv, err = convertPrimitive(name, envv, vv.Type())
 			if err != nil {
-				return errors.Wrapf(err, "failed to parse %s as number", name)
+				return err
 			}
-			vv = cty.NumberVal(big.NewFloat(n))
 		default:
 			return errors.Errorf("unsupported type %s for variable %s", vv.Type().FriendlyName(), name)
 		}
@@ -954,6 +955,119 @@ func typeConstraint(expr hcl.Expression) (cty.Type, hcl.Diagnostics) {
 	}
 	// even if the evaluation resulted in error, the original (error) diagnostics are likely more useful
 	return t, diag
+}
+
+// convertPrimitive converts a single string primitive value to a given cty.Type.
+func convertPrimitive(name, value string, target cty.Type) (cty.Value, error) {
+	switch {
+	case target.Equals(cty.String):
+		return cty.StringVal(value), nil
+	case target.Equals(cty.Bool):
+		b, err := strconv.ParseBool(value)
+		if err != nil {
+			return cty.NilVal, errors.Wrapf(err, "failed to parse %s as bool", name)
+		}
+		return cty.BoolVal(b), nil
+	case target.Equals(cty.Number):
+		n, err := strconv.ParseFloat(value, 64)
+		if err == nil && (math.IsNaN(n) || math.IsInf(n, 0)) {
+			err = errors.Errorf("invalid number value")
+		}
+		if err != nil {
+			return cty.NilVal, errors.Wrapf(err, "failed to parse %s as number", name)
+		}
+		return cty.NumberVal(big.NewFloat(n)), nil
+	default:
+		return cty.NilVal, errors.Errorf("%s of type %s is not a primitive", name, target.FriendlyName())
+	}
+}
+
+// valueFromCSV takes CSV value and converts it to cty.Type.
+//
+// This currently supports conversion to cty.List and cty.Set.
+// It also contains preliminary support for cty.Map (the other collection type).
+// While not considered a collection type, it also tentatively supports cty.Tuple.
+func valueFromCSV(name, value string, target cty.Type) (cty.Value, error) {
+	fields, err := csvvalue.Fields(value, nil)
+	if err != nil {
+		return cty.NilVal, errors.Wrapf(err, "failed to parse %s as CSV", value)
+	}
+
+	// used for lists and set, which require identical processing and differ only in return type
+	singleTypeConvert := func(t cty.Type) ([]cty.Value, error) {
+		var elems []cty.Value
+		for _, f := range fields {
+			v, err := convertPrimitive(name, f, t)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to parse element of type %s", target.FriendlyName())
+			}
+			elems = append(elems, v)
+		}
+		return elems, nil
+	}
+
+	switch {
+	case target.IsListType():
+		if !target.ElementType().IsPrimitiveType() {
+			return cty.NilVal, errors.Errorf("unsupported type %s for CSV specification", target.FriendlyName())
+		}
+		elems, err := singleTypeConvert(target.ElementType())
+		if err != nil {
+			return cty.NilVal, err
+		}
+		return cty.ListVal(elems), nil
+	case target.IsSetType():
+		if !target.ElementType().IsPrimitiveType() {
+			return cty.NilVal, errors.Errorf("unsupported type %s for CSV specification", target.FriendlyName())
+		}
+		elems, err := singleTypeConvert(target.ElementType())
+		if err != nil {
+			return cty.NilVal, err
+		}
+		return cty.SetVal(elems), nil
+	case target.IsTupleType():
+		tupleTypes := target.TupleElementTypes()
+		if len(tupleTypes) != len(fields) {
+			return cty.NilVal, errors.Errorf("%s expects %d elements but only %d provided", target.FriendlyName(), len(tupleTypes), len(fields))
+		}
+		var elems []cty.Value
+		for i, f := range fields {
+			tt := tupleTypes[i]
+			if !tt.IsPrimitiveType() {
+				return cty.NilVal, errors.Errorf("unsupported type %s for CSV specification", target.FriendlyName())
+			}
+			v, err := convertPrimitive(name, f, tt)
+			if err != nil {
+				return cty.NilVal, errors.Wrapf(err, "failed to parse element of type %s", target.FriendlyName())
+			}
+			elems = append(elems, v)
+		}
+		return cty.TupleVal(elems), nil
+	case target.IsMapType():
+		if !target.ElementType().IsPrimitiveType() {
+			return cty.NilVal, errors.Errorf("unsupported type %s for CSV specification", target.FriendlyName())
+		}
+		p := csvvalue.Parser{Comma: ':'}
+		var kvSlice []string
+		m := make(map[string]cty.Value)
+		for _, f := range fields {
+			kvSlice, err = p.Fields(f, kvSlice)
+			if err != nil {
+				return cty.NilVal, errors.Wrapf(err, "failed to parse %s as k/v", f)
+			}
+			if len(kvSlice) != 2 {
+				return cty.NilVal, errors.Errorf("expected one k/v pair but got %d pieces from %s", len(kvSlice), f)
+			}
+			v, err := convertPrimitive(name, kvSlice[1], target.ElementType())
+			if err != nil {
+				return cty.NilVal, errors.Wrapf(err, "failed to parse value from type %s", target.FriendlyName())
+			}
+			m[kvSlice[0]] = v
+		}
+		return cty.MapVal(m), nil
+	default:
+		return cty.NilVal, errors.Errorf("unsupported type %s for CSV specification", target.FriendlyName())
+	}
 }
 
 // wrapErrorDiagnostic wraps an error into a hcl.Diagnostics object.


### PR DESCRIPTION
Resolves #3160 and likely replaces #3161

In https://github.com/docker/buildx/issues/3160#issuecomment-2840204139 it was suggested that prior to allowing variable lists to be overridden via environment, proper typing capabilities should be implemented (and used).  This implements that typing, which results in the actual override code being superior to #3161 in every way, but touches more code.

This allows (but does not require) variables to have explicit types, similar to Terraform variables.  It uses HCL's `typeexpr` extension for the specification. For conversion of overrides to complex types (when explicit typing is provided), HCL's native JSON-based unmarshalling is used.

Typing is independent of any default value, but if a default is provided, it will be validated.  Similarly, if an override is provided, it will be converted to that type.  If typing is not provided, previous behavior is used.

For complex types, the happy path is lists of primitives, but in theory any complex/composite type can be used provided they are expressed correctly in JSON.  In the interest of simplicity and correctness, there are no shortcuts for lists (i.e., `VAR='["foo","bar"]'` and not `VAR=foo,bar`).  There *is* a shortcut for strings as users don't provide them for untyped variables and would be unintuitive (i.e. `VAR=foo` is valid for a string, though not valid JSON).

---

There should be no changes in behavior (for current or future un-typed usage), with one theoretical exception.  Today, extraneous attributes (for variables at least) are accepted, but ignored with no warnings.  It is theoretical possibly that users may have become reliant on this, e.g.
```hcl
variable "server" {
  default = "some.host"
  type = "linux"
}
```
Anyone using that attribute for their own purposes *will* encounter breaking behavior with this implementation (unless it happens to be a legitimate type expression).  I don't know if that is a real concern.

Also, this PR only contains code changes.  I assumed that 1) this change was unlikely to go through on the first submission and may require changes (or, of course, rejected), and 2) you may have dedicated people/processes for updating user docs.  Let me know if you want/need me to do anything in this regard.