### PR TITLE
bake: fix dockerfile default if empty

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -676,7 +676,7 @@ func (c Config) ResolveTarget(name string, overrides map[string]map[string]Overr
 		s := "."
 		t.Context = &s
 	}
-	if t.Dockerfile == nil {
+	if t.Dockerfile == nil || (t.Dockerfile != nil && *t.Dockerfile == "") {
 		s := "Dockerfile"
 		t.Dockerfile = &s
 	}

--- a/bake/bake_test.go
+++ b/bake/bake_test.go
@@ -2248,6 +2248,23 @@ target "app" {
 	require.Len(t, m["app"].Outputs, 0)
 }
 
+func TestEmptyDockerfile(t *testing.T) {
+	fp := File{
+		Name: "docker-bake.hcl",
+		Data: []byte(`
+target "app" {
+  dockerfile = ""
+}
+`),
+	}
+
+	ctx := context.TODO()
+	m, _, err := ReadTargets(ctx, []File{fp}, []string{"app"}, nil, nil, &EntitlementConf{})
+	require.NoError(t, err)
+	require.Contains(t, m, "app")
+	require.Equal(t, "Dockerfile", *m["app"].Dockerfile)
+}
+
 // https://github.com/docker/buildx/issues/2859
 func TestGroupTargetsWithDefault(t *testing.T) {
 	t.Run("OnTarget", func(t *testing.T) {


### PR DESCRIPTION
When trying to build a bake target with an empty Dockerfile:

```hcl
target "default" {
  dockerfile = ""
}
```

```
$ docker buildx bake --print
#1 [internal] load local bake definitions
#1 reading docker-bake.hcl 39B / 39B done
#1 DONE 0.0s
{
  "group": {
    "default": {
      "targets": [
        "default"
      ]
    }
  },
  "target": {
    "default": {
      "context": ".",
      "dockerfile": ""
    }
  }
}
```

```
$ docker buildx bake
#0 building with "default" instance using docker driver

#1 [internal] load local bake definitions
#1 reading docker-bake.hcl 39B / 39B done
#1 DONE 0.0s

#2 [internal] load build definition from .
#2 transferring dockerfile: 132B done
#2 DONE 0.0s
ERROR: failed to solve: failed to read dockerfile: read /var/lib/docker/tmp/buildkit-mount205981038: is a directory
```

It doesn't set the default but tries to solve the working dir: `load build definition from .`.

When solving build opts in https://github.com/docker/buildx/blob/1e50e8ddabe108f009b9925e13a321d7c8f99f26/bake/bake.go#L1370-L1376

It will resolve to working dir (`.`) if empty: https://go.dev/play/p/yHTdZe5AXj8

With `build` command it sets `Dockerfile` if empty:

```
$ docker buildx build --file "" .                                                                                                      
#0 building with "default" instance using docker driver                                                                                                                                                        
                                                                                                                                                                                                               
#1 [internal] load build definition from Dockerfile                                                                                                                                                            
#1 transferring dockerfile: 49B done                                                                                                                                                                           
#1 DONE 0.0s
```

I think we should do the same with Bake and check for both nil and empty.