### PR TITLE
bake: fix compose files validation

### DIFF
--- a/bake/compose.go
+++ b/bake/compose.go
@@ -242,6 +242,9 @@ func loadComposeFiles(cfgs []composetypes.ConfigFile, envs map[string]string, op
 			filtered[key] = v
 		}
 	}
+	if len(filtered) == 0 {
+		return nil, errors.New("empty compose file")
+	}
 
 	if err := composeschema.Validate(filtered); err != nil {
 		return nil, err


### PR DESCRIPTION
fixes #3328

This is a regression from https://github.com/docker/buildx/pull/3292 where we ignore unrelated fields, but we should check that the filtered model is not empty, similar to the load behavior in compose-go: https://github.com/compose-spec/compose-go/blob/a42e7579d813e64c0c1f598a666358bc0c0a0eb4/loader/loader.go#L541-L543.

Otherwise, it erroneously validates it as a Compose file and does not try to load it as an HCL/JSON definition.