### PR TITLE
Add BUILDKIT_SYNTAX option handling

### DIFF
--- a/build/opt.go
+++ b/build/opt.go
@@ -116,6 +116,11 @@ func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt *O
 		so.FrontendAttrs["cgroup-parent"] = opt.CgroupParent
 	}
 
+	if v, ok := opt.BuildArgs["BUILDKIT_SYNTAX"]; ok {
+		so.Frontend = "gateway.v0"
+		so.FrontendAttrs["source"] = v
+	}
+
 	if v, ok := opt.BuildArgs["BUILDKIT_MULTI_PLATFORM"]; ok {
 		if v, _ := strconv.ParseBool(v); v {
 			so.FrontendAttrs["multi-platform"] = "true"

--- a/build/opt.go
+++ b/build/opt.go
@@ -117,8 +117,10 @@ func toSolveOpt(ctx context.Context, node builder.Node, multiDriver bool, opt *O
 	}
 
 	if v, ok := opt.BuildArgs["BUILDKIT_SYNTAX"]; ok {
+		p := strings.SplitN(strings.TrimSpace(v), " ", 2)
 		so.Frontend = "gateway.v0"
-		so.FrontendAttrs["source"] = v
+		so.FrontendAttrs["source"] = p[0]
+		so.FrontendAttrs["cmdline"] = v
 	}
 
 	if v, ok := opt.BuildArgs["BUILDKIT_MULTI_PLATFORM"]; ok {


### PR DESCRIPTION
Handle the `BUILDKIT_SYNTAX` build argument directly in buildx instead of relying on the `dockerfile.v0` frontend to perform forwarding.

Derived from #3157 preserving the initial commit from @wnonnemaker and making changes requested by @tonistiigi.