### PR TITLE
Show types during variable list operation

### DIFF
--- a/commands/bake.go
+++ b/commands/bake.go
@@ -663,7 +663,7 @@ func printVars(w io.Writer, format string, vars []*hclparser.Variable) error {
 	tw := tabwriter.NewWriter(w, 1, 8, 1, '\t', 0)
 	defer tw.Flush()
 
-	tw.Write([]byte("VARIABLE\tVALUE\tDESCRIPTION\n"))
+	tw.Write([]byte("VARIABLE\tTYPE\tVALUE\tDESCRIPTION\n"))
 
 	for _, v := range vars {
 		var value string
@@ -672,7 +672,7 @@ func printVars(w io.Writer, format string, vars []*hclparser.Variable) error {
 		} else {
 			value = "<null>"
 		}
-		fmt.Fprintf(tw, "%s\t%s\t%s\n", v.Name, value, v.Description)
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", v.Name, v.Type, value, v.Description)
 	}
 	return nil
 }


### PR DESCRIPTION
If a type was explicitly provided, it will be displayed in the variable listing.  Inferred type names are not displayed, as they likely would not match the user's intent.

Previously only `string` and `bool` default values were displayed in the listing.  All default values, regardless of type, are now displayed.

Fixes #3202 