### PR TITLE
Allow bake files to be specified via environment variable

### DIFF
--- a/docs/reference/buildx_bake.md
+++ b/docs/reference/buildx_bake.md
@@ -143,6 +143,11 @@ Use the `-f` / `--file` option to specify the build definition file to use.
 The file can be an HCL, JSON or Compose file. If multiple files are specified,
 all are read and the build configurations are combined.
 
+Alternatively, the environment variable `BUILDX_BAKE_FILE` can be used to specify the build definition to use.
+This is mutually exclusive with `-f` / `--file`; if both are specified, the environment variable is ignored.
+Multiple definitions can be specified by separating them with the system's path separator
+(typically `;` on Windows and `:` elsewhere), but can be changed with `BUILDX_BAKE_PATH_SEPARATOR`.
+
 You can pass the names of the targets to build, to build only specific target(s).
 The following example builds the `db` and `webapp-release` targets that are
 defined in the `docker-bake.dev.hcl` file:


### PR DESCRIPTION
Fixes #3218 

The environment variable `BUILDX_BAKE_FILE` (and optional variable `BUILDX_BAKE_FILE_SEPARATOR`) can be used to specify one or more bake files (similar to `compose`).  This is mutually exclusive with`--file` (which takes precedence).

This is done very early to ensure the values are treated just like `--file`, e.g., participate in telemetry.  This includes leaving relative paths as-is, which deviates from `compose` (which makes them absolute).

This was intended to functionally be just like compose, but there was no opportunity to reuse code and the patterns/flows used were different enough that I went with something simple rather than trying to make them look the same.

When I created the feature request, it didn't occur to me that there could be potential confusion/ambiguity between `COMPOSE_FILE` (not respected by bake to my knowledge), `--file` (which can be used to specify compose files), and whether the new `BUILDX_BAKE_FILE` would/should allow compose files.  The issue is ignored/unaddressed in this initial implementation, as it wasn't immediately obvious whether `COMPOSE_FILE` _should_ be supported and what its relationship to `BUILDX_BAKE_FILE` would be.  The focus is solely on `BUILDX_BAKE_FILE` is equivalent to `--file`.