### PR TITLE
driver/kubernetes/context: don't use ResolveDefaultContext in test

### DIFF
--- a/driver/kubernetes/context/load_test.go
+++ b/driver/kubernetes/context/load_test.go
@@ -13,10 +13,20 @@ import (
 
 func TestDefaultContextInitializer(t *testing.T) {
 	t.Setenv("KUBECONFIG", "./fixtures/test-kubeconfig")
-	ctx, err := command.ResolveDefaultContext(&cliflags.ClientOptions{}, command.DefaultContextStoreConfig())
+	dockerCLI, err := command.NewDockerCli()
 	require.NoError(t, err)
-	assert.Equal(t, "default", ctx.Meta.Name)
-	assert.Equal(t, "zoinx", ctx.Meta.Endpoints[KubernetesEndpoint].(EndpointMeta).DefaultNamespace)
+
+	// FIXME(thaJeztah): the context-store is not initialized until "Initialize" is called.
+	err = dockerCLI.Initialize(cliflags.NewClientOptions())
+	require.NoError(t, err)
+
+	cs := dockerCLI.ContextStore()
+	assert.NotNil(t, cs)
+	meta, err := cs.GetMetadata(command.DefaultContextName)
+	require.NoError(t, err)
+
+	assert.Equal(t, "default", meta.Name)
+	assert.Equal(t, "zoinx", meta.Endpoints[KubernetesEndpoint].(EndpointMeta).DefaultNamespace)
 }
 
 func TestConfigFromEndpoint(t *testing.T) {


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/6528

The ResolveDefaultContext function is only used internally by the CLI, and has no known external users, except for this test in buildx. It was exported in [cli@f820766] to allow (unit) testing, but did not document that it was only exported for this purpose.

This patch rewrites the test to allow deprecating / removing the function in the CLI.

[cli@f820766]: https://github.com/docker/cli/commit/f820766f6ac57188d96c9ca377f2b4627e90da28