### PR TITLE
go.mod: bump to go 1.24

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -299,9 +299,8 @@ func validateTargetLinks(reqForNodes map[string][]*reqForNode, drivers map[strin
 
 func toRepoOnly(in string) (string, error) {
 	m := map[string]struct{}{}
-	p := strings.Split(in, ",")
-	for _, pp := range p {
-		n, err := reference.ParseNormalizedNamed(pp)
+	for ref := range strings.SplitSeq(in, ",") {
+		n, err := reference.ParseNormalizedNamed(ref)
 		if err != nil {
 			return "", err
 		}

--- a/build/utils.go
+++ b/build/utils.go
@@ -85,7 +85,7 @@ func toBuildkitExtraHosts(ctx context.Context, inp []string, nodeDriver *driver.
 			}
 			ips = append(ips, hgip.String())
 		} else {
-			for _, v := range strings.Split(ip, ",") {
+			for v := range strings.SplitSeq(ip, ",") {
 				// If the address is enclosed in square brackets, extract it
 				// (for IPv6, but permit it for IPv4 as well; we don't know the
 				// address family here, but it's unambiguous).

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -268,7 +268,7 @@ func (b *Builder) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
 		Name         string
 		Driver       string
-		LastActivity time.Time `json:",omitempty"`
+		LastActivity time.Time
 		Dynamic      bool
 		Nodes        []Node
 		Err          string `json:",omitempty"`

--- a/commands/history/inspect.go
+++ b/commands/history/inspect.go
@@ -88,7 +88,7 @@ type inspectOutput struct {
 	BuildArgs []keyValueOutput `json:",omitempty"`
 	Labels    []keyValueOutput `json:",omitempty"`
 
-	Config configOutput `json:",omitempty"`
+	Config configOutput
 
 	Materials   []materialOutput   `json:",omitempty"`
 	Attachments []attachmentOutput `json:",omitempty"`
@@ -263,7 +263,7 @@ workers0:
 	readAttr(attrs, "platform", &out.Platform, func(v string) ([]string, bool) {
 		return tryParseValue(v, &out.Errors, func(v string) ([]string, error) {
 			var pp []string
-			for _, v := range strings.Split(v, ",") {
+			for v := range strings.SplitSeq(v, ",") {
 				p, err := platforms.Parse(v)
 				if err != nil {
 					return nil, err

--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -155,7 +155,7 @@ func runInspect(ctx context.Context, dockerCli command.Cli, in inspectOptions) e
 				}
 				for f, dt := range nodes[i].Files {
 					fmt.Fprintf(w, "File#%s:\n", f)
-					for _, line := range strings.Split(string(dt), "\n") {
+					for line := range strings.SplitSeq(string(dt), "\n") {
 						fmt.Fprintf(w, "\t> %s\n", line)
 					}
 				}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/docker/buildx
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0

--- a/tests/create.go
+++ b/tests/create.go
@@ -100,7 +100,7 @@ func testCreateRemoteContainer(t *testing.T, sb integration.Sandbox) {
 	out, err = inspectCmd(sb, withArgs(remoteBuilderName))
 	require.NoError(t, err, out)
 
-	for _, line := range strings.Split(out, "\n") {
+	for line := range strings.SplitSeq(out, "\n") {
 		if v, ok := strings.CutPrefix(line, "Status:"); ok {
 			require.Equal(t, "running", strings.TrimSpace(v))
 			return

--- a/tests/inspect.go
+++ b/tests/inspect.go
@@ -32,7 +32,7 @@ func testInspect(t *testing.T, sb integration.Sandbox) {
 	var name string
 	var driver string
 	var hostGatewayIP string
-	for _, line := range strings.Split(out, "\n") {
+	for line := range strings.SplitSeq(out, "\n") {
 		if v, ok := strings.CutPrefix(line, "Name:"); ok && name == "" {
 			name = strings.TrimSpace(v)
 		}
@@ -75,7 +75,7 @@ func testInspectBuildkitdFlags(t *testing.T, sb integration.Sandbox) {
 	out, err = inspectCmd(sb, withArgs(builderName))
 	require.NoError(t, err, out)
 
-	for _, line := range strings.Split(out, "\n") {
+	for line := range strings.SplitSeq(out, "\n") {
 		if v, ok := strings.CutPrefix(line, "BuildKit daemon flags:"); ok {
 			require.Contains(t, v, "--oci-worker-net=bridge")
 			return
@@ -105,7 +105,7 @@ func testInspectNetworkHostEntitlement(t *testing.T, sb integration.Sandbox) {
 	out, err = inspectCmd(sb, withArgs(builderName))
 	require.NoError(t, err, out)
 
-	for _, line := range strings.Split(out, "\n") {
+	for line := range strings.SplitSeq(out, "\n") {
 		if v, ok := strings.CutPrefix(line, "BuildKit daemon flags:"); ok {
 			require.Contains(t, v, "--allow-insecure-entitlement=network.host")
 			return
@@ -160,7 +160,7 @@ insecure-entitlements = ["network.host", "security.insecure"]
 	var fileLines []string
 	var fileFound bool
 	var reConfLine = regexp.MustCompile(`^[\s\t]*>\s(.*)`)
-	for _, line := range strings.Split(out, "\n") {
+	for line := range strings.SplitSeq(out, "\n") {
 		if strings.HasPrefix(line, "File#buildkitd.toml:") {
 			fileFound = true
 			continue

--- a/tests/integration.go
+++ b/tests/integration.go
@@ -184,7 +184,7 @@ func buildkitVersion(t *testing.T, sb integration.Sandbox) string {
 	if !ok {
 		out, err := inspectCmd(sb, withArgs(sb.Address()))
 		require.NoError(t, err, out)
-		for _, line := range strings.Split(out, "\n") {
+		for line := range strings.SplitSeq(out, "\n") {
 			if v, ok := strings.CutPrefix(line, "BuildKit version:"); ok {
 				ver = strings.TrimSpace(v)
 				bkvers[sb.Name()] = ver

--- a/tests/ls.go
+++ b/tests/ls.go
@@ -40,7 +40,7 @@ func testLs(t *testing.T, sb integration.Sandbox) {
 			out, err := lsCmd(sb, withArgs(tt.args...))
 			require.NoError(t, err, out)
 			found := false
-			for _, line := range strings.Split(out, "\n") {
+			for line := range strings.SplitSeq(out, "\n") {
 				if strings.Contains(line, sb.Address()) {
 					found = true
 					require.Contains(t, line, sbDriver)

--- a/tests/workers/docker.go
+++ b/tests/workers/docker.go
@@ -27,8 +27,7 @@ func InitDockerWorker() {
 	})
 	// e.g. `docker@26.0=/opt/docker-26.0,docker@25.0=/opt/docker-25.0`
 	if s := os.Getenv("TEST_DOCKER_EXTRA"); s != "" {
-		entries := strings.Split(s, ",")
-		for _, entry := range entries {
+		for entry := range strings.SplitSeq(s, ",") {
 			ver, bin, err := func(entry string) (string, string, error) {
 				p1 := strings.Split(strings.TrimSpace(entry), "=")
 				if len(p1) != 2 {

--- a/util/buildflags/export.go
+++ b/util/buildflags/export.go
@@ -190,8 +190,7 @@ func ParseAnnotations(inp []string) (map[exptypes.AnnotationKey]string, error) {
 			continue
 		}
 
-		typesSplit := strings.Split(types, ",")
-		for _, typeAndPlatform := range typesSplit {
+		for typeAndPlatform := range strings.SplitSeq(types, ",") {
 			groups := annotationTypeRegexp.FindStringSubmatch(typeAndPlatform)
 			if groups == nil {
 				return nil, errors.Errorf(


### PR DESCRIPTION
relates to https://github.com/docker/buildx/pull/3318#pullrequestreview-3020426158

similar to https://github.com/moby/buildkit/pull/6205

`modernize-fix` run output:

```
#22 0.472 + /gopls-analyzers/modernize -fix ./...
#22 18.12 modernize: modernize@github.com/docker/buildx/builder: ignoring alternative fix "Replace omitempty with omitzero (behavior change)"
#22 18.12 modernize: modernize@github.com/docker/buildx/commands/history: ignoring alternative fix "Replace omitempty with omitzero (behavior change)"
#22 18.12 modernize: modernize@github.com/docker/buildx/builder [github.com/docker/buildx/builder.test]: ignoring alternative fix "Replace omitempty with omitzero (behavior change)"
#22 18.15 + git status --porcelain
#22 18.15 + awk '/^ M/ {print $2}'
#22 18.20 + dirname build/build.go
#22 18.20 + mkdir -p /out/build
#22 18.20 + cp build/build.go /out/build/build.go
#22 18.20 + dirname build/utils.go
#22 18.20 + mkdir -p /out/build
#22 18.20 + cp build/utils.go /out/build/utils.go
#22 18.20 + dirname builder/builder.go
#22 18.20 + mkdir -p /out/builder
#22 18.20 + cp builder/builder.go /out/builder/builder.go
#22 18.20 + dirname commands/history/inspect.go
#22 18.21 + mkdir -p /out/commands/history
#22 18.21 + cp commands/history/inspect.go /out/commands/history/inspect.go
#22 18.21 + dirname commands/inspect.go
#22 18.21 + mkdir -p /out/commands
#22 18.21 + cp commands/inspect.go /out/commands/inspect.go
#22 18.21 + dirname go.mod
#22 18.21 + mkdir -p /out/.
#22 18.21 + cp go.mod /out/go.mod
#22 18.21 + dirname tests/create.go
#22 18.21 + mkdir -p /out/tests
#22 18.21 + cp tests/create.go /out/tests/create.go
#22 18.21 + dirname tests/inspect.go
#22 18.21 + mkdir -p /out/tests
#22 18.21 + cp tests/inspect.go /out/tests/inspect.go
#22 18.21 + dirname tests/integration.go
#22 18.21 + mkdir -p /out/tests
#22 18.22 + cp tests/integration.go /out/tests/integration.go
#22 18.22 + dirname tests/ls.go
#22 18.22 + mkdir -p /out/tests
#22 18.22 + cp tests/ls.go /out/tests/ls.go
#22 18.22 + dirname tests/workers/docker.go
#22 18.22 + mkdir -p /out/tests/workers
#22 18.22 + cp tests/workers/docker.go /out/tests/workers/docker.go
#22 18.22 + dirname util/buildflags/export.go
#22 18.22 + mkdir -p /out/util/buildflags
#22 18.22 + cp util/buildflags/export.go /out/util/buildflags/export.go
#22 DONE 20.4s
```