### PR TITLE
lint: fix linter error on arm64

### DIFF
--- a/hack/dockerfiles/lint.Dockerfile
+++ b/hack/dockerfiles/lint.Dockerfile
@@ -13,7 +13,7 @@ ARG GOPLS_ANALYZERS="embeddirective fillreturns infertypeargs maprange modernize
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS base
-RUN apk add --no-cache git gcc musl-dev
+RUN apk add --no-cache git gcc musl-dev binutils-gold
 
 FROM base AS golangci-build
 WORKDIR /src


### PR DESCRIPTION
Something has changed in golang or alpine requiring gold linker by default. In future this could be updated to clang/lld instead, eg. by just calling xx.