### PR TITLE
progress: ensure bake waits for progress to finish printing on error conditions

### DIFF
--- a/commands/bake.go
+++ b/commands/bake.go
@@ -162,7 +162,13 @@ func runBake(ctx context.Context, dockerCli command.Cli, targets []string, in ba
 	attributes := bakeMetricAttributes(dockerCli, driverType, url, cmdContext, targets, &in)
 
 	progressMode := progressui.DisplayMode(cFlags.progress)
+
 	var printer *progress.Printer
+	defer func() {
+		if printer != nil {
+			printer.Wait()
+		}
+	}()
 
 	makePrinter := func() error {
 		var err error


### PR DESCRIPTION

Some minor fixes to the printer and how bake invokes it. Bake previously
had a race condition that could result in the display not updating on an
error condition, but it was much rarer because the channel communication
was much closer. The refactor added a proxy for the status channel so
there was more of an opportunity to surface the race condition.

When bake exits with an error when reading the bakefiles, it doesn't
wait for the printer to finish so it is possible for the printer to
update the display after an error is printed. This adds an extra `Wait`
in a defer to make sure the printer is finished.

`Wait` has also been fixed to allow it to be called multiple times and
have the same behavior. Previously, it only waited for the done channel
once so only the first wait would block.

The `onclose` method is now called every time the display is paused or
stopped. That was the previous behavior and it's been restored here.

The display only gets refreshed if we aren't exiting. There's no point
in initializing another display if we're about to exit.

The metric writer attached to the printer was erroneously removed. It is
now assigned properly.
