### PR TITLE
commands: verify that DisableFlagsInUseLine is set for all commands

### DIFF
--- a/commands/bake.go
+++ b/commands/bake.go
@@ -492,7 +492,8 @@ func bakeCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 			// Other common flags (noCache, pull and progress) are processed in runBake function.
 			return runBake(cmd.Context(), dockerCli, args, options, cFlags, filesFromEnv)
 		},
-		ValidArgsFunction: completion.BakeTargets(options.files),
+		ValidArgsFunction:     completion.BakeTargets(options.files),
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/commands/build.go
+++ b/commands/build.go
@@ -490,6 +490,7 @@ func buildCmd(dockerCli command.Cli, rootOpts *rootOptions, debugger debuggerOpt
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return nil, cobra.ShellCompDirectiveFilterDirs
 		},
+		DisableFlagsInUseLine: true,
 	}
 
 	var platformsDefault []string

--- a/commands/create.go
+++ b/commands/create.go
@@ -98,7 +98,8 @@ func createCmd(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCreate(cmd.Context(), dockerCli, options, args)
 		},
-		ValidArgsFunction: completion.Disable,
+		ValidArgsFunction:     completion.Disable,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/commands/dap.go
+++ b/commands/dap.go
@@ -23,6 +23,8 @@ func dapCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "dap",
 		Short: "Start debug adapter protocol compatible debugger",
+
+		DisableFlagsInUseLine: true,
 	}
 	cobrautil.MarkCommandExperimental(cmd)
 
@@ -116,6 +118,7 @@ func dapAttachCmd() *cobra.Command {
 			}
 			return nil
 		},
+		DisableFlagsInUseLine: true,
 	}
 	return cmd
 }

--- a/commands/debug.go
+++ b/commands/debug.go
@@ -44,6 +44,8 @@ func debugCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "debug",
 		Short: "Start debugger",
+
+		DisableFlagsInUseLine: true,
 	}
 	cobrautil.MarkCommandExperimental(cmd)
 

--- a/commands/dial_stdio.go
+++ b/commands/dial_stdio.go
@@ -122,6 +122,7 @@ func dialStdioCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 			opts.builder = rootOpts.builder
 			return runDialStdio(dockerCli, opts)
 		},
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/commands/diskusage.go
+++ b/commands/diskusage.go
@@ -189,7 +189,8 @@ func duCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 			options.builder = rootOpts.builder
 			return runDiskUsage(cmd.Context(), dockerCli, options)
 		},
-		ValidArgsFunction: completion.Disable,
+		ValidArgsFunction:     completion.Disable,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/commands/history/export.go
+++ b/commands/history/export.go
@@ -160,7 +160,8 @@ func exportCmd(dockerCli command.Cli, rootOpts RootOptions) *cobra.Command {
 			options.builder = *rootOpts.Builder
 			return runExport(cmd.Context(), dockerCli, options)
 		},
-		ValidArgsFunction: completion.Disable,
+		ValidArgsFunction:     completion.Disable,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/commands/history/import.go
+++ b/commands/history/import.go
@@ -125,7 +125,8 @@ func importCmd(dockerCli command.Cli, _ RootOptions) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runImport(cmd.Context(), dockerCli, options)
 		},
-		ValidArgsFunction: completion.Disable,
+		ValidArgsFunction:     completion.Disable,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/commands/history/inspect.go
+++ b/commands/history/inspect.go
@@ -656,7 +656,8 @@ func inspectCmd(dockerCli command.Cli, rootOpts RootOptions) *cobra.Command {
 			options.builder = *rootOpts.Builder
 			return runInspect(cmd.Context(), dockerCli, options)
 		},
-		ValidArgsFunction: completion.Disable,
+		ValidArgsFunction:     completion.Disable,
+		DisableFlagsInUseLine: true,
 	}
 
 	cmd.AddCommand(

--- a/commands/history/inspect_attachment.go
+++ b/commands/history/inspect_attachment.go
@@ -129,7 +129,8 @@ func attachmentCmd(dockerCli command.Cli, rootOpts RootOptions) *cobra.Command {
 			options.builder = *rootOpts.Builder
 			return runAttachment(cmd.Context(), dockerCli, options)
 		},
-		ValidArgsFunction: completion.Disable,
+		ValidArgsFunction:     completion.Disable,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/commands/history/logs.go
+++ b/commands/history/logs.go
@@ -96,7 +96,8 @@ func logsCmd(dockerCli command.Cli, rootOpts RootOptions) *cobra.Command {
 			options.builder = *rootOpts.Builder
 			return runLogs(cmd.Context(), dockerCli, options)
 		},
-		ValidArgsFunction: completion.Disable,
+		ValidArgsFunction:     completion.Disable,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/commands/history/ls.go
+++ b/commands/history/ls.go
@@ -103,7 +103,8 @@ func lsCmd(dockerCli command.Cli, rootOpts RootOptions) *cobra.Command {
 			options.builder = *rootOpts.Builder
 			return runLs(cmd.Context(), dockerCli, options)
 		},
-		ValidArgsFunction: completion.Disable,
+		ValidArgsFunction:     completion.Disable,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/commands/history/open.go
+++ b/commands/history/open.go
@@ -55,7 +55,8 @@ func openCmd(dockerCli command.Cli, rootOpts RootOptions) *cobra.Command {
 			options.builder = *rootOpts.Builder
 			return runOpen(cmd.Context(), dockerCli, options)
 		},
-		ValidArgsFunction: completion.Disable,
+		ValidArgsFunction:     completion.Disable,
+		DisableFlagsInUseLine: true,
 	}
 
 	return cmd

--- a/commands/history/rm.go
+++ b/commands/history/rm.go
@@ -129,7 +129,8 @@ func rmCmd(dockerCli command.Cli, rootOpts RootOptions) *cobra.Command {
 			options.builder = *rootOpts.Builder
 			return runRm(cmd.Context(), dockerCli, options)
 		},
-		ValidArgsFunction: completion.Disable,
+		ValidArgsFunction:     completion.Disable,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/commands/history/root.go
+++ b/commands/history/root.go
@@ -16,6 +16,8 @@ func RootCmd(rootcmd *cobra.Command, dockerCli command.Cli, opts RootOptions) *c
 		Short:             "Commands to work on build records",
 		ValidArgsFunction: completion.Disable,
 		RunE:              rootcmd.RunE,
+
+		DisableFlagsInUseLine: true,
 	}
 
 	cmd.AddCommand(

--- a/commands/history/trace.go
+++ b/commands/history/trace.go
@@ -199,7 +199,8 @@ func traceCmd(dockerCli command.Cli, rootOpts RootOptions) *cobra.Command {
 			options.builder = *rootOpts.Builder
 			return runTrace(cmd.Context(), dockerCli, options)
 		},
-		ValidArgsFunction: completion.Disable,
+		ValidArgsFunction:     completion.Disable,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/commands/imagetools/create.go
+++ b/commands/imagetools/create.go
@@ -279,7 +279,8 @@ func createCmd(dockerCli command.Cli, opts RootOptions) *cobra.Command {
 			options.builder = *opts.Builder
 			return runCreate(cmd.Context(), dockerCli, options, args)
 		},
-		ValidArgsFunction: completion.Disable,
+		ValidArgsFunction:     completion.Disable,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/commands/imagetools/inspect.go
+++ b/commands/imagetools/inspect.go
@@ -52,7 +52,8 @@ func inspectCmd(dockerCli command.Cli, rootOpts RootOptions) *cobra.Command {
 			options.builder = *rootOpts.Builder
 			return runInspect(cmd.Context(), dockerCli, options, args[0])
 		},
-		ValidArgsFunction: completion.Disable,
+		ValidArgsFunction:     completion.Disable,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/commands/imagetools/root.go
+++ b/commands/imagetools/root.go
@@ -12,10 +12,11 @@ type RootOptions struct {
 
 func RootCmd(rootcmd *cobra.Command, dockerCli command.Cli, opts RootOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:               "imagetools",
-		Short:             "Commands to work on images in registry",
-		ValidArgsFunction: completion.Disable,
-		RunE:              rootcmd.RunE,
+		Use:                   "imagetools",
+		Short:                 "Commands to work on images in registry",
+		ValidArgsFunction:     completion.Disable,
+		RunE:                  rootcmd.RunE,
+		DisableFlagsInUseLine: true,
 	}
 
 	cmd.AddCommand(

--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -182,7 +182,8 @@ func inspectCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 			}
 			return runInspect(cmd.Context(), dockerCli, options)
 		},
-		ValidArgsFunction: completion.BuilderNames(dockerCli),
+		ValidArgsFunction:     completion.BuilderNames(dockerCli),
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/commands/install.go
+++ b/commands/install.go
@@ -47,8 +47,9 @@ func installCmd(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runInstall(dockerCli, options)
 		},
-		Hidden:            true,
-		ValidArgsFunction: completion.Disable,
+		Hidden:                true,
+		ValidArgsFunction:     completion.Disable,
+		DisableFlagsInUseLine: true,
 	}
 
 	// hide builder persistent flag for this command

--- a/commands/ls.go
+++ b/commands/ls.go
@@ -107,7 +107,8 @@ func lsCmd(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runLs(cmd.Context(), dockerCli, options)
 		},
-		ValidArgsFunction: completion.Disable,
+		ValidArgsFunction:     completion.Disable,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/commands/prune.go
+++ b/commands/prune.go
@@ -170,7 +170,8 @@ func pruneCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 			options.builder = rootOpts.builder
 			return runPrune(cmd.Context(), dockerCli, options)
 		},
-		ValidArgsFunction: completion.Disable,
+		ValidArgsFunction:     completion.Disable,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/commands/rm.go
+++ b/commands/rm.go
@@ -111,7 +111,8 @@ func rmCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 			}
 			return runRm(cmd.Context(), dockerCli, options)
 		},
-		ValidArgsFunction: completion.BuilderNames(dockerCli),
+		ValidArgsFunction:     completion.BuilderNames(dockerCli),
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/commands/root.go
+++ b/commands/root.go
@@ -71,6 +71,7 @@ func NewRootCmd(name string, isPlugin bool, dockerCli *command.DockerCli) *cobra
 				Status:     fmt.Sprintf("ERROR: unknown command: %q", args[0]),
 			}
 		},
+		DisableFlagsInUseLine: true,
 	}
 	if !isPlugin {
 		// match plugin behavior for standalone mode
@@ -78,8 +79,6 @@ func NewRootCmd(name string, isPlugin bool, dockerCli *command.DockerCli) *cobra
 		cmd.SilenceUsage = true
 		cmd.SilenceErrors = true
 		cmd.TraverseChildren = true
-		cmd.DisableFlagsInUseLine = true
-		cli.DisableFlagsInUseLine(cmd)
 		if !confutil.IsExperimental() {
 			cmd.SetHelpTemplate(cmd.HelpTemplate() + "\n" + experimentalCommandHint + "\n")
 		}

--- a/commands/root_test.go
+++ b/commands/root_test.go
@@ -1,0 +1,33 @@
+package commands
+
+import (
+	stderrs "errors"
+	"testing"
+
+	"github.com/docker/cli/cli/command"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDisableFlagsInUseLineIsSet(t *testing.T) {
+	cmd, err := command.NewDockerCli()
+	require.NoError(t, err)
+	rootCmd := NewRootCmd("buildx", true, cmd)
+
+	var errs []error
+	visitAll(rootCmd, func(c *cobra.Command) {
+		if !c.DisableFlagsInUseLine {
+			errs = append(errs, errors.New("DisableFlagsInUseLine is not set for "+c.CommandPath()))
+		}
+	})
+	err = stderrs.Join(errs...)
+	require.NoError(t, err)
+}
+
+func visitAll(root *cobra.Command, fn func(*cobra.Command)) {
+	for _, cmd := range root.Commands() {
+		visitAll(cmd, fn)
+	}
+	fn(root)
+}

--- a/commands/stop.go
+++ b/commands/stop.go
@@ -44,7 +44,8 @@ func stopCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 			}
 			return runStop(cmd.Context(), dockerCli, options)
 		},
-		ValidArgsFunction: completion.BuilderNames(dockerCli),
+		ValidArgsFunction:     completion.BuilderNames(dockerCli),
+		DisableFlagsInUseLine: true,
 	}
 
 	return cmd

--- a/commands/uninstall.go
+++ b/commands/uninstall.go
@@ -53,8 +53,9 @@ func uninstallCmd(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runUninstall(dockerCli, options)
 		},
-		Hidden:            true,
-		ValidArgsFunction: completion.Disable,
+		Hidden:                true,
+		ValidArgsFunction:     completion.Disable,
+		DisableFlagsInUseLine: true,
 	}
 
 	// hide builder persistent flag for this command

--- a/commands/use.go
+++ b/commands/use.go
@@ -71,7 +71,8 @@ func useCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 			}
 			return runUse(dockerCli, options)
 		},
-		ValidArgsFunction: completion.BuilderNames(dockerCli),
+		ValidArgsFunction:     completion.BuilderNames(dockerCli),
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/commands/version.go
+++ b/commands/version.go
@@ -24,7 +24,8 @@ func versionCmd(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runVersion(dockerCli)
 		},
-		ValidArgsFunction: completion.Disable,
+		ValidArgsFunction:     completion.Disable,
+		DisableFlagsInUseLine: true,
 	}
 
 	// hide builder persistent flag for this command


### PR DESCRIPTION
- alternative to, closes https://github.com/docker/buildx/pull/3393

This replaces the DisableFlagsInUseLine call from the CLI with a test that verifies the option is set for all commands and subcommands, so that it doesn't have to be modified at runtime.