### PR TITLE
dap: alias step into to next and step out to continue

### DIFF
--- a/dap/adapter.go
+++ b/dap/adapter.go
@@ -156,6 +156,29 @@ func (d *Adapter[C]) Next(c Context, req *dap.NextRequest, resp *dap.NextRespons
 	return nil
 }
 
+func (d *Adapter[C]) StepIn(c Context, req *dap.StepInRequest, resp *dap.StepInResponse) error {
+	var (
+		subReq  dap.NextRequest
+		subResp dap.NextResponse
+	)
+
+	subReq.Arguments.ThreadId = req.Arguments.ThreadId
+	subReq.Arguments.SingleThread = req.Arguments.SingleThread
+	subReq.Arguments.Granularity = req.Arguments.Granularity
+	return d.Next(c, &subReq, &subResp)
+}
+
+func (d *Adapter[C]) StepOut(c Context, req *dap.StepOutRequest, resp *dap.StepOutResponse) error {
+	var (
+		subReq  dap.ContinueRequest
+		subResp dap.ContinueResponse
+	)
+
+	subReq.Arguments.ThreadId = req.Arguments.ThreadId
+	subReq.Arguments.SingleThread = req.Arguments.SingleThread
+	return d.Continue(c, &subReq, &subResp)
+}
+
 func (d *Adapter[C]) SetBreakpoints(c Context, req *dap.SetBreakpointsRequest, resp *dap.SetBreakpointsResponse) error {
 	resp.Body.Breakpoints = d.breakpointMap.Set(req.Arguments.Source.Path, req.Arguments.Breakpoints)
 	return nil
@@ -373,6 +396,8 @@ func (d *Adapter[C]) dapHandler() Handler {
 		Launch:            d.Launch,
 		Continue:          d.Continue,
 		Next:              d.Next,
+		StepIn:            d.StepIn,
+		StepOut:           d.StepOut,
 		SetBreakpoints:    d.SetBreakpoints,
 		ConfigurationDone: d.ConfigurationDone,
 		Disconnect:        d.Disconnect,

--- a/dap/handler.go
+++ b/dap/handler.go
@@ -52,6 +52,8 @@ type Handler struct {
 	Terminate         HandlerFunc[*dap.TerminateRequest, *dap.TerminateResponse]
 	Continue          HandlerFunc[*dap.ContinueRequest, *dap.ContinueResponse]
 	Next              HandlerFunc[*dap.NextRequest, *dap.NextResponse]
+	StepIn            HandlerFunc[*dap.StepInRequest, *dap.StepInResponse]
+	StepOut           HandlerFunc[*dap.StepOutRequest, *dap.StepOutResponse]
 	Restart           HandlerFunc[*dap.RestartRequest, *dap.RestartResponse]
 	Threads           HandlerFunc[*dap.ThreadsRequest, *dap.ThreadsResponse]
 	StackTrace        HandlerFunc[*dap.StackTraceRequest, *dap.StackTraceResponse]

--- a/dap/server.go
+++ b/dap/server.go
@@ -119,6 +119,10 @@ func (s *Server) handleMessage(c Context, m dap.Message) (dap.ResponseMessage, e
 		return s.h.Continue.Do(c, req)
 	case *dap.NextRequest:
 		return s.h.Next.Do(c, req)
+	case *dap.StepInRequest:
+		return s.h.StepIn.Do(c, req)
+	case *dap.StepOutRequest:
+		return s.h.StepOut.Do(c, req)
 	case *dap.RestartRequest:
 		return s.h.Restart.Do(c, req)
 	case *dap.ThreadsRequest:


### PR DESCRIPTION

Step into and step out are required by the UI for DAP. We don't have a
way to implement these in a logical manner but they need to exist. We'll
discuss in further iterations how these might differ from next and
continue, but for now, we just need some implementation for the UI.
