### PR TITLE
dap: refactor how step in/step out works

### DIFF
--- a/dap/adapter.go
+++ b/dap/adapter.go
@@ -161,26 +161,21 @@ func (d *Adapter[C]) Next(c Context, req *dap.NextRequest, resp *dap.NextRespons
 }
 
 func (d *Adapter[C]) StepIn(c Context, req *dap.StepInRequest, resp *dap.StepInResponse) error {
-	var (
-		subReq  dap.NextRequest
-		subResp dap.NextResponse
-	)
+	d.threadsMu.RLock()
+	t := d.threads[req.Arguments.ThreadId]
+	d.threadsMu.RUnlock()
 
-	subReq.Arguments.ThreadId = req.Arguments.ThreadId
-	subReq.Arguments.SingleThread = req.Arguments.SingleThread
-	subReq.Arguments.Granularity = req.Arguments.Granularity
-	return d.Next(c, &subReq, &subResp)
+	t.StepIn()
+	return nil
 }
 
 func (d *Adapter[C]) StepOut(c Context, req *dap.StepOutRequest, resp *dap.StepOutResponse) error {
-	var (
-		subReq  dap.ContinueRequest
-		subResp dap.ContinueResponse
-	)
+	d.threadsMu.RLock()
+	t := d.threads[req.Arguments.ThreadId]
+	d.threadsMu.RUnlock()
 
-	subReq.Arguments.ThreadId = req.Arguments.ThreadId
-	subReq.Arguments.SingleThread = req.Arguments.SingleThread
-	return d.Continue(c, &subReq, &subResp)
+	t.StepOut()
+	return nil
 }
 
 func (d *Adapter[C]) SetBreakpoints(c Context, req *dap.SetBreakpointsRequest, resp *dap.SetBreakpointsResponse) error {

--- a/dap/eval.go
+++ b/dap/eval.go
@@ -93,6 +93,10 @@ func replCmd[Flags any, RetVal any](ctx Context, name string, resp *dap.Evaluate
 }
 
 func (t *thread) Exec(ctx Context, args []string) (message string, retErr error) {
+	if t.rCtx == nil {
+		return "", errors.New("no container context for exec")
+	}
+
 	cfg := &build.InvokeConfig{Tty: true}
 	if len(cfg.Entrypoint) == 0 && len(cfg.Cmd) == 0 {
 		cfg.Entrypoint = []string{"/bin/sh"} // launch shell by default

--- a/dap/variables.go
+++ b/dap/variables.go
@@ -15,6 +15,7 @@ import (
 
 type frame struct {
 	dap.StackFrame
+	op     *pb.Op
 	scopes []dap.Scope
 }
 
@@ -42,6 +43,10 @@ func (f *frame) fillLocation(def *llb.Definition, loc *pb.Locations, ws string) 
 			return
 		}
 	}
+}
+
+func (f *frame) ExportVars(refs *variableReferences) {
+	f.fillVarsFromOp(f.op, refs)
 }
 
 func (f *frame) fillVarsFromOp(op *pb.Op, refs *variableReferences) {
@@ -155,6 +160,9 @@ func execOpVars(exec *pb.ExecOp, refs *variableReferences) dap.Variable {
 }
 
 func (f *frame) Scopes() []dap.Scope {
+	if f.scopes == nil {
+		return []dap.Scope{}
+	}
 	return f.scopes
 }
 


### PR DESCRIPTION

Change how breakpoints and stepping works. These now work more how you
would expect another programming language to work. Breakpoints happen
before the step has been invoked rather than after which means you can
inspect the state before the command runs.

This has the advantage of being more intuitive for someone familiar with
other debuggers. The negative is that you can't run to after a certain
step as easily as you could before. Instead, you would run to that stage
and then use next to go to the step directly afterwards.

Step in and out also now have different behaviors. When a step has
multiple inputs, the inputs of non-zero index are considered like
"function calls". The most common cause of this is to use `COPY --from`
or a bind mount. Stepping into these will cause it to jump to the
beginning of the call chain for that branch. Using step out will exit
back to the location where step in was used.

This change also makes it so some steps may be invoked multiple times in
the callgraph if multiple steps depend on them. The reused steps will
still be cached, but you may end up stepping through more lines than the
previous implementation.

Stack traces now represent where these step in and step out areas
happen rather than the previous steps. This can help you know from where
a certain step is being used.
