### PR TITLE
history: fix required args for inspect attachment command

### DIFF
--- a/commands/history/inspect_attachment.go
+++ b/commands/history/inspect_attachment.go
@@ -118,9 +118,9 @@ func attachmentCmd(dockerCli command.Cli, rootOpts RootOptions) *cobra.Command {
 	var options attachmentOptions
 
 	cmd := &cobra.Command{
-		Use:   "attachment [OPTIONS] REF [DIGEST]",
+		Use:   "attachment [OPTIONS] [REF [DIGEST]]",
 		Short: "Inspect a build record attachment",
-		Args:  cobra.RangeArgs(1, 2),
+		Args:  cobra.MaximumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
 				options.ref = args[0]

--- a/docs/reference/buildx_history_inspect_attachment.md
+++ b/docs/reference/buildx_history_inspect_attachment.md
@@ -1,7 +1,7 @@
 # docker buildx history inspect attachment
 
 ```text
-docker buildx history inspect attachment [OPTIONS] REF [DIGEST]
+docker buildx history inspect attachment [OPTIONS] [REF [DIGEST]]
 ```
 
 <!---MARKER_GEN_START-->


### PR DESCRIPTION
follow-up https://github.com/docker/buildx/pull/3258#discussion_r2160905234

Ref should not be required.

Before:

```
$ docker buildx history inspect attachment --type provenance
ERROR: accepts between 1 and 2 arg(s), received 0
```

After:

```
$ docker buildx history inspect attachment --type provenance
{
  "builder": {
    "id": ""
  },
  "buildType": "https://mobyproject.org/buildkit@v1",
  "materials": [
    {
      "uri": "pkg:docker/docker/dockerfile@1",
      "digest": {
        "sha256": "9857836c9ee4268391bb5b09f9f157f3c91bb15821bb77969642813b0d00518d"
      }
    },
    {
      "uri": "pkg:docker/alpine@3.21?platform=linux%2Famd64",
      "digest": {
        "sha256": "a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c"
      }
    },
    {
      "uri": "pkg:docker/golang@1.24-alpine3.21?platform=linux%2Famd64",
      "digest": {
        "sha256": "56a23791af0f77c87b049230ead03bd8c3ad41683415ea4595e84ce7eada121a"
      }
    }
  ],
  ...
}
```