### PR TITLE
ls: make sure current builder is available in JSON output

### DIFF
--- a/commands/ls.go
+++ b/commands/ls.go
@@ -213,7 +213,17 @@ type lsContext struct {
 }
 
 func (c *lsContext) MarshalJSON() ([]byte, error) {
-	return json.Marshal(c.Builder)
+	// can't marshal c.Builder directly because Builder type has custom MarshalJSON
+	dt, err := json.Marshal(c.Builder.Builder)
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]any
+	if err := json.Unmarshal(dt, &m); err != nil {
+		return nil, err
+	}
+	m["Current"] = c.Builder.Current
+	return json.Marshal(m)
 }
 
 func (c *lsContext) Name() string {


### PR DESCRIPTION
fixes #3175

While lsBuilder has a field called Current that gets lost because the embedded struct implements custom MarshalJSON method.

This was the best workaround hack I could come up with. Didn't know about this behavior, but here is the sample case https://go.dev/play/p/XH8oRG_wGEU