### PR TITLE
docs: missing call as override field

### DIFF
--- a/docs/reference/buildx_bake.md
+++ b/docs/reference/buildx_bake.md
@@ -368,6 +368,7 @@ You can override the following fields:
 * `args`
 * `cache-from`
 * `cache-to`
+* `call`
 * `context`
 * `dockerfile`
 * `entitlements`


### PR DESCRIPTION
https://github.com/docker/bake-action/issues/337#issuecomment-3135798103