### PR TITLE
dap: use slash separator when reading ref files

### DIFF
--- a/dap/variables.go
+++ b/dap/variables.go
@@ -203,7 +203,7 @@ func fsVars(ctx context.Context, ref gateway.Reference, path string, vars *varia
 			Name: file.Path,
 		}
 
-		fullpath := filepath.Join(path, file.Path)
+		fullpath := filepath.ToSlash(filepath.Join(path, file.Path))
 		if file.IsDir() {
 			fv.Name += "/"
 			fv.VariablesReference = vars.New(func() []dap.Variable {


### PR DESCRIPTION
fixes https://github.com/docker/buildx/issues/3411

<img width="1007" height="529" alt="image" src="https://github.com/user-attachments/assets/1be7d46f-4407-44df-8e76-002e17aec5e1" />
