### PR TITLE
3172 - Allow passing env vars with set for docker compose cases

### DIFF
--- a/bake/bake_test.go
+++ b/bake/bake_test.go
@@ -1641,7 +1641,7 @@ services:
 	c, _, err := ParseFiles([]File{
 		{Data: dt, Name: "c1.foo"},
 		{Data: dt2, Name: "c2.bar"},
-	}, nil)
+	}, nil, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(c.Targets))

--- a/bake/compose.go
+++ b/bake/compose.go
@@ -19,8 +19,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func ParseComposeFiles(fs []File) (*Config, error) {
-	envs, err := composeEnv()
+func ParseComposeFiles(fs []File, envOverrides map[string]string) (*Config, error) {
+	envs, err := composeEnv(envOverrides)
 	if err != nil {
 		return nil, err
 	}
@@ -199,8 +199,8 @@ func ParseCompose(cfgs []composetypes.ConfigFile, envs map[string]string) (*Conf
 	return &c, nil
 }
 
-func validateComposeFile(dt []byte, fn string) (bool, error) {
-	envs, err := composeEnv()
+func validateComposeFile(dt []byte, fn string, envOverrides map[string]string) (bool, error) {
+	envs, err := composeEnv(envOverrides)
 	if err != nil {
 		return true, err
 	}
@@ -233,12 +233,18 @@ func validateCompose(dt []byte, envs map[string]string) error {
 	return err
 }
 
-func composeEnv() (map[string]string, error) {
+func composeEnv(envOverrides map[string]string) (map[string]string, error) {
 	envs := sliceToMap(os.Environ())
 	if wd, err := os.Getwd(); err == nil {
 		envs, err = loadDotEnv(envs, wd)
 		if err != nil {
 			return nil, err
+		}
+	}
+	if envOverrides != nil {
+		// Apply envOverrides on envs
+		for key, value := range envOverrides {
+			envs[key] = value
 		}
 	}
 	return envs, nil

--- a/bake/hcl_test.go
+++ b/bake/hcl_test.go
@@ -284,7 +284,7 @@ func TestHCLMultiFileSharedVariables(t *testing.T) {
 	c, _, err := ParseFiles([]File{
 		{Data: dt, Name: "c1.hcl"},
 		{Data: dt2, Name: "c2.hcl"},
-	}, nil)
+	}, nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(c.Targets))
 	require.Equal(t, "app", c.Targets[0].Name)
@@ -296,7 +296,7 @@ func TestHCLMultiFileSharedVariables(t *testing.T) {
 	c, _, err = ParseFiles([]File{
 		{Data: dt, Name: "c1.hcl"},
 		{Data: dt2, Name: "c2.hcl"},
-	}, nil)
+	}, nil, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(c.Targets))
@@ -333,7 +333,7 @@ func TestHCLVarsWithVars(t *testing.T) {
 	c, _, err := ParseFiles([]File{
 		{Data: dt, Name: "c1.hcl"},
 		{Data: dt2, Name: "c2.hcl"},
-	}, nil)
+	}, nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(c.Targets))
 	require.Equal(t, "app", c.Targets[0].Name)
@@ -345,7 +345,7 @@ func TestHCLVarsWithVars(t *testing.T) {
 	c, _, err = ParseFiles([]File{
 		{Data: dt, Name: "c1.hcl"},
 		{Data: dt2, Name: "c2.hcl"},
-	}, nil)
+	}, nil, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(c.Targets))
@@ -841,7 +841,7 @@ func TestHCLMultiFileAttrs(t *testing.T) {
 	c, _, err := ParseFiles([]File{
 		{Data: dt, Name: "c1.hcl"},
 		{Data: dt2, Name: "c2.hcl"},
-	}, nil)
+	}, nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(c.Targets))
 	require.Equal(t, "app", c.Targets[0].Name)
@@ -852,7 +852,7 @@ func TestHCLMultiFileAttrs(t *testing.T) {
 	c, _, err = ParseFiles([]File{
 		{Data: dt, Name: "c1.hcl"},
 		{Data: dt2, Name: "c2.hcl"},
-	}, nil)
+	}, nil, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(c.Targets))
@@ -876,7 +876,7 @@ func TestHCLMultiFileGlobalAttrs(t *testing.T) {
 	c, _, err := ParseFiles([]File{
 		{Data: dt, Name: "c1.hcl"},
 		{Data: dt2, Name: "c2.hcl"},
-	}, nil)
+	}, nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(c.Targets))
 	require.Equal(t, "app", c.Targets[0].Name)
@@ -1060,7 +1060,7 @@ func TestHCLRenameMultiFile(t *testing.T) {
 		{Data: dt, Name: "c1.hcl"},
 		{Data: dt2, Name: "c2.hcl"},
 		{Data: dt3, Name: "c3.hcl"},
-	}, nil)
+	}, nil, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, 2, len(c.Targets))
@@ -1278,7 +1278,7 @@ func TestHCLMatrixArgsOverride(t *testing.T) {
 
 	c, _, err := ParseFiles([]File{
 		{Data: dt, Name: "docker-bake.hcl"},
-	}, map[string]string{"ABC": "11,22,33"})
+	}, nil, map[string]string{"ABC": "11,22,33"})
 	require.NoError(t, err)
 
 	require.Equal(t, 3, len(c.Targets))
@@ -1465,7 +1465,7 @@ services:
 	c, _, err := ParseFiles([]File{
 		{Data: dt, Name: "c1.hcl"},
 		{Data: dt2, Name: "c2.yml"},
-	}, nil)
+	}, nil, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(c.Targets))
@@ -1486,7 +1486,7 @@ func TestHCLBuiltinVars(t *testing.T) {
 
 	c, _, err := ParseFiles([]File{
 		{Data: dt, Name: "c1.hcl"},
-	}, map[string]string{
+	}, nil, map[string]string{
 		"BAKE_CMD_CONTEXT": "foo",
 	})
 	require.NoError(t, err)
@@ -1549,7 +1549,7 @@ target "b" {
   }]
 }`),
 		},
-	}, nil)
+	}, nil, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(c.Groups))
@@ -1606,7 +1606,7 @@ target "two" {
 			Name: "bar.json",
 			Data: []byte(`{"ABC": "ghi", "DEF": "jkl"}`),
 		},
-	}, nil)
+	}, nil, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(c.Groups))
@@ -2267,6 +2267,7 @@ func TestJSONOverridePriority(t *testing.T) {
 		t.Setenv("FOO_JSON", "[3,4,5]")
 		c, _, err := ParseFiles(
 			[]File{{Name: "docker-bake.hcl", Data: dt}},
+			nil,
 			map[string]string{"FOO_JSON": "whatever"},
 		)
 		require.NoError(t, err)

--- a/commands/bake.go
+++ b/commands/bake.go
@@ -198,7 +198,7 @@ func runBake(ctx context.Context, dockerCli command.Cli, targets []string, in ba
 	}
 
 	if in.list != "" {
-		cfg, pm, err := bake.ParseFiles(files, defaults)
+		cfg, pm, err := bake.ParseFiles(files, overrides, defaults)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Rough draft.
Adds support for using existing `set` flag to pass individual env vars through to docker-compose.yaml files:
```
docker buildx bake  --set "env.FOO=BAR"
```
- Related: 
- #3172 
- #1135

Note: Does not add `--env-file` flag which was original plan, only because not sure if acceptable to add a compose-specific flag to the general command as in:

```
docker buildx bake  --env-file=path`
```

If maintainers say thats ok, it's easy to add.

