### PR TITLE
hack: modernize-fix bake target

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -73,6 +73,13 @@ target "lint-gopls" {
   target = "gopls-analyze"
 }
 
+target "modernize-fix" {
+  inherits = ["_common"]
+  dockerfile = "./hack/dockerfiles/lint.Dockerfile"
+  target = "modernize-fix"
+  output = ["."]
+}
+
 target "validate-vendor" {
   inherits = ["_common"]
   dockerfile = "./hack/dockerfiles/vendor.Dockerfile"

--- a/hack/dockerfiles/lint.Dockerfile
+++ b/hack/dockerfiles/lint.Dockerfile
@@ -92,4 +92,25 @@ RUN --mount=target=. \
   done
 EOF
 
+FROM base AS modernize-fix-run
+COPY --link --from=xx / /
+ARG TARGETNAME
+ARG TARGETPLATFORM
+WORKDIR /go/src/github.com/docker/buildx
+RUN --mount=target=.,rw \
+  --mount=target=/root/.cache,type=cache,id=lint-cache-${TARGETNAME}-${TARGETPLATFORM} \
+  --mount=target=/gopls-analyzers,from=gopls,source=/out <<EOF
+  set -ex
+  xx-go --wrap
+  mkdir /out
+  /gopls-analyzers/modernize -fix ./...
+  for file in $(git status --porcelain | awk '/^ M/ {print $2}'); do
+    mkdir -p /out/$(dirname $file)
+    cp $file /out/$file
+  done
+EOF
+
+FROM scratch AS modernize-fix
+COPY --link --from=modernize-fix-run /out /
+
 FROM lint


### PR DESCRIPTION
Atm I was invoking `modernize -fix ./...` to fix issues reported by lint-gopls but it doesn't fix everything. Using our sandbox with linux container seems to do the trick.