### PR TITLE
driver kubernetes: allow to work in a Memory mount to speed up things

### DIFF
--- a/driver/kubernetes/factory.go
+++ b/driver/kubernetes/factory.go
@@ -286,6 +286,10 @@ func (f *factory) processDriverOpts(deploymentName string, namespace string, cfg
 			if v != "" {
 				deploymentOpt.Qemu.Image = v
 			}
+		case "buildkit-root-volume-memory":
+			if v != "" {
+				deploymentOpt.BuildKitRootVolumeMemory = v
+			}
 		case "default-load":
 			defaultLoad, err = strconv.ParseBool(v)
 			if err != nil {


### PR DESCRIPTION
Depending on the size of the layers, it can increase build speed by a lot.
our use case is an docker buildx on a c7i.4xlarge. For a big COPY of about 1GB, we gained 1min of build time!