### PR TITLE
bake: multi ips support for extra hosts

### DIFF
--- a/bake/compose.go
+++ b/bake/compose.go
@@ -125,10 +125,8 @@ func ParseCompose(cfgs []composetypes.ConfigFile, envs map[string]string) (*Conf
 			extraHosts := map[string]*string{}
 			if s.Build.ExtraHosts != nil {
 				for k, v := range s.Build.ExtraHosts {
-					for _, ip := range v {
-						vv := ip
-						extraHosts[k] = &vv
-					}
+					vv := strings.Join(v, ",")
+					extraHosts[k] = &vv
 				}
 			}
 

--- a/bake/compose_test.go
+++ b/bake/compose_test.go
@@ -34,6 +34,7 @@ services:
         - type=local,dest=path/to/cache
       extra_hosts:
         - "somehost:162.242.195.82"
+        - "somehost:162.242.195.83"
         - "myhostv6:::1"
       ssh:
         - key=/path/to/key
@@ -79,7 +80,7 @@ secrets:
 	require.Equal(t, ptrstr("123"), c.Targets[1].Args["buildno"])
 	require.Equal(t, []string{"type=local,src=path/to/cache"}, stringify(c.Targets[1].CacheFrom))
 	require.Equal(t, []string{"type=local,dest=path/to/cache"}, stringify(c.Targets[1].CacheTo))
-	require.Equal(t, map[string]*string{"myhostv6": ptrstr("::1"), "somehost": ptrstr("162.242.195.82")}, c.Targets[1].ExtraHosts)
+	require.Equal(t, map[string]*string{"myhostv6": ptrstr("::1"), "somehost": ptrstr("162.242.195.82,162.242.195.83")}, c.Targets[1].ExtraHosts)
 	require.Equal(t, "none", *c.Targets[1].NetworkMode)
 	require.Equal(t, []string{"default", "key=/path/to/key"}, stringify(c.Targets[1].SSH))
 	require.Equal(t, []string{

--- a/build/utils.go
+++ b/build/utils.go
@@ -77,24 +77,30 @@ func toBuildkitExtraHosts(ctx context.Context, inp []string, nodeDriver *driver.
 		}
 		// If the IP Address is a "host-gateway", replace this value with the
 		// IP address provided by the worker's label.
+		var ips []string
 		if ip == mobyHostGatewayName {
 			hgip, err := nodeDriver.HostGatewayIP(ctx)
 			if err != nil {
 				return "", errors.Wrap(err, "unable to derive the IP value for host-gateway")
 			}
-			ip = hgip.String()
+			ips = append(ips, hgip.String())
 		} else {
-			// If the address is enclosed in square brackets, extract it (for IPv6, but
-			// permit it for IPv4 as well; we don't know the address family here, but it's
-			// unambiguous).
-			if len(ip) > 2 && ip[0] == '[' && ip[len(ip)-1] == ']' {
-				ip = ip[1 : len(ip)-1]
-			}
-			if net.ParseIP(ip) == nil {
-				return "", errors.Errorf("invalid host %s", h)
+			for _, v := range strings.Split(ip, ",") {
+				// If the address is enclosed in square brackets, extract it
+				// (for IPv6, but permit it for IPv4 as well; we don't know the
+				// address family here, but it's unambiguous).
+				if len(v) > 2 && v[0] == '[' && v[len(v)-1] == ']' {
+					v = v[1 : len(v)-1]
+				}
+				if net.ParseIP(v) == nil {
+					return "", errors.Errorf("invalid host %s", h)
+				}
+				ips = append(ips, v)
 			}
 		}
-		hosts = append(hosts, host+"="+ip)
+		for _, v := range ips {
+			hosts = append(hosts, host+"="+v)
+		}
 	}
 	return strings.Join(hosts, ","), nil
 }

--- a/build/utils_test.go
+++ b/build/utils_test.go
@@ -73,6 +73,11 @@ func TestToBuildkitExtraHosts(t *testing.T) {
 			input: []string{`ipv6local=0:0:0:0:0:0:0:1`},
 		},
 		{
+			doc:         "Multi IPs",
+			input:       []string{`myhost=162.242.195.82,162.242.195.83`},
+			expectedOut: `myhost=162.242.195.82,myhost=162.242.195.83`,
+		},
+		{
 			doc:         "IPv6 localhost, non-canonical, eq sep, brackets",
 			input:       []string{`ipv6local=[0:0:0:0:0:0:0:1]`},
 			expectedOut: `ipv6local=0:0:0:0:0:0:0:1`,

--- a/tests/bake.go
+++ b/tests/bake.go
@@ -2167,11 +2167,14 @@ func testBakeExtraHosts(t *testing.T, sb integration.Sandbox) {
 	dockerfile := []byte(`
 FROM busybox
 RUN cat /etc/hosts | grep myhost | grep 1.2.3.4
+RUN cat /etc/hosts | grep myhostmulti | grep 162.242.195.81
+RUN cat /etc/hosts | grep myhostmulti | grep 162.242.195.82
 	`)
 	bakefile := []byte(`
 target "default" {
   extra-hosts = {
     myhost = "1.2.3.4"
+    myhostmulti = "162.242.195.81,162.242.195.82"
   }
 }
 `)


### PR DESCRIPTION
follow-up
* https://github.com/docker/buildx/pull/3234
* https://github.com/docker/compose/pull/12935

Adds multiple IPs support for extra hosts value using `,` separator for Bake.

```hcl
target "default" {
  extra-hosts = {
    myhost = "1.2.3.4"
    myhostmulti = "162.242.195.81,162.242.195.82"
  }
}
```

```dockerfile
FROM busybox
RUN cat /etc/hosts
```

```
$ docker buildx bake
...
#7 [2/5] RUN cat /etc/hosts
#7 0.243 127.0.0.1      localhost buildkitsandbox
#7 0.243 ::1    localhost ip6-localhost ip6-loopback
#7 0.243 1.2.3.4        myhost
#7 0.243 162.242.195.81 myhostmulti
#7 0.243 162.242.195.82 myhostmulti
#7 DONE 0.3s
```