### PR TITLE
restore junctions to have os.ModeSymlink flag set on Windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -183,3 +183,6 @@ exclude (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 )
+
+// restore junctions to have os.ModeSymlink flag set on Windows: https://github.com/docker/buildx/issues/3221
+godebug winsymlink=0


### PR DESCRIPTION
fixes https://github.com/docker/buildx/issues/3221

Since Go 1.23, reparse points are not read anymore: 


> On Windows, the mode bits reported by [Lstat](https://go.dev/pkg/os#Lstat) and [Stat](https://go.dev/pkg/os#Stat) for reparse points changed. Mount points no longer have [ModeSymlink](https://go.dev/pkg/os#ModeSymlink) set, and reparse points that are not symlinks, Unix sockets, or dedup files now always have [ModeIrregular](https://go.dev/pkg/os#ModeIrregular) set. This behavior is controlled by the winsymlink setting. For Go 1.23, it defaults to winsymlink=1. Previous versions default to winsymlink=0.
> (from https://go.dev/doc/go1.23#ospkgos)
> 
> ...
> 
> On Windows, [EvalSymlinks](https://go.dev/pkg/path/filepath#EvalSymlinks) no longer evaluates mount points, which was a source of many inconsistencies and bugs. This behavior is controlled by the winsymlink setting. For Go 1.23, it defaults to winsymlink=1. Previous versions default to winsymlink=0.
> (from https://go.dev/doc/go1.23#pathfilepathpkgpathfilepath)

And therefore files within a NTFS folder using a mounted a volume can't be read when building. Either the context or Dockerfile:

```dockerfile
FROM busybox
RUN echo hello
```

```
> docker buildx build .
[+] Building 0.1s (1/1) FINISHED                                                                   docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                               0.0s
 => => transferring dockerfile: 2B                                                                                 0.0s
ERROR: failed to solve: failed to read dockerfile: open Dockerfile: no such file or directory
```

We can restore the previous behavior by setting `winsymlink=0` in our `go.mod` using the `godebug` directive that pins runtime behavior independently of the go language version.

Before:

```
> docker buildx build .
[+] Building 0.1s (1/1) FINISHED                                                                   docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                               0.0s
 => => transferring dockerfile: 2B                                                                                 0.0s
ERROR: failed to build: failed to run Build function: failed to read dockerfile: open Dockerfile: no such file or directory
```

After:

```
> docker buildx build .
[+] Building 0.4s (6/6) FINISHED                                                                   docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                               0.0s
 => => transferring dockerfile: 65B                                                                                0.0s
 => [internal] load metadata for docker.io/library/busybox:latest                                                  0.1s
 => [internal] load .dockerignore                                                                                  0.0s
 => => transferring context: 2B                                                                                    0.0s
 => [1/2] FROM docker.io/library/busybox:latest@sha256:f85340bf132ae937d2c2a763b8335c9bab35d6e8293f70f606b9c6178d  0.0s
 => => resolve docker.io/library/busybox:latest@sha256:f85340bf132ae937d2c2a763b8335c9bab35d6e8293f70f606b9c6178d  0.0s
 => CACHED [2/2] RUN echo hello                                                                                    0.0s
 => exporting to image                                                                                             0.1s
 => => exporting layers                                                                                            0.0s
 => => exporting manifest sha256:aba0e7cc9ba36a377761381a6545bd136e126fd978a3828a92ec18e68631c677                  0.0s
 => => exporting config sha256:0664101238d194cd8ccc6ca3659cb0aa3709b3f02092e1d70b01866919439fcb                    0.0s
 => => exporting attestation manifest sha256:cf1ae7848a2002c73b8945a7563e8302013b000c6cb40dd74898591c82beb047      0.0s
 => => exporting manifest list sha256:c0b95700bc421c6c1bcfbaaffa23922521abb36371273924cfe47a0e76186196             0.0s
 => => naming to moby-dangling@sha256:c0b95700bc421c6c1bcfbaaffa23922521abb36371273924cfe47a0e76186196             0.0s
 => => unpacking to moby-dangling@sha256:c0b95700bc421c6c1bcfbaaffa23922521abb36371273924cfe47a0e76186196          0.0s
```