### PR TITLE
monitor: refactor how reload works

### DIFF
--- a/commands/debug/root.go
+++ b/commands/debug/root.go
@@ -53,7 +53,7 @@ func RootCmd(dockerCli command.Cli, children ...DebuggableCmd) *cobra.Command {
 				return errors.Errorf("failed to configure terminal: %v", err)
 			}
 
-			_, err = monitor.RunMonitor(ctx, "", nil, &controllerapi.InvokeConfig{
+			err = monitor.RunMonitor(ctx, &controllerapi.InvokeConfig{
 				Tty: true,
 			}, c, dockerCli.In(), os.Stdout, os.Stderr, printer)
 			con.Reset()

--- a/controller/local/controller.go
+++ b/controller/local/controller.go
@@ -88,10 +88,6 @@ func (b *Controller) Invoke(ctx context.Context, processes *processes.Manager, p
 	}
 }
 
-func (b *Controller) Inspect(ctx context.Context) *cbuild.Options {
-	return b.buildConfig.buildOptions
-}
-
 func (b *Controller) Close() error {
 	if b.buildConfig.resultCtx != nil {
 		b.buildConfig.resultCtx.Done()

--- a/monitor/commands/reload.go
+++ b/monitor/commands/reload.go
@@ -2,30 +2,16 @@ package commands
 
 import (
 	"context"
-	"fmt"
-	"io"
 
-	cbuild "github.com/docker/buildx/controller/build"
-	controllererrors "github.com/docker/buildx/controller/errdefs"
-	controllerapi "github.com/docker/buildx/controller/pb"
 	"github.com/docker/buildx/monitor/types"
-	"github.com/docker/buildx/util/progress"
-	"github.com/moby/buildkit/solver/errdefs"
-	"github.com/pkg/errors"
 )
 
 type ReloadCmd struct {
 	m types.Monitor
-
-	stdout   io.WriteCloser
-	progress *progress.Printer
-
-	options      *cbuild.Options
-	invokeConfig *controllerapi.InvokeConfig
 }
 
-func NewReloadCmd(m types.Monitor, stdout io.WriteCloser, progress *progress.Printer, options *cbuild.Options, invokeConfig *controllerapi.InvokeConfig) types.Command {
-	return &ReloadCmd{m, stdout, progress, options, invokeConfig}
+func NewReloadCmd(m types.Monitor) types.Command {
+	return &ReloadCmd{m: m}
 }
 
 func (cm *ReloadCmd) Info() types.CommandInfo {
@@ -40,31 +26,6 @@ Usage:
 }
 
 func (cm *ReloadCmd) Exec(ctx context.Context, args []string) error {
-	bo := cm.m.Inspect(ctx)
-
-	var resultUpdated bool
-	cm.progress.Unpause()
-	_, _, err := cm.m.Build(ctx, bo, nil, cm.progress) // TODO: support stdin, hold build ref
-	cm.progress.Pause()
-	if err != nil {
-		var be *controllererrors.BuildError
-		if errors.As(err, &be) {
-			resultUpdated = true
-		} else {
-			fmt.Printf("failed to reload: %v\n", err)
-		}
-		// report error
-		for _, s := range errdefs.Sources(err) {
-			s.Print(cm.stdout)
-		}
-		fmt.Fprintf(cm.stdout, "ERROR: %v\n", err)
-	} else {
-		resultUpdated = true
-	}
-	if resultUpdated {
-		// rollback the running container with the new result
-		id := cm.m.Rollback(ctx, cm.invokeConfig)
-		fmt.Fprintf(cm.stdout, "Interactive container was restarted with process %q. Press Ctrl-a-c to switch to the new container\n", id)
-	}
+	cm.m.Reload()
 	return nil
 }

--- a/monitor/types/types.go
+++ b/monitor/types/types.go
@@ -4,20 +4,12 @@ import (
 	"context"
 	"io"
 
-	"github.com/docker/buildx/build"
-	cbuild "github.com/docker/buildx/controller/build"
 	controllerapi "github.com/docker/buildx/controller/pb"
 	"github.com/docker/buildx/controller/processes"
-	"github.com/docker/buildx/util/progress"
-	"github.com/moby/buildkit/client"
 )
 
 // Monitor provides APIs for attaching and controlling the buildx server.
 type Monitor interface {
-	Build(ctx context.Context, options *cbuild.Options, in io.ReadCloser, progress progress.Writer) (resp *client.SolveResponse, inputs *build.Inputs, err error)
-
-	Inspect(ctx context.Context) *cbuild.Options
-
 	// Invoke starts an IO session into the specified process.
 	// If pid doesn't match to any running processes, it starts a new process with the specified config.
 	// If there is no container running or InvokeConfig.Rollback is specified, the process will start in a newly created container.
@@ -42,6 +34,9 @@ type Monitor interface {
 
 	// Detach detaches IO from the container.
 	Detach()
+
+	// Reload will signal the monitor to be reloaded.
+	Reload()
 
 	io.Closer
 }


### PR DESCRIPTION

The build now happens in a loop and the monitor is run after every
build. The monitor can return `ErrReload` to signal to the main thread
that it should reload the build result.

This will be used in the future to move the monitor into a callback
rather than as a separate existence. It allows the monitor to not
control the build itself which now makes it possible to completely
remove the controller.
  