### PR TITLE
fix some linting issues

### DIFF
--- a/bake/hclparser/gohcl/decode_test.go
+++ b/bake/hclparser/gohcl/decode_test.go
@@ -413,11 +413,10 @@ func TestDecodeBody(t *testing.T) {
 				} `hcl:"noodle,block"`
 			}{}),
 			func(gotI any) bool {
-				//nolint:misspell
 				// Generating two diagnostics is good enough for this one.
 				// (one for the missing noodle block and the other for
 				// the JSON serialization detecting the missing level of
-				// heirarchy for the label.)
+				// hierarchy for the label.)
 				return true
 			},
 			2,

--- a/bake/hclparser/gohcl/schema.go
+++ b/bake/hclparser/gohcl/schema.go
@@ -52,8 +52,7 @@ func ImpliedBodySchema(val any) (schema *hcl.BodySchema, partial bool) {
 
 		switch {
 		case field.Type.AssignableTo(exprType):
-			//nolint:misspell
-			// If we're decoding to hcl.Expression then absense can be
+			// If we're decoding to hcl.Expression then absence can be
 			// indicated via a null value, so we don't specify that
 			// the field is required during decoding.
 			required = false

--- a/build/replicatedstream_test.go
+++ b/build/replicatedstream_test.go
@@ -43,7 +43,7 @@ func TestSyncMultiReaderParallel(t *testing.T) {
 			buf := make([]byte, bufferSize)
 			for totalRead < len(data) {
 				// Simulate random read sizes
-				readSize := mathrand.Intn(bufferSize) //nolint:gosec
+				readSize := mathrand.Intn(bufferSize) // #nosec G404 -- ignore "Use of weak random number generator (math/rand instead of crypto/rand)"
 				n, err := reader.Read(buf[:readSize])
 
 				if n > 0 {
@@ -58,14 +58,15 @@ func TestSyncMultiReaderParallel(t *testing.T) {
 
 				assert.NoError(t, err, "Reader %d error", readerId)
 
-				if mathrand.Intn(1000) == 0 { //nolint:gosec
+				// #nosec G404 -- ignore "Use of weak random number generator (math/rand instead of crypto/rand)"
+				if mathrand.Intn(1000) == 0 {
 					t.Logf("Reader %d closing", readerId)
 					// Simulate random close
 					return
 				}
 
 				// Simulate random timing between reads
-				time.Sleep(time.Millisecond * time.Duration(mathrand.Intn(5))) //nolint:gosec
+				time.Sleep(time.Millisecond * time.Duration(mathrand.Intn(5))) // #nosec G404 -- ignore "Use of weak random number generator (math/rand instead of crypto/rand)"
 			}
 
 			assert.Equal(t, len(data), totalRead, "Reader %d total read mismatch", readerId)

--- a/driver/kubernetes/podchooser/podchooser.go
+++ b/driver/kubernetes/podchooser/podchooser.go
@@ -37,7 +37,7 @@ func (pc *RandomPodChooser) ChoosePod(ctx context.Context) (*corev1.Pod, error) 
 	if randSource == nil {
 		randSource = rand.NewSource(time.Now().Unix())
 	}
-	rnd := rand.New(randSource) //nolint:gosec // no strong seeding required
+	rnd := rand.New(randSource) // #nosec G404 -- no strong seeding required
 	n := rnd.Int() % len(pods)
 	logrus.Debugf("RandomPodChooser.ChoosePod(): len(pods)=%d, n=%d", len(pods), n)
 	return pods[n], nil

--- a/util/otelutil/span.go
+++ b/util/otelutil/span.go
@@ -59,8 +59,7 @@ type Span struct {
 	Resource []attribute.KeyValue
 	// InstrumentationLibrary is information about the library that produced
 	// the span
-	//nolint:staticcheck
-	InstrumentationLibrary instrumentation.Library
+	InstrumentationLibrary instrumentation.Scope
 }
 
 type Spans []Span
@@ -112,8 +111,8 @@ type spanData struct {
 	DroppedLinks      int
 	ChildSpanCount    int
 	Resource          []keyValue // change this type from the otel type to make this struct marshallable
-	//nolint:staticcheck
-	InstrumentationLibrary instrumentation.Library
+
+	InstrumentationLibrary instrumentation.Scope
 }
 
 // spanContext is a custom type used to unmarshal otel SpanContext correctly.
@@ -484,8 +483,6 @@ func (s spanSnapshot) InstrumentationScope() instrumentation.Scope {
 }
 
 // InstrumentationLibrary returns the InstrumentationLibrary of the snapshot
-//
-//nolint:staticcheck
-func (s spanSnapshot) InstrumentationLibrary() instrumentation.Library {
+func (s spanSnapshot) InstrumentationLibrary() instrumentation.Scope {
 	return s.instrumentationScope
 }


### PR DESCRIPTION
### bake/hclparser/gohcl: fix typo

Looks like we forked this code, including the typo. As we already modify
the code to add the `//nolint`, we may as well fix the typo itself instead.
https://github.com/hashicorp/hcl/blob/dfa124f3c93ff1764fda03702a7a9aa8c9db48d8/gohcl/decode_test.go#L417-L423
https://github.com/hashicorp/hcl/blob/dfa124f3c93ff1764fda03702a7a9aa8c9db48d8/gohcl/schema.go#L54-L58

### use "#nosec" instead of "nolint:gosec" to be more specific

The `#nosec` comment allows ignoring a specific rule; this prevents
potentially other "gosec" linting failulres from being silently ignored.


### util/otelutil: change uses of deprecated instrumentation.Library

While the interface's signature uses the deprecated "Library" type,
and upstream documents it as "needed for backward compatibility";
https://github.com/open-telemetry/opentelemetry-go/blob/0f7f1d0bad21aba18feaadc0171c53705fbda419/sdk/trace/span.go#L62-L65

The Library type is now an alias for Scope, so using the non-deprecated
type still satisfies the interface;
https://github.com/open-telemetry/opentelemetry-go/blob/0f7f1d0bad21aba18feaadc0171c53705fbda419/sdk/instrumentation/library.go#L6-L9