### PR TITLE
driver/docker-container: remove conditional UsernsMode=host for userns

### DIFF
--- a/driver/docker-container/driver.go
+++ b/driver/docker-container/driver.go
@@ -25,7 +25,6 @@ import (
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
-	"github.com/docker/docker/api/types/system"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/moby/buildkit/client"
@@ -205,17 +204,6 @@ func (d *Driver) create(ctx context.Context, l progress.SubLogger) error {
 				hc.CgroupParent = "/docker/buildx"
 				if d.cgroupParent != "" {
 					hc.CgroupParent = d.cgroupParent
-				}
-			}
-
-			secOpts, err := system.DecodeSecurityOptions(info.SecurityOptions)
-			if err != nil {
-				return err
-			}
-			for _, f := range secOpts {
-				if f.Name == "userns" {
-					hc.UsernsMode = "host"
-					break
 				}
 			}
 		}


### PR DESCRIPTION
relates to:

- https://github.com/docker/buildx/pull/887
    - to address https://github.com/docker/buildx/issues/561
- https://github.com/moby/moby/pull/42736
- https://github.com/moby/moby/pull/43084
- https://github.com/moby/moby/pull/50825



-----

This special handling was added in 5f8600f09865ece328641f965e1e8af65dd37ba1, to work around an issue in the daemon. That issue was fixed in [moby@a826ca3], which was backported to docker v20.10.13 in [moby@660b996].

Given that docker 20.10 reached EOL, and any currently supported version of docker would have the fix from [moby@a826ca3], we can remove this special handling.

[moby@a826ca3]: https://github.com/moby/moby/commit/a826ca3aefbd4d29344d851723731e3809f2a4ad
[moby@660b996]: https://github.com/moby/moby/commit/660b9962e4d2d4ad68898b00571a43127b84f6c3