### PR TITLE
remove "experimental" hint from help / usage output

### DIFF
--- a/commands/root.go
+++ b/commands/root.go
@@ -85,10 +85,6 @@ func NewRootCmd(name string, isPlugin bool, dockerCli *command.DockerCli) *cobra
 		"using default config store",
 	))
 
-	if !confutil.IsExperimental() {
-		cmd.SetHelpTemplate(cmd.HelpTemplate() + "\nExperimental commands and flags are hidden. Set BUILDX_EXPERIMENTAL=1 to show them.\n")
-	}
-
 	addCommands(cmd, &opt, dockerCli)
 	return cmd
 }


### PR DESCRIPTION
I saw https://github.com/docker/buildx/pull/3240 which reminded me that I wanted to open this patch as suggestion.


This was added in 02c2073feb3681e5c13e944d5f1cd2246cc22013, which changed the buildx CLI to match the behavior of the docker CLI, which conditionally hid some options that were marked experimental. The CLI now shows has client-side experimental options enabled by default (but labeled as experimental where suitable).

Before this patch, every command would print this message unless experimental was enabled;

    docker buildx --help
    ...
    Run 'docker buildx COMMAND --help' for more information on a command.

    Experimental commands and flags are hidden. Set BUILDX_EXPERIMENTAL=1 to show them.

With this patch applied, that message is no longer shown.