### PR TITLE
dap: file explorer uses the wrong path when looking up mounts

### DIFF
--- a/dap/variables.go
+++ b/dap/variables.go
@@ -447,7 +447,7 @@ func lookupPath(path string, mounts map[string]gateway.Reference) (remainder str
 	for p, r := range mounts {
 		if len(p) > len(prefix) && strings.HasPrefix(path, p) {
 			prefix = p
-			remainder, _ = filepath.Rel(prefix, p)
+			remainder, _ = filepath.Rel(prefix, path)
 			ref = r
 		}
 	}


### PR DESCRIPTION

It accidentally retrieved the relative path to the mount directory
instead of the full path which resulted in always returning the root
directory.
