### PR TITLE
history: bootstrap builder

### DIFF
--- a/commands/history/export.go
+++ b/commands/history/export.go
@@ -28,19 +28,9 @@ type exportOptions struct {
 }
 
 func runExport(ctx context.Context, dockerCli command.Cli, opts exportOptions) error {
-	b, err := builder.New(dockerCli, builder.WithName(opts.builder))
+	nodes, err := loadNodes(ctx, dockerCli, opts.builder)
 	if err != nil {
 		return err
-	}
-
-	nodes, err := b.LoadNodes(ctx, builder.WithData())
-	if err != nil {
-		return err
-	}
-	for _, node := range nodes {
-		if node.Err != nil {
-			return node.Err
-		}
 	}
 
 	if len(opts.refs) == 0 {

--- a/commands/history/inspect.go
+++ b/commands/history/inspect.go
@@ -20,7 +20,6 @@ import (
 	"github.com/containerd/containerd/v2/core/content/proxy"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/platforms"
-	"github.com/docker/buildx/builder"
 	"github.com/docker/buildx/localstate"
 	"github.com/docker/buildx/util/cobrautil/completion"
 	"github.com/docker/buildx/util/confutil"
@@ -158,19 +157,9 @@ func readAttr[T any](attrs map[string]string, k string, dest *T, f func(v string
 }
 
 func runInspect(ctx context.Context, dockerCli command.Cli, opts inspectOptions) error {
-	b, err := builder.New(dockerCli, builder.WithName(opts.builder))
+	nodes, err := loadNodes(ctx, dockerCli, opts.builder)
 	if err != nil {
 		return err
-	}
-
-	nodes, err := b.LoadNodes(ctx)
-	if err != nil {
-		return err
-	}
-	for _, node := range nodes {
-		if node.Err != nil {
-			return node.Err
-		}
 	}
 
 	recs, err := queryRecords(ctx, opts.ref, nodes, nil)

--- a/commands/history/inspect_attachment.go
+++ b/commands/history/inspect_attachment.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/containerd/containerd/v2/core/content/proxy"
 	"github.com/containerd/platforms"
-	"github.com/docker/buildx/builder"
 	"github.com/docker/buildx/util/cobrautil/completion"
 	"github.com/docker/cli/cli/command"
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
@@ -27,19 +26,9 @@ type attachmentOptions struct {
 }
 
 func runAttachment(ctx context.Context, dockerCli command.Cli, opts attachmentOptions) error {
-	b, err := builder.New(dockerCli, builder.WithName(opts.builder))
+	nodes, err := loadNodes(ctx, dockerCli, opts.builder)
 	if err != nil {
 		return err
-	}
-
-	nodes, err := b.LoadNodes(ctx)
-	if err != nil {
-		return err
-	}
-	for _, node := range nodes {
-		if node.Err != nil {
-			return node.Err
-		}
 	}
 
 	recs, err := queryRecords(ctx, opts.ref, nodes, nil)

--- a/commands/history/logs.go
+++ b/commands/history/logs.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 
-	"github.com/docker/buildx/builder"
 	"github.com/docker/buildx/util/cobrautil/completion"
 	"github.com/docker/buildx/util/progress"
 	"github.com/docker/cli/cli/command"
@@ -23,19 +22,9 @@ type logsOptions struct {
 }
 
 func runLogs(ctx context.Context, dockerCli command.Cli, opts logsOptions) error {
-	b, err := builder.New(dockerCli, builder.WithName(opts.builder))
+	nodes, err := loadNodes(ctx, dockerCli, opts.builder)
 	if err != nil {
 		return err
-	}
-
-	nodes, err := b.LoadNodes(ctx)
-	if err != nil {
-		return err
-	}
-	for _, node := range nodes {
-		if node.Err != nil {
-			return node.Err
-		}
 	}
 
 	recs, err := queryRecords(ctx, opts.ref, nodes, nil)

--- a/commands/history/ls.go
+++ b/commands/history/ls.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/containerd/console"
-	"github.com/docker/buildx/builder"
 	"github.com/docker/buildx/localstate"
 	"github.com/docker/buildx/util/cobrautil/completion"
 	"github.com/docker/buildx/util/confutil"
@@ -47,19 +46,9 @@ type lsOptions struct {
 }
 
 func runLs(ctx context.Context, dockerCli command.Cli, opts lsOptions) error {
-	b, err := builder.New(dockerCli, builder.WithName(opts.builder))
+	nodes, err := loadNodes(ctx, dockerCli, opts.builder)
 	if err != nil {
 		return err
-	}
-
-	nodes, err := b.LoadNodes(ctx)
-	if err != nil {
-		return err
-	}
-	for _, node := range nodes {
-		if node.Err != nil {
-			return node.Err
-		}
 	}
 
 	queryOptions := &queryOptions{}

--- a/commands/history/open.go
+++ b/commands/history/open.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/docker/buildx/builder"
 	"github.com/docker/buildx/util/cobrautil/completion"
 	"github.com/docker/buildx/util/desktop"
 	"github.com/docker/cli/cli/command"
@@ -19,19 +18,9 @@ type openOptions struct {
 }
 
 func runOpen(ctx context.Context, dockerCli command.Cli, opts openOptions) error {
-	b, err := builder.New(dockerCli, builder.WithName(opts.builder))
+	nodes, err := loadNodes(ctx, dockerCli, opts.builder)
 	if err != nil {
 		return err
-	}
-
-	nodes, err := b.LoadNodes(ctx)
-	if err != nil {
-		return err
-	}
-	for _, node := range nodes {
-		if node.Err != nil {
-			return node.Err
-		}
 	}
 
 	recs, err := queryRecords(ctx, opts.ref, nodes, nil)

--- a/commands/history/rm.go
+++ b/commands/history/rm.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io"
 
-	"github.com/docker/buildx/builder"
 	"github.com/docker/buildx/util/cobrautil/completion"
 	"github.com/docker/cli/cli/command"
 	"github.com/hashicorp/go-multierror"
@@ -21,19 +20,9 @@ type rmOptions struct {
 }
 
 func runRm(ctx context.Context, dockerCli command.Cli, opts rmOptions) error {
-	b, err := builder.New(dockerCli, builder.WithName(opts.builder))
+	nodes, err := loadNodes(ctx, dockerCli, opts.builder)
 	if err != nil {
 		return err
-	}
-
-	nodes, err := b.LoadNodes(ctx)
-	if err != nil {
-		return err
-	}
-	for _, node := range nodes {
-		if node.Err != nil {
-			return node.Err
-		}
 	}
 
 	errs := make([][]error, len(opts.refs))

--- a/commands/history/trace.go
+++ b/commands/history/trace.go
@@ -120,19 +120,9 @@ func loadTrace(ctx context.Context, ref string, nodes []builder.Node) (string, [
 }
 
 func runTrace(ctx context.Context, dockerCli command.Cli, opts traceOptions) error {
-	b, err := builder.New(dockerCli, builder.WithName(opts.builder))
+	nodes, err := loadNodes(ctx, dockerCli, opts.builder)
 	if err != nil {
 		return err
-	}
-
-	nodes, err := b.LoadNodes(ctx)
-	if err != nil {
-		return err
-	}
-	for _, node := range nodes {
-		if node.Err != nil {
-			return node.Err
-		}
 	}
 
 	traceID, data, err := loadTrace(ctx, opts.ref, nodes)


### PR DESCRIPTION
fixes #3296 

Before:

```
$ docker buildx --builder builder history ls
ERROR: Error response from daemon: container 82f708fa6dfc1935f56ea3f97c57872f47b24774d182928c3560a21187a2d869 is not running
```

After:

```
$ docker buildx --builder builder history ls
#1 [internal] booting buildkit
#1 starting container buildx_buildkit_builder0
#1 starting container buildx_buildkit_builder0 0.9s done
#1 DONE 0.9s
BUILD ID                    NAME                                   STATUS      CREATED AT       DURATION   
1i4j7lqd7egb2s27xkqlyx83k   buildx                                 Error       16 seconds ago   3.6s       Open
```