### PR TITLE
driver: mount wsl lib folder for docker-container driver

### DIFF
--- a/builder/node.go
+++ b/builder/node.go
@@ -122,6 +122,7 @@ func (b *Builder) LoadNodes(ctx context.Context, opts ...LoadNodesOption) (_ []N
 					Name:            driver.BuilderName(n.Name),
 					EndpointAddr:    n.Endpoint,
 					DockerAPI:       dockerapi,
+					DockerContext:   b.opts.dockerCli.CurrentContext(),
 					ContextStore:    b.opts.dockerCli.ContextStore(),
 					BuildkitdFlags:  n.BuildkitdFlags,
 					Files:           n.Files,

--- a/driver/docker-container/driver.go
+++ b/driver/docker-container/driver.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/buildx/util/confutil"
 	"github.com/docker/buildx/util/imagetools"
 	"github.com/docker/buildx/util/progress"
+	"github.com/docker/cli/cli/context/docker"
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
@@ -125,15 +126,36 @@ func (d *Driver) create(ctx context.Context, l progress.SubLogger) error {
 		hc := &container.HostConfig{
 			Privileged:    true,
 			RestartPolicy: d.restartPolicy,
-			Mounts: []mount.Mount{
-				{
-					Type:   mount.TypeVolume,
-					Source: d.Name + volumeStateSuffix,
-					Target: confutil.DefaultBuildKitStateDir,
-				},
-			},
-			Init: &useInit,
+			Init:          &useInit,
 		}
+
+		mounts := []mount.Mount{
+			{
+				Type:   mount.TypeVolume,
+				Source: d.Name + volumeStateSuffix,
+				Target: confutil.DefaultBuildKitStateDir,
+			},
+		}
+
+		// Mount WSL libaries if running in WSL environment and Docker context
+		// is a local socket.
+		if os.Getenv("WSL_DISTRO_NAME") != "" {
+			if cm, err := d.ContextStore.GetMetadata(d.DockerContext); err == nil {
+				if epm, err := docker.EndpointFromContext(cm); err == nil && isSocket(epm.Host) {
+					wslLibPath := "/usr/lib/wsl"
+					if st, err := os.Stat(wslLibPath); err == nil && st.IsDir() {
+						mounts = append(mounts, mount.Mount{
+							Type:     mount.TypeBind,
+							Source:   wslLibPath,
+							Target:   wslLibPath,
+							ReadOnly: true,
+						})
+					}
+				}
+			}
+		}
+		hc.Mounts = mounts
+
 		if d.netMode != "" {
 			hc.NetworkMode = container.NetworkMode(d.netMode)
 		}
@@ -530,4 +552,13 @@ func getBuildkitFlags(initConfig driver.InitConfig) []string {
 		flags = append(newFlags, flags...)
 	}
 	return flags
+}
+
+func isSocket(addr string) bool {
+	switch proto, _, _ := strings.Cut(addr, "://"); proto {
+	case "unix", "npipe", "fd":
+		return true
+	default:
+		return false
+	}
 }

--- a/driver/manager.go
+++ b/driver/manager.go
@@ -30,6 +30,7 @@ type InitConfig struct {
 	Name            string
 	EndpointAddr    string
 	DockerAPI       dockerclient.APIClient
+	DockerContext   string
 	ContextStore    store.Reader
 	BuildkitdFlags  []string
 	Files           map[string][]byte


### PR DESCRIPTION
relates to https://github.com/docker/buildx/issues/3295#issuecomment-3088560362

When generating the CDI spec during build for a container builder created on WSL it fails with:

```
#7 11.40 time="2025-07-18T02:55:21Z" level=warning msg="Could not locate libdxcore.so: pattern libdxcore.so not found"
```

It seems requesting GPU on container builder creation introduced in https://github.com/docker/buildx/pull/3063 is not enough as some libraries are missing on WSL.

To fix this issue we can mount the WSL libraries in the container if docker context is local.

```
$ docker buildx create --name wsltest --bootstrap --driver-opt "image=crazymax/buildkit:v0.23.2-ubuntu-nvidia" --buildkitd-flags "--debug"
#1 [internal] booting buildkit
#1 pulling image crazymax/buildkit:v0.23.2-ubuntu-nvidia
#1 pulling image crazymax/buildkit:v0.23.2-ubuntu-nvidia 0.9s done
#1 creating container buildx_buildkit_wsltest0
#1 creating container buildx_buildkit_wsltest0 1.7s done
#1 DONE 2.6s
wsltest
```

```
$ docker inspect buildx_buildkit_wsltest0
...
        "Mounts": [
            {
                "Type": "volume",
                "Name": "buildx_buildkit_wsltest0_state",
                "Source": "/var/lib/docker/volumes/buildx_buildkit_wsltest0_state/_data",
                "Destination": "/var/lib/buildkit",
                "Driver": "local",
                "Mode": "z",
                "RW": true,
                "Propagation": ""
            },
            {
                "Type": "bind",
                "Source": "/run/desktop/mnt/host/wsl/docker-desktop-bind-mounts/Ubuntu/f969f076ad437ac0162d56bf356c2a910d8ddd313a6ac1d90246b6b64d06d59a",
                "Destination": "/usr/lib/wsl",
                "Mode": "",
                "RW": false,
                "Propagation": "rprivate"
            }
        ],
...
```

```dockerfile
# syntax=docker/dockerfile:1.17-labs
FROM ubuntu
RUN --device=nvidia.com/gpu nvidia-smi -L
```

```
$ docker buildx --builder wsltest build --progress=plain .
#0 building with "wsltest" instance using docker-container driver

#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 128B done
#1 DONE 0.1s

#2 resolve image config for docker-image://docker.io/docker/dockerfile:1.17-labs
#2 ...

#3 [auth] docker/dockerfile:pull token for registry-1.docker.io
#3 DONE 0.0s

#2 resolve image config for docker-image://docker.io/docker/dockerfile:1.17-labs
#2 DONE 1.3s

#4 docker-image://docker.io/docker/dockerfile:1.17-labs@sha256:9187104f31e3a002a8a6a3209ea1f937fb7486c093cbbde1e14b0fa0d7e4f1b5
#4 resolve docker.io/docker/dockerfile:1.17-labs@sha256:9187104f31e3a002a8a6a3209ea1f937fb7486c093cbbde1e14b0fa0d7e4f1b5 0.0s done
#4 sha256:a8987824096eac360499af15e51f5ecbaa6120cae7d3fa32cfddb6984d449c0d 0B / 14.09MB 0.2s
#4 sha256:a8987824096eac360499af15e51f5ecbaa6120cae7d3fa32cfddb6984d449c0d 7.34MB / 14.09MB 0.3s
#4 sha256:a8987824096eac360499af15e51f5ecbaa6120cae7d3fa32cfddb6984d449c0d 14.09MB / 14.09MB 0.5s
#4 sha256:a8987824096eac360499af15e51f5ecbaa6120cae7d3fa32cfddb6984d449c0d 14.09MB / 14.09MB 0.5s done
#4 extracting sha256:a8987824096eac360499af15e51f5ecbaa6120cae7d3fa32cfddb6984d449c0d 0.1s done
#4 DONE 0.6s

#5 [internal] load metadata for docker.io/library/ubuntu:latest
#5 ...

#6 [auth] library/ubuntu:pull token for registry-1.docker.io
#6 DONE 0.0s

#5 [internal] load metadata for docker.io/library/ubuntu:latest
#5 DONE 0.8s

#7 [internal] load .dockerignore
#7 transferring context: 2B done
#7 DONE 0.0s

#8 [1/2] FROM docker.io/library/ubuntu:latest@sha256:c4570d2f4665d5d118ae29fb494dee4f8db8fcfaee0e37a2e19b827f399070d3
#8 resolve docker.io/library/ubuntu:latest@sha256:c4570d2f4665d5d118ae29fb494dee4f8db8fcfaee0e37a2e19b827f399070d3 0.0s done
#8 sha256:32f112e3802cadcab3543160f4d2aa607b3cc1c62140d57b4f5441384f40e927 0B / 29.72MB 0.2s
#8 sha256:32f112e3802cadcab3543160f4d2aa607b3cc1c62140d57b4f5441384f40e927 9.44MB / 29.72MB 0.3s
#8 sha256:32f112e3802cadcab3543160f4d2aa607b3cc1c62140d57b4f5441384f40e927 18.87MB / 29.72MB 0.5s
#8 sha256:32f112e3802cadcab3543160f4d2aa607b3cc1c62140d57b4f5441384f40e927 28.31MB / 29.72MB 0.6s
#8 sha256:32f112e3802cadcab3543160f4d2aa607b3cc1c62140d57b4f5441384f40e927 29.72MB / 29.72MB 0.7s done
#8 extracting sha256:32f112e3802cadcab3543160f4d2aa607b3cc1c62140d57b4f5441384f40e927
#8 extracting sha256:32f112e3802cadcab3543160f4d2aa607b3cc1c62140d57b4f5441384f40e927 0.7s done
#8 DONE 1.5s

#9 preparing device nvidia.com/gpu
#9 0.001 > /usr/bin/nvidia-smi -L
#9 0.042 GPU 0: NVIDIA GeForce RTX 3060 Ti (UUID: GPU-63109a83-ae03-3291-b519-c133b6caf78e)
#9 0.051 > apt-get update
#9 0.169 Get:1 http://archive.ubuntu.com/ubuntu noble InRelease [256 kB]
#9 0.246 Get:2 http://archive.ubuntu.com/ubuntu noble-updates InRelease [126 kB]
#9 0.265 Get:3 http://archive.ubuntu.com/ubuntu noble-backports InRelease [126 kB]
#9 0.296 Get:4 http://security.ubuntu.com/ubuntu noble-security InRelease [126 kB]
#9 0.311 Get:5 http://archive.ubuntu.com/ubuntu noble/main amd64 Packages [1808 kB]
#9 0.389 Get:6 http://archive.ubuntu.com/ubuntu noble/restricted amd64 Packages [117 kB]
#9 0.418 Get:7 http://archive.ubuntu.com/ubuntu noble/universe amd64 Packages [19.3 MB]
#9 0.736 Get:8 http://archive.ubuntu.com/ubuntu noble/multiverse amd64 Packages [331 kB]
#9 0.739 Get:9 http://archive.ubuntu.com/ubuntu noble-updates/universe amd64 Packages [1443 kB]
#9 0.763 Get:10 http://archive.ubuntu.com/ubuntu noble-updates/multiverse amd64 Packages [45.2 kB]
#9 0.764 Get:11 http://archive.ubuntu.com/ubuntu noble-updates/restricted amd64 Packages [1942 kB]
#9 0.796 Get:12 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 Packages [1608 kB]
#9 0.813 Get:13 http://security.ubuntu.com/ubuntu noble-security/restricted amd64 Packages [1820 kB]
#9 0.821 Get:14 http://archive.ubuntu.com/ubuntu noble-backports/universe amd64 Packages [33.0 kB]
#9 0.822 Get:15 http://archive.ubuntu.com/ubuntu noble-backports/main amd64 Packages [48.8 kB]
#9 1.399 Get:16 http://security.ubuntu.com/ubuntu noble-security/universe amd64 Packages [1128 kB]
#9 1.446 Get:17 http://security.ubuntu.com/ubuntu noble-security/main amd64 Packages [1270 kB]
#9 1.512 Get:18 http://security.ubuntu.com/ubuntu noble-security/multiverse amd64 Packages [23.0 kB]
#9 1.556 Fetched 31.6 MB in 1s (21.6 MB/s)
#9 1.556 Reading package lists...
#9 2.198 > apt-get install -y gpg
#9 2.204 Reading package lists...
#9 2.816 Building dependency tree...
#9 2.968 Reading state information...
#9 3.114 The following additional packages will be installed:
#9 3.115   dirmngr gpg-agent gpgconf gpgv libksba8 libreadline8t64 libsqlite3-0
#9 3.115   pinentry-curses readline-common
#9 3.115 Suggested packages:
#9 3.115   gnupg dbus-user-session libpam-systemd pinentry-gnome3 tor keyboxd scdaemon
#9 3.115   pinentry-doc readline-doc
#9 3.146 The following NEW packages will be installed:
#9 3.147   dirmngr gpg gpg-agent gpgconf libksba8 libreadline8t64 libsqlite3-0
#9 3.147   pinentry-curses readline-common
#9 3.148 The following packages will be upgraded:
#9 3.149   gpgv
#9 3.193 1 upgraded, 9 newly installed, 0 to remove and 13 not upgraded.
#9 3.193 Need to get 2444 kB of archives.
#9 3.193 After this operation, 5597 kB of additional disk space will be used.
#9 3.193 Get:1 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 gpgv amd64 2.4.4-2ubuntu17.3 [158 kB]
#9 3.262 Get:2 http://archive.ubuntu.com/ubuntu noble/main amd64 readline-common all 8.2-4build1 [56.5 kB]
#9 3.266 Get:3 http://archive.ubuntu.com/ubuntu noble/main amd64 libreadline8t64 amd64 8.2-4build1 [153 kB]
#9 3.281 Get:4 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 libsqlite3-0 amd64 3.45.1-1ubuntu2.3 [701 kB]
#9 3.315 Get:5 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 gpgconf amd64 2.4.4-2ubuntu17.3 [104 kB]
#9 3.317 Get:6 http://archive.ubuntu.com/ubuntu noble/main amd64 libksba8 amd64 1.6.6-1build1 [122 kB]
#9 3.323 Get:7 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 dirmngr amd64 2.4.4-2ubuntu17.3 [323 kB]
#9 3.329 Get:8 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 gpg amd64 2.4.4-2ubuntu17.3 [565 kB]
#9 3.352 Get:9 http://archive.ubuntu.com/ubuntu noble/main amd64 pinentry-curses amd64 1.2.1-3ubuntu5 [35.2 kB]
#9 3.352 Get:10 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 gpg-agent amd64 2.4.4-2ubuntu17.3 [227 kB]
#9 3.490 debconf: delaying package configuration, since apt-utils is not installed
#9 3.530 Fetched 2444 kB in 0s (12.0 MB/s)
(Reading database ... 8613 files and directories currently installed.)
#9 3.580 Preparing to unpack .../gpgv_2.4.4-2ubuntu17.3_amd64.deb ...
#9 3.596 Unpacking gpgv (2.4.4-2ubuntu17.3) over (2.4.4-2ubuntu17.2) ...
#9 3.661 Setting up gpgv (2.4.4-2ubuntu17.3) ...
#9 3.708 Selecting previously unselected package readline-common.
(Reading database ... 8613 files and directories currently installed.)
#9 3.713 Preparing to unpack .../0-readline-common_8.2-4build1_all.deb ...
#9 3.718 Unpacking readline-common (8.2-4build1) ...
#9 3.770 Selecting previously unselected package libreadline8t64:amd64.
#9 3.772 Preparing to unpack .../1-libreadline8t64_8.2-4build1_amd64.deb ...
#9 3.786 Adding 'diversion of /lib/x86_64-linux-gnu/libhistory.so.8 to /lib/x86_64-linux-gnu/libhistory.so.8.usr-is-merged by libreadline8t64'
#9 3.794 Adding 'diversion of /lib/x86_64-linux-gnu/libhistory.so.8.2 to /lib/x86_64-linux-gnu/libhistory.so.8.2.usr-is-merged by libreadline8t64'
#9 3.800 Adding 'diversion of /lib/x86_64-linux-gnu/libreadline.so.8 to /lib/x86_64-linux-gnu/libreadline.so.8.usr-is-merged by libreadline8t64'
#9 3.805 Adding 'diversion of /lib/x86_64-linux-gnu/libreadline.so.8.2 to /lib/x86_64-linux-gnu/libreadline.so.8.2.usr-is-merged by libreadline8t64'
#9 3.809 Unpacking libreadline8t64:amd64 (8.2-4build1) ...
#9 3.856 Selecting previously unselected package libsqlite3-0:amd64.
#9 3.858 Preparing to unpack .../2-libsqlite3-0_3.45.1-1ubuntu2.3_amd64.deb ...
#9 3.863 Unpacking libsqlite3-0:amd64 (3.45.1-1ubuntu2.3) ...
#9 3.903 Selecting previously unselected package gpgconf.
#9 3.904 Preparing to unpack .../3-gpgconf_2.4.4-2ubuntu17.3_amd64.deb ...
#9 3.909 Unpacking gpgconf (2.4.4-2ubuntu17.3) ...
#9 3.954 Selecting previously unselected package libksba8:amd64.
#9 3.955 Preparing to unpack .../4-libksba8_1.6.6-1build1_amd64.deb ...
#9 3.961 Unpacking libksba8:amd64 (1.6.6-1build1) ...
#9 4.006 Selecting previously unselected package dirmngr.
#9 4.007 Preparing to unpack .../5-dirmngr_2.4.4-2ubuntu17.3_amd64.deb ...
#9 4.022 Unpacking dirmngr (2.4.4-2ubuntu17.3) ...
#9 4.062 Selecting previously unselected package gpg.
#9 4.063 Preparing to unpack .../6-gpg_2.4.4-2ubuntu17.3_amd64.deb ...
#9 4.068 Unpacking gpg (2.4.4-2ubuntu17.3) ...
#9 4.113 Selecting previously unselected package pinentry-curses.
#9 4.114 Preparing to unpack .../7-pinentry-curses_1.2.1-3ubuntu5_amd64.deb ...
#9 4.119 Unpacking pinentry-curses (1.2.1-3ubuntu5) ...
#9 4.161 Selecting previously unselected package gpg-agent.
#9 4.162 Preparing to unpack .../8-gpg-agent_2.4.4-2ubuntu17.3_amd64.deb ...
#9 4.167 Unpacking gpg-agent (2.4.4-2ubuntu17.3) ...
#9 4.212 Setting up libksba8:amd64 (1.6.6-1build1) ...
#9 4.228 Setting up pinentry-curses (1.2.1-3ubuntu5) ...
#9 4.255 Setting up libsqlite3-0:amd64 (3.45.1-1ubuntu2.3) ...
#9 4.271 Setting up readline-common (8.2-4build1) ...
#9 4.290 Setting up libreadline8t64:amd64 (8.2-4build1) ...
#9 4.306 Setting up gpgconf (2.4.4-2ubuntu17.3) ...
#9 4.321 Setting up gpg (2.4.4-2ubuntu17.3) ...
#9 4.336 Setting up gpg-agent (2.4.4-2ubuntu17.3) ...
#9 4.693 Setting up dirmngr (2.4.4-2ubuntu17.3) ...
#9 4.796 Processing triggers for libc-bin (2.39-0ubuntu8.4) ...
#9 4.860 Downloading NVIDIA GPG key
#9 4.912 > apt-get update
#9 4.972 Hit:1 http://archive.ubuntu.com/ubuntu noble InRelease
#9 4.981 Hit:2 http://archive.ubuntu.com/ubuntu noble-updates InRelease
#9 4.996 Hit:3 http://archive.ubuntu.com/ubuntu noble-backports InRelease
#9 4.996 Get:4 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64  InRelease [1581 B]
#9 5.128 Hit:5 http://security.ubuntu.com/ubuntu noble-security InRelease
#9 5.155 Get:6 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64  Packages [737 kB]
#9 5.256 Fetched 739 kB in 0s (2257 kB/s)
#9 5.256 Reading package lists...
#9 5.899 > apt-get install -y --no-install-recommends nvidia-container-toolkit-base
#9 5.903 Reading package lists...
#9 6.512 Building dependency tree...
#9 6.683 Reading state information...
#9 6.867 The following NEW packages will be installed:
#9 6.868   nvidia-container-toolkit-base
#9 7.533 0 upgraded, 1 newly installed, 0 to remove and 13 not upgraded.
#9 7.533 Need to get 3797 kB of archives.
#9 7.533 After this operation, 20.7 MB of additional disk space will be used.
#9 7.533 Get:1 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64  nvidia-container-toolkit-base 1.17.8-1 [3797 kB]
#9 7.732 debconf: delaying package configuration, since apt-utils is not installed
#9 7.753 Fetched 3797 kB in 1s (4977 kB/s)
#9 7.775 Selecting previously unselected package nvidia-container-toolkit-base.
(Reading database ... 8732 files and directories currently installed.)
#9 7.779 Preparing to unpack .../nvidia-container-toolkit-base_1.17.8-1_amd64.deb ...
#9 7.785 Unpacking nvidia-container-toolkit-base (1.17.8-1) ...
#9 8.028 Setting up nvidia-container-toolkit-base (1.17.8-1) ...
#9 8.078 time="2025-07-18T11:21:09Z" level=info msg="Using /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1"
#9 8.099 time="2025-07-18T11:21:09Z" level=info msg="Auto-detected mode as 'wsl'"
#9 8.099 time="2025-07-18T11:21:09Z" level=info msg="Selecting /dev/dxg as /dev/dxg"
#9 8.100 time="2025-07-18T11:21:09Z" level=info msg="Using WSL driver store paths: [/usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f]"
#9 8.100 time="2025-07-18T11:21:09Z" level=info msg="Selecting /usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f/libcuda.so.1.1 as /usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f/libcuda.so.1.1"   
#9 8.101 time="2025-07-18T11:21:09Z" level=info msg="Selecting /usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f/libcuda_loader.so as /usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f/libcuda_loader.so"
#9 8.101 time="2025-07-18T11:21:09Z" level=info msg="Selecting /usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f/libnvidia-ptxjitcompiler.so.1 as /usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f/libnvidia-ptxjitcompiler.so.1"
#9 8.101 time="2025-07-18T11:21:09Z" level=info msg="Selecting /usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f/libnvidia-ml.so.1 as /usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f/libnvidia-ml.so.1"
#9 8.102 time="2025-07-18T11:21:09Z" level=info msg="Selecting /usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f/libnvidia-ml_loader.so as /usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f/libnvidia-ml_loader.so"
#9 8.102 time="2025-07-18T11:21:09Z" level=info msg="Selecting /usr/lib/wsl/lib/libdxcore.so as /usr/lib/wsl/lib/libdxcore.so"
#9 8.103 time="2025-07-18T11:21:09Z" level=info msg="Selecting /usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f/libnvdxgdmal.so.1 as /usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f/libnvdxgdmal.so.1"
#9 8.103 time="2025-07-18T11:21:09Z" level=info msg="Selecting /usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f/nvcubins.bin as /usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f/nvcubins.bin"
#9 8.104 time="2025-07-18T11:21:09Z" level=info msg="Selecting /usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f/nvidia-smi as /usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f/nvidia-smi"
#9 8.104 time="2025-07-18T11:21:09Z" level=info msg="Generated CDI spec with version 0.8.0"
#9 DONE 8.1s

#10 [2/2] RUN --device=nvidia.com/gpu nvidia-smi -L
#10 0.129 GPU 0: NVIDIA GeForce RTX 3060 Ti (UUID: GPU-63109a83-ae03-3291-b519-c133b6caf78e)
#10 DONE 0.6s
```

Inspecting the CDI spec we can see `libdxcore.so` is properly detected and mounted:

```
$ docker exec -it buildx_buildkit_wsltest0 cat /etc/cdi/nvidia.yaml
---
cdiVersion: 0.3.0
containerEdits:
  env:
  - NVIDIA_VISIBLE_DEVICES=void
  hooks:
  - args:
    - nvidia-cdi-hook
    - create-symlinks
    - --link
    - /usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f/nvidia-smi::/usr/bin/nvidia-smi
    env:
    - NVIDIA_CTK_DEBUG=false
    hookName: createContainer
    path: /usr/bin/nvidia-cdi-hook
  - args:
    - nvidia-cdi-hook
    - update-ldcache
    - --folder
    - /usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f
    - --folder
    - /usr/lib/wsl/lib
    env:
    - NVIDIA_CTK_DEBUG=false
    hookName: createContainer
    path: /usr/bin/nvidia-cdi-hook
  mounts:
  - containerPath: /usr/lib/wsl/lib/libdxcore.so
    hostPath: /usr/lib/wsl/lib/libdxcore.so
    options:
    - ro
    - nosuid
    - nodev
    - bind
  - containerPath: /usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f/libcuda.so.1.1
    hostPath: /usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f/libcuda.so.1.1
    options:
    - ro
    - nosuid
    - nodev
    - bind
  - containerPath: /usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f/libcuda_loader.so
    hostPath: /usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f/libcuda_loader.so
    options:
    - ro
    - nosuid
    - nodev
    - bind
  - containerPath: /usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f/libnvdxgdmal.so.1
    hostPath: /usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f/libnvdxgdmal.so.1
    options:
    - ro
    - nosuid
    - nodev
    - bind
  - containerPath: /usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f/libnvidia-ml.so.1
    hostPath: /usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f/libnvidia-ml.so.1
    options:
    - ro
    - nosuid
    - nodev
    - bind
  - containerPath: /usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f/libnvidia-ml_loader.so
    hostPath: /usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f/libnvidia-ml_loader.so
    options:
    - ro
    - nosuid
    - nodev
    - bind
  - containerPath: /usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f/libnvidia-ptxjitcompiler.so.1
    hostPath: /usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f/libnvidia-ptxjitcompiler.so.1
    options:
    - ro
    - nosuid
    - nodev
    - bind
  - containerPath: /usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f/nvcubins.bin
    hostPath: /usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f/nvcubins.bin
    options:
    - ro
    - nosuid
    - nodev
    - bind
  - containerPath: /usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f/nvidia-smi
    hostPath: /usr/lib/wsl/drivers/nvmdi.inf_amd64_f55cb1d07ac1033f/nvidia-smi
    options:
    - ro
    - nosuid
    - nodev
    - bind
devices:
- containerEdits:
    deviceNodes:
    - path: /dev/dxg
  name: all
kind: nvidia.com/gpu
```
