### PR TITLE
Show types during variable list operation

### DIFF
--- a/bake/hclparser/hclparser.go
+++ b/bake/hclparser/hclparser.go
@@ -38,6 +38,9 @@ type variable struct {
 	Validations []*variableValidation `json:"validation,omitempty" hcl:"validation,block"`
 	Body        hcl.Body              `json:"-" hcl:",body"`
 	Remain      hcl.Body              `json:"-" hcl:",remain"`
+
+	// the type described by Type if it was specified
+	constraint *cty.Type
 }
 
 type variableValidation struct {
@@ -296,6 +299,9 @@ func (p *parser) resolveValue(ectx *hcl.EvalContext, name string) (err error) {
 			return diags
 		}
 		typeSpecified = !varType.Equals(cty.DynamicPseudoType) || hcl.ExprAsKeyword(vr.Type) == "any"
+		if typeSpecified {
+			vr.constraint = &varType
+		}
 	}
 
 	if def == nil {
@@ -674,6 +680,7 @@ func (p *parser) validateVariables(vars map[string]*variable, ectx *hcl.EvalCont
 type Variable struct {
 	Name        string  `json:"name"`
 	Description string  `json:"description,omitempty"`
+	Type        string  `json:"type,omitempty"`
 	Value       *string `json:"value,omitempty"`
 }
 
@@ -803,13 +810,31 @@ func Parse(b hcl.Body, opt Opt, val any) (*ParseMeta, hcl.Diagnostics) {
 			Name:        p.vars[k].Name,
 			Description: p.vars[k].Description,
 		}
+		tc := p.vars[k].constraint
+		if tc != nil {
+			v.Type = tc.FriendlyNameForConstraint()
+		}
 		if vv := p.ectx.Variables[k]; !vv.IsNull() {
 			var s string
-			switch vv.Type() {
-			case cty.String:
-				s = vv.AsString()
-			case cty.Bool:
-				s = strconv.FormatBool(vv.True())
+			switch {
+			case tc != nil:
+				if bs, err := ctyjson.Marshal(vv, *tc); err == nil {
+					s = string(bs)
+					// untyped strings were always unquoted, so be consistent with typed strings as well
+					if tc.Equals(cty.String) {
+						s = strings.Trim(s, "\"")
+					}
+				}
+			case vv.Type().IsPrimitiveType():
+				// all primitives can convert to string, so error should never occur
+				if val, err := convert.Convert(vv, cty.String); err == nil {
+					s = val.AsString()
+				}
+			default:
+				// must be an (inferred) tuple or object
+				if bs, err := ctyjson.Marshal(vv, vv.Type()); err == nil {
+					s = string(bs)
+				}
 			}
 			v.Value = &s
 		}

--- a/commands/bake.go
+++ b/commands/bake.go
@@ -663,7 +663,7 @@ func printVars(w io.Writer, format string, vars []*hclparser.Variable) error {
 	tw := tabwriter.NewWriter(w, 1, 8, 1, '\t', 0)
 	defer tw.Flush()
 
-	tw.Write([]byte("VARIABLE\tVALUE\tDESCRIPTION\n"))
+	tw.Write([]byte("VARIABLE\tTYPE\tVALUE\tDESCRIPTION\n"))
 
 	for _, v := range vars {
 		var value string
@@ -672,7 +672,7 @@ func printVars(w io.Writer, format string, vars []*hclparser.Variable) error {
 		} else {
 			value = "<null>"
 		}
-		fmt.Fprintf(tw, "%s\t%s\t%s\n", v.Name, value, v.Description)
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", v.Name, v.Type, value, v.Description)
 	}
 	return nil
 }

--- a/docs/reference/buildx_bake.md
+++ b/docs/reference/buildx_bake.md
@@ -198,11 +198,14 @@ To list variables:
 
 ```console
 $ docker buildx bake --list=variables
-VARIABLE      VALUE                DESCRIPTION
-REGISTRY      docker.io/username   Registry and namespace
-IMAGE_NAME    my-app               Image name
-GO_VERSION    <null>
+VARIABLE      TYPE      VALUE                DESCRIPTION
+REGISTRY      string    docker.io/username   Registry and namespace
+IMAGE_NAME    string    my-app               Image name
+GO_VERSION              <null>
+DEBUG         bool      false                Add debug symbols
 ```
+
+Variable types will be shown when set using the `type` property in the Bake file.
 
 By default, the output of `docker buildx bake --list` is presented in a table
 format. Alternatively, you can use a long-form CSV syntax and specify a


### PR DESCRIPTION
If a type was explicitly provided, it will be displayed in the variable listing. Inferred type names are not displayed, as they likely would not match the user's intent.

Previously only `string` and `bool` default values were displayed in the listing.  All default values, regardless of type, are now displayed.

Fixes #3202 