### PR TITLE
commands: update deprecation notice for keep-storage

### DIFF
--- a/commands/prune.go
+++ b/commands/prune.go
@@ -182,7 +182,7 @@ func pruneCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 	flags.BoolVarP(&options.force, "force", "f", false, "Do not prompt for confirmation")
 
 	flags.Var(&options.reservedSpace, "keep-storage", "Amount of disk space to keep for cache")
-	flags.MarkDeprecated("keep-storage", "keep-storage flag has been changed to max-storage")
+	flags.MarkDeprecated("keep-storage", "keep-storage flag has been changed to reserved-space")
 
 	return cmd
 }


### PR DESCRIPTION

The `--keep-storage` flag was changed to `--reserved-space`. Before it was
changed to that name, it was changed to `--max-storage`. This flag never
made it into a release as the name was changed before release, but the
update to the flag in buildx forgot to update the deprecation notice.

Fixes moby/moby#50120.
