### PR TITLE
dap: look for base name of dockerfile name instead of path from context

### DIFF
--- a/dap/thread.go
+++ b/dap/thread.go
@@ -2,6 +2,7 @@ package dap
 
 import (
 	"context"
+	"path"
 	"path/filepath"
 	"sync"
 
@@ -106,7 +107,14 @@ func (t *thread) init(ctx Context, c gateway.Client, ref gateway.Reference, meta
 	t.c = c
 	t.ref = ref
 	t.meta = meta
-	t.sourcePath = inputs.ContextPath
+
+	// Combine the dockerfile directory with the context path to find the
+	// real base path. The frontend will report the base path as the filename.
+	dir := path.Dir(inputs.DockerfilePath)
+	if !path.IsAbs(dir) {
+		dir = path.Join(inputs.ContextPath, dir)
+	}
+	t.sourcePath = dir
 
 	if err := t.getLLBState(ctx); err != nil {
 		return err

--- a/dap/variables.go
+++ b/dap/variables.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -44,6 +45,7 @@ func (f *frame) fillLocation(def *llb.Definition, loc *pb.Locations, ws string) 
 
 			info := def.Source.Infos[l.SourceIndex]
 			f.Source = &dap.Source{
+				Name: path.Base(info.Filename),
 				Path: filepath.Join(ws, info.Filename),
 			}
 			return


### PR DESCRIPTION

When the builder loads a dockerfile, it does it by using the base name
of the dockerfile path and only loads the innermost directory. This
means that the source name we're looking for is the base name and not
the full relative path.

Update the set breakpoints functionality so it takes this into account.
Fixes scenarios where DAP is used with a dockerfile nested in the
context.
