### PR TITLE
dap: utilize the container filesystem for the file explorer

### DIFF
--- a/build/invoke.go
+++ b/build/invoke.go
@@ -11,6 +11,7 @@ import (
 	gateway "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"github.com/tonistiigi/fsutil/types"
 )
 
 type InvokeConfig struct {
@@ -143,6 +144,14 @@ func (c *Container) Exec(ctx context.Context, cfg *InvokeConfig, stdin io.ReadCl
 		c.markUnavailable()
 	}
 	return err
+}
+
+func (c *Container) ReadFile(ctx context.Context, req gateway.ReadRequest) ([]byte, error) {
+	return c.container.ReadFile(ctx, req)
+}
+
+func (c *Container) ReadDir(ctx context.Context, req gateway.ReadDirRequest) ([]*types.Stat, error) {
+	return c.container.ReadDir(ctx, req)
 }
 
 func exec(ctx context.Context, resultCtx *ResultHandle, cfg *InvokeConfig, ctr gateway.Container, stdin io.ReadCloser, stdout io.WriteCloser, stderr io.WriteCloser) error {

--- a/dap/thread.go
+++ b/dap/thread.go
@@ -294,13 +294,13 @@ func (t *thread) pause(c Context, ref gateway.Reference, err error, mounts map[s
 	}
 	t.paused = make(chan stepType, 1)
 
-	ctx, cancel := context.WithCancelCause(c)
-	t.collectStackTrace(ctx, pos, mounts)
-	t.cancel = cancel
-
 	if ref != nil || err != nil {
 		t.prepareResultHandle(c, ref, err)
 	}
+
+	ctx, cancel := context.WithCancelCause(c)
+	t.collectStackTrace(ctx, pos)
+	t.cancel = cancel
 
 	event.ThreadId = t.id
 	c.C() <- &dap.StoppedEvent{
@@ -544,12 +544,13 @@ func (t *thread) releaseState() {
 	t.variables.Reset()
 }
 
-func (t *thread) collectStackTrace(ctx context.Context, pos *step, mounts map[string]gateway.Reference) {
+func (t *thread) collectStackTrace(ctx context.Context, pos *step) {
+	res := t.rCtx
 	for pos != nil {
 		frame := pos.frame
-		frame.ExportVars(ctx, mounts, t.variables)
+		frame.ExportVars(ctx, res, t.variables)
 		t.stackTrace = append(t.stackTrace, int32(frame.Id))
-		pos, mounts = pos.out, nil
+		pos, res = pos.out, nil
 	}
 }
 

--- a/dap/variables.go
+++ b/dap/variables.go
@@ -13,6 +13,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/docker/buildx/build"
 	"github.com/google/go-dap"
 	"github.com/moby/buildkit/client/llb"
 	gateway "github.com/moby/buildkit/frontend/gateway/client"
@@ -67,10 +68,10 @@ func (f *frame) fillLocation(def *llb.Definition, loc *pb.Locations, ws string, 
 	}
 }
 
-func (f *frame) ExportVars(ctx context.Context, mounts map[string]gateway.Reference, refs *variableReferences) {
+func (f *frame) ExportVars(ctx context.Context, res *build.ResultHandle, refs *variableReferences) {
 	f.fillVarsFromOp(f.op, refs)
-	if len(mounts) > 0 {
-		f.fillVarsFromResult(ctx, mounts, refs)
+	if res != nil {
+		f.fillVarsFromResult(ctx, res, refs)
 	}
 }
 
@@ -186,30 +187,35 @@ func execOpVars(exec *pb.ExecOp, refs *variableReferences) dap.Variable {
 	}
 }
 
-func (f *frame) fillVarsFromResult(ctx context.Context, mounts map[string]gateway.Reference, refs *variableReferences) {
+func (f *frame) fillVarsFromResult(ctx context.Context, res *build.ResultHandle, refs *variableReferences) {
 	f.scopes = append(f.scopes, dap.Scope{
 		Name:             "File Explorer",
 		PresentationHint: "locals",
 		VariablesReference: refs.New(func() []dap.Variable {
-			return fsVars(ctx, mounts, "/", refs)
+			ctr, err := build.NewContainer(ctx, res, &build.InvokeConfig{})
+			if err != nil {
+				return []dap.Variable{
+					{
+						Name:  "error1",
+						Value: err.Error(),
+					},
+				}
+			}
+			return fsVars(ctx, ctr, "/", refs)
 		}),
 		Expensive: true,
 	})
 }
 
-func fsVars(ctx context.Context, mounts map[string]gateway.Reference, path string, vars *variableReferences) []dap.Variable {
-	path, ref := lookupPath(path, mounts)
-	if ref == nil {
-		return nil
-	}
-
-	files, err := ref.ReadDir(ctx, gateway.ReadDirRequest{
+func fsVars(ctx context.Context, ctr *build.Container, path string, vars *variableReferences) []dap.Variable {
+	req := gateway.ReadDirRequest{
 		Path: path,
-	})
+	}
+	files, err := ctr.ReadDir(ctx, req)
 	if err != nil {
 		return []dap.Variable{
 			{
-				Name:  "error",
+				Name:  "error2",
 				Value: err.Error(),
 			},
 		}
@@ -233,7 +239,7 @@ func fsVars(ctx context.Context, mounts map[string]gateway.Reference, path strin
 						return statVars(file)
 					}),
 				}
-				return append([]dap.Variable{dvar}, fsVars(ctx, mounts, fullpath, vars)...)
+				return append([]dap.Variable{dvar}, fsVars(ctx, ctr, fullpath, vars)...)
 			})
 			fv.Value = ""
 		} else {
@@ -241,7 +247,7 @@ func fsVars(ctx context.Context, mounts map[string]gateway.Reference, path strin
 			fv.VariablesReference = vars.New(func() (dvars []dap.Variable) {
 				if fs.FileMode(file.Mode).IsRegular() {
 					// Regular file so display a small blurb of the file.
-					dvars = append(dvars, fileVars(ctx, ref, fullpath)...)
+					dvars = append(dvars, fileVars(ctx, ctr, fullpath)...)
 				}
 				return append(dvars, statVars(file)...)
 			})
@@ -257,8 +263,8 @@ func statf(st *types.Stat) string {
 	return fmt.Sprintf("%s %d:%d %s", mode, st.Uid, st.Gid, modTime.Format("Jan 2 15:04:05 2006"))
 }
 
-func fileVars(ctx context.Context, ref gateway.Reference, fullpath string) []dap.Variable {
-	b, err := ref.ReadFile(ctx, gateway.ReadRequest{
+func fileVars(ctx context.Context, ctr *build.Container, fullpath string) []dap.Variable {
+	b, err := ctr.ReadFile(ctx, gateway.ReadRequest{
 		Filename: fullpath,
 		Range:    &gateway.FileRange{Length: 512},
 	})
@@ -274,7 +280,7 @@ func fileVars(ctx context.Context, ref gateway.Reference, fullpath string) []dap
 	} else {
 		if len(b) == 512 {
 			// Get the remainder of the file.
-			remaining, err := ref.ReadFile(ctx, gateway.ReadRequest{
+			remaining, err := ctr.ReadFile(ctx, gateway.ReadRequest{
 				Filename: fullpath,
 				Range:    &gateway.FileRange{Offset: 512},
 			})

--- a/go.mod
+++ b/go.mod
@@ -186,3 +186,5 @@ exclude (
 
 // restore junctions to have os.ModeSymlink flag set on Windows: https://github.com/docker/buildx/issues/3221
 godebug winsymlink=0
+
+replace github.com/moby/buildkit => ../buildkit

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,8 @@ github.com/containerd/fifo v1.1.0 h1:4I2mbh5stb1u6ycIABlBw9zgtlK8viPI9QkQNRQEEmY
 github.com/containerd/fifo v1.1.0/go.mod h1:bmC4NWMbXlt2EZ0Hc7Fx7QzTFxgPID13eH0Qu+MAb2o=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
-github.com/containerd/nydus-snapshotter v0.15.2 h1:qsHI4M+Wwrf6Jr4eBqhNx8qh+YU0dSiJ+WPmcLFWNcg=
-github.com/containerd/nydus-snapshotter v0.15.2/go.mod h1:FfwH2KBkNYoisK/e+KsmNr7xTU53DmnavQHMFOcXwfM=
+github.com/containerd/nydus-snapshotter v0.15.4 h1:l59kGRVMtwMLDLh322HsWhEsBCkRKMkGWYV5vBeLYCE=
+github.com/containerd/nydus-snapshotter v0.15.4/go.mod h1:eRJqnxQDr48HNop15kZdLZpFF5B6vf6Q11Aq1K0E4Ms=
 github.com/containerd/platforms v1.0.0-rc.1 h1:83KIq4yy1erSRgOVHNk1HYdPvzdJ5CnsWaRoJX4C41E=
 github.com/containerd/platforms v1.0.0-rc.1/go.mod h1:J71L7B+aiM5SdIEqmd9wp6THLVRzJGXfNuWCZCllLA4=
 github.com/containerd/plugin v1.0.0 h1:c8Kf1TNl6+e2TtMHZt+39yAPDbouRH9WAToRjex483Y=
@@ -255,8 +255,6 @@ github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTS
 github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
 github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/mitchellh/mapstructure v0.0.0-20150613213606-2caf8efc9366/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
-github.com/moby/buildkit v0.25.0 h1:cRgh74ymzyHxS5a/lsYT4OCyVU8iC3UgkwasIEUi0og=
-github.com/moby/buildkit v0.25.0/go.mod h1:phM8sdqnvgK2y1dPDnbwI6veUCXHOZ6KFSl6E164tkc=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/go-archive v0.1.0 h1:Kk/5rdW/g+H8NHdJW2gsXyZ7UnzvJNOy6VKJqueWdcQ=

--- a/vendor/github.com/moby/buildkit/client/build.go
+++ b/vendor/github.com/moby/buildkit/client/build.go
@@ -178,6 +178,36 @@ func (g *gatewayClientForBuild) ReleaseContainer(ctx context.Context, in *gatewa
 	return g.gateway.ReleaseContainer(ctx, in, opts...)
 }
 
+func (g *gatewayClientForBuild) ReadFileContainer(ctx context.Context, in *gatewayapi.ReadFileRequest, opts ...grpc.CallOption) (*gatewayapi.ReadFileResponse, error) {
+	if g.caps != nil {
+		if err := g.caps.Supports(gatewayapi.CapGatewayExecFilesystem); err != nil {
+			return nil, err
+		}
+	}
+	ctx = buildid.AppendToOutgoingContext(ctx, g.buildID)
+	return g.gateway.ReadFileContainer(ctx, in, opts...)
+}
+
+func (g *gatewayClientForBuild) ReadDirContainer(ctx context.Context, in *gatewayapi.ReadDirRequest, opts ...grpc.CallOption) (*gatewayapi.ReadDirResponse, error) {
+	if g.caps != nil {
+		if err := g.caps.Supports(gatewayapi.CapGatewayExecFilesystem); err != nil {
+			return nil, err
+		}
+	}
+	ctx = buildid.AppendToOutgoingContext(ctx, g.buildID)
+	return g.gateway.ReadDirContainer(ctx, in, opts...)
+}
+
+func (g *gatewayClientForBuild) StatFileContainer(ctx context.Context, in *gatewayapi.StatFileRequest, opts ...grpc.CallOption) (*gatewayapi.StatFileResponse, error) {
+	if g.caps != nil {
+		if err := g.caps.Supports(gatewayapi.CapGatewayExecFilesystem); err != nil {
+			return nil, err
+		}
+	}
+	ctx = buildid.AppendToOutgoingContext(ctx, g.buildID)
+	return g.gateway.StatFileContainer(ctx, in, opts...)
+}
+
 func (g *gatewayClientForBuild) ExecProcess(ctx context.Context, opts ...grpc.CallOption) (gatewayapi.LLBBridge_ExecProcessClient, error) {
 	if g.caps != nil {
 		if err := g.caps.Supports(gatewayapi.CapGatewayExec); err != nil {

--- a/vendor/github.com/moby/buildkit/frontend/gateway/client/client.go
+++ b/vendor/github.com/moby/buildkit/frontend/gateway/client/client.go
@@ -66,6 +66,7 @@ type Mount struct {
 type Container interface {
 	Start(context.Context, StartRequest) (ContainerProcess, error)
 	Release(context.Context) error
+	MountReference
 }
 
 // StartRequest encapsulates the arguments to define a process within a
@@ -101,6 +102,10 @@ type ContainerProcess interface {
 type Reference interface {
 	ToState() (llb.State, error)
 	Evaluate(ctx context.Context) error
+	MountReference
+}
+
+type MountReference interface {
 	ReadFile(ctx context.Context, req ReadRequest) ([]byte, error)
 	StatFile(ctx context.Context, req StatRequest) (*fstypes.Stat, error)
 	ReadDir(ctx context.Context, req ReadDirRequest) ([]*fstypes.Stat, error)

--- a/vendor/github.com/moby/buildkit/frontend/gateway/grpcclient/client.go
+++ b/vendor/github.com/moby/buildkit/frontend/gateway/grpcclient/client.go
@@ -1105,6 +1105,67 @@ func (ctr *container) Release(ctx context.Context) error {
 	return err
 }
 
+func (ctr *container) ReadFile(ctx context.Context, req client.ReadRequest) ([]byte, error) {
+	if err := ctr.caps.Supports(pb.CapGatewayExecFilesystem); err != nil {
+		return nil, err
+	}
+
+	bklog.G(ctx).Debugf("|---> ReadFileContainer %s", ctr.id)
+	in := &pb.ReadFileRequest{
+		Ref:      ctr.id,
+		FilePath: req.Filename,
+	}
+	if req.Range != nil {
+		in.Range = &pb.FileRange{
+			Length: int64(req.Range.Length),
+			Offset: int64(req.Range.Offset),
+		}
+	}
+
+	resp, err := ctr.client.ReadFileContainer(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
+}
+
+func (ctr *container) ReadDir(ctx context.Context, req client.ReadDirRequest) ([]*fstypes.Stat, error) {
+	if err := ctr.caps.Supports(pb.CapGatewayExecFilesystem); err != nil {
+		return nil, err
+	}
+
+	bklog.G(ctx).Debugf("|---> ReadDirContainer %s", ctr.id)
+	in := &pb.ReadDirRequest{
+		Ref:            ctr.id,
+		DirPath:        req.Path,
+		IncludePattern: req.IncludePattern,
+	}
+
+	resp, err := ctr.client.ReadDirContainer(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Entries, nil
+}
+
+func (ctr *container) StatFile(ctx context.Context, req client.StatRequest) (*fstypes.Stat, error) {
+	if err := ctr.caps.Supports(pb.CapGatewayExecFilesystem); err != nil {
+		return nil, err
+	}
+
+	bklog.G(ctx).Debugf("|---> StatFileContainer %s", ctr.id)
+	in := &pb.StatFileRequest{
+		Ref:  ctr.id,
+		Path: req.Path,
+	}
+
+	resp, err := ctr.client.StatFileContainer(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Stat, nil
+}
+
 type containerProcess struct {
 	execMsgs *messageForwarder
 	id       string

--- a/vendor/github.com/moby/buildkit/frontend/gateway/pb/caps.go
+++ b/vendor/github.com/moby/buildkit/frontend/gateway/pb/caps.go
@@ -52,6 +52,10 @@ const (
 	// created via gateway exec.
 	CapGatewayExecSignals apicaps.CapID = "gateway.exec.signals"
 
+	// CapGatewayExecFilesystem is the capability to interact with the filesystem for
+	// containers directly through the gateway.
+	CapGatewayExecFilesystem apicaps.CapID = "gateway.exec.filesystem"
+
 	// CapFrontendCaps can be used to check that frontends define support for certain capabilities
 	CapFrontendCaps apicaps.CapID = "frontend.caps"
 
@@ -197,6 +201,13 @@ func init() {
 	Caps.Init(apicaps.Cap{
 		ID:      CapGatewayExecSignals,
 		Name:    "gateway exec signals",
+		Enabled: true,
+		Status:  apicaps.CapStatusExperimental,
+	})
+
+	Caps.Init(apicaps.Cap{
+		ID:      CapGatewayExecFilesystem,
+		Name:    "gateway exec filesystem",
 		Enabled: true,
 		Status:  apicaps.CapStatusExperimental,
 	})

--- a/vendor/github.com/moby/buildkit/frontend/gateway/pb/gateway.pb.go
+++ b/vendor/github.com/moby/buildkit/frontend/gateway/pb/gateway.pb.go
@@ -2945,7 +2945,7 @@ const file_github_com_moby_buildkit_frontend_gateway_pb_gateway_proto_rawDesc = 
 	"\x06Bundle\x10\x01*&\n" +
 	"\x11InTotoSubjectKind\x12\b\n" +
 	"\x04Self\x10\x00\x12\a\n" +
-	"\x03Raw\x10\x012\xbd\v\n" +
+	"\x03Raw\x10\x012\x84\x0e\n" +
 	"\tLLBBridge\x12\x81\x01\n" +
 	"\x12ResolveImageConfig\x124.moby.buildkit.v1.frontend.ResolveImageConfigRequest\x1a5.moby.buildkit.v1.frontend.ResolveImageConfigResponse\x12~\n" +
 	"\x11ResolveSourceMeta\x123.moby.buildkit.v1.frontend.ResolveSourceMetaRequest\x1a4.moby.buildkit.v1.frontend.ResolveSourceMetaResponse\x12Z\n" +
@@ -2959,7 +2959,10 @@ const file_github_com_moby_buildkit_frontend_gateway_pb_gateway_proto_rawDesc = 
 	"\x06Inputs\x12(.moby.buildkit.v1.frontend.InputsRequest\x1a).moby.buildkit.v1.frontend.InputsResponse\x12o\n" +
 	"\fNewContainer\x12..moby.buildkit.v1.frontend.NewContainerRequest\x1a/.moby.buildkit.v1.frontend.NewContainerResponse\x12{\n" +
 	"\x10ReleaseContainer\x122.moby.buildkit.v1.frontend.ReleaseContainerRequest\x1a3.moby.buildkit.v1.frontend.ReleaseContainerResponse\x12a\n" +
-	"\vExecProcess\x12&.moby.buildkit.v1.frontend.ExecMessage\x1a&.moby.buildkit.v1.frontend.ExecMessage(\x010\x01\x12W\n" +
+	"\vExecProcess\x12&.moby.buildkit.v1.frontend.ExecMessage\x1a&.moby.buildkit.v1.frontend.ExecMessage(\x010\x01\x12l\n" +
+	"\x11ReadFileContainer\x12*.moby.buildkit.v1.frontend.ReadFileRequest\x1a+.moby.buildkit.v1.frontend.ReadFileResponse\x12i\n" +
+	"\x10ReadDirContainer\x12).moby.buildkit.v1.frontend.ReadDirRequest\x1a*.moby.buildkit.v1.frontend.ReadDirResponse\x12l\n" +
+	"\x11StatFileContainer\x12*.moby.buildkit.v1.frontend.StatFileRequest\x1a+.moby.buildkit.v1.frontend.StatFileResponse\x12W\n" +
 	"\x04Warn\x12&.moby.buildkit.v1.frontend.WarnRequest\x1a'.moby.buildkit.v1.frontend.WarnResponseBHZFgithub.com/moby/buildkit/frontend/gateway/pb;moby_buildkit_v1_frontendb\x06proto3"
 
 var (
@@ -3123,23 +3126,29 @@ var file_github_com_moby_buildkit_frontend_gateway_pb_gateway_proto_depIdxs = []
 	34, // 69: moby.buildkit.v1.frontend.LLBBridge.NewContainer:input_type -> moby.buildkit.v1.frontend.NewContainerRequest
 	36, // 70: moby.buildkit.v1.frontend.LLBBridge.ReleaseContainer:input_type -> moby.buildkit.v1.frontend.ReleaseContainerRequest
 	38, // 71: moby.buildkit.v1.frontend.LLBBridge.ExecProcess:input_type -> moby.buildkit.v1.frontend.ExecMessage
-	32, // 72: moby.buildkit.v1.frontend.LLBBridge.Warn:input_type -> moby.buildkit.v1.frontend.WarnRequest
-	14, // 73: moby.buildkit.v1.frontend.LLBBridge.ResolveImageConfig:output_type -> moby.buildkit.v1.frontend.ResolveImageConfigResponse
-	16, // 74: moby.buildkit.v1.frontend.LLBBridge.ResolveSourceMeta:output_type -> moby.buildkit.v1.frontend.ResolveSourceMetaResponse
-	20, // 75: moby.buildkit.v1.frontend.LLBBridge.Solve:output_type -> moby.buildkit.v1.frontend.SolveResponse
-	23, // 76: moby.buildkit.v1.frontend.LLBBridge.ReadFile:output_type -> moby.buildkit.v1.frontend.ReadFileResponse
-	25, // 77: moby.buildkit.v1.frontend.LLBBridge.ReadDir:output_type -> moby.buildkit.v1.frontend.ReadDirResponse
-	27, // 78: moby.buildkit.v1.frontend.LLBBridge.StatFile:output_type -> moby.buildkit.v1.frontend.StatFileResponse
-	29, // 79: moby.buildkit.v1.frontend.LLBBridge.Evaluate:output_type -> moby.buildkit.v1.frontend.EvaluateResponse
-	31, // 80: moby.buildkit.v1.frontend.LLBBridge.Ping:output_type -> moby.buildkit.v1.frontend.PongResponse
-	10, // 81: moby.buildkit.v1.frontend.LLBBridge.Return:output_type -> moby.buildkit.v1.frontend.ReturnResponse
-	12, // 82: moby.buildkit.v1.frontend.LLBBridge.Inputs:output_type -> moby.buildkit.v1.frontend.InputsResponse
-	35, // 83: moby.buildkit.v1.frontend.LLBBridge.NewContainer:output_type -> moby.buildkit.v1.frontend.NewContainerResponse
-	37, // 84: moby.buildkit.v1.frontend.LLBBridge.ReleaseContainer:output_type -> moby.buildkit.v1.frontend.ReleaseContainerResponse
-	38, // 85: moby.buildkit.v1.frontend.LLBBridge.ExecProcess:output_type -> moby.buildkit.v1.frontend.ExecMessage
-	33, // 86: moby.buildkit.v1.frontend.LLBBridge.Warn:output_type -> moby.buildkit.v1.frontend.WarnResponse
-	73, // [73:87] is the sub-list for method output_type
-	59, // [59:73] is the sub-list for method input_type
+	21, // 72: moby.buildkit.v1.frontend.LLBBridge.ReadFileContainer:input_type -> moby.buildkit.v1.frontend.ReadFileRequest
+	24, // 73: moby.buildkit.v1.frontend.LLBBridge.ReadDirContainer:input_type -> moby.buildkit.v1.frontend.ReadDirRequest
+	26, // 74: moby.buildkit.v1.frontend.LLBBridge.StatFileContainer:input_type -> moby.buildkit.v1.frontend.StatFileRequest
+	32, // 75: moby.buildkit.v1.frontend.LLBBridge.Warn:input_type -> moby.buildkit.v1.frontend.WarnRequest
+	14, // 76: moby.buildkit.v1.frontend.LLBBridge.ResolveImageConfig:output_type -> moby.buildkit.v1.frontend.ResolveImageConfigResponse
+	16, // 77: moby.buildkit.v1.frontend.LLBBridge.ResolveSourceMeta:output_type -> moby.buildkit.v1.frontend.ResolveSourceMetaResponse
+	20, // 78: moby.buildkit.v1.frontend.LLBBridge.Solve:output_type -> moby.buildkit.v1.frontend.SolveResponse
+	23, // 79: moby.buildkit.v1.frontend.LLBBridge.ReadFile:output_type -> moby.buildkit.v1.frontend.ReadFileResponse
+	25, // 80: moby.buildkit.v1.frontend.LLBBridge.ReadDir:output_type -> moby.buildkit.v1.frontend.ReadDirResponse
+	27, // 81: moby.buildkit.v1.frontend.LLBBridge.StatFile:output_type -> moby.buildkit.v1.frontend.StatFileResponse
+	29, // 82: moby.buildkit.v1.frontend.LLBBridge.Evaluate:output_type -> moby.buildkit.v1.frontend.EvaluateResponse
+	31, // 83: moby.buildkit.v1.frontend.LLBBridge.Ping:output_type -> moby.buildkit.v1.frontend.PongResponse
+	10, // 84: moby.buildkit.v1.frontend.LLBBridge.Return:output_type -> moby.buildkit.v1.frontend.ReturnResponse
+	12, // 85: moby.buildkit.v1.frontend.LLBBridge.Inputs:output_type -> moby.buildkit.v1.frontend.InputsResponse
+	35, // 86: moby.buildkit.v1.frontend.LLBBridge.NewContainer:output_type -> moby.buildkit.v1.frontend.NewContainerResponse
+	37, // 87: moby.buildkit.v1.frontend.LLBBridge.ReleaseContainer:output_type -> moby.buildkit.v1.frontend.ReleaseContainerResponse
+	38, // 88: moby.buildkit.v1.frontend.LLBBridge.ExecProcess:output_type -> moby.buildkit.v1.frontend.ExecMessage
+	23, // 89: moby.buildkit.v1.frontend.LLBBridge.ReadFileContainer:output_type -> moby.buildkit.v1.frontend.ReadFileResponse
+	25, // 90: moby.buildkit.v1.frontend.LLBBridge.ReadDirContainer:output_type -> moby.buildkit.v1.frontend.ReadDirResponse
+	27, // 91: moby.buildkit.v1.frontend.LLBBridge.StatFileContainer:output_type -> moby.buildkit.v1.frontend.StatFileResponse
+	33, // 92: moby.buildkit.v1.frontend.LLBBridge.Warn:output_type -> moby.buildkit.v1.frontend.WarnResponse
+	76, // [76:93] is the sub-list for method output_type
+	59, // [59:76] is the sub-list for method input_type
 	59, // [59:59] is the sub-list for extension type_name
 	59, // [59:59] is the sub-list for extension extendee
 	0,  // [0:59] is the sub-list for field type_name

--- a/vendor/github.com/moby/buildkit/frontend/gateway/pb/gateway.proto
+++ b/vendor/github.com/moby/buildkit/frontend/gateway/pb/gateway.proto
@@ -34,6 +34,9 @@ service LLBBridge {
 	rpc NewContainer(NewContainerRequest) returns (NewContainerResponse);
 	rpc ReleaseContainer(ReleaseContainerRequest) returns (ReleaseContainerResponse);
 	rpc ExecProcess(stream ExecMessage) returns (stream ExecMessage);
+  rpc ReadFileContainer(ReadFileRequest) returns (ReadFileResponse);
+  rpc ReadDirContainer(ReadDirRequest) returns (ReadDirResponse);
+  rpc StatFileContainer(StatFileRequest) returns (StatFileResponse);
 
 	// apicaps:CapGatewayWarnings
 	rpc Warn(WarnRequest) returns (WarnResponse);

--- a/vendor/github.com/moby/buildkit/frontend/gateway/pb/gateway_grpc.pb.go
+++ b/vendor/github.com/moby/buildkit/frontend/gateway/pb/gateway_grpc.pb.go
@@ -32,6 +32,9 @@ const (
 	LLBBridge_NewContainer_FullMethodName       = "/moby.buildkit.v1.frontend.LLBBridge/NewContainer"
 	LLBBridge_ReleaseContainer_FullMethodName   = "/moby.buildkit.v1.frontend.LLBBridge/ReleaseContainer"
 	LLBBridge_ExecProcess_FullMethodName        = "/moby.buildkit.v1.frontend.LLBBridge/ExecProcess"
+	LLBBridge_ReadFileContainer_FullMethodName  = "/moby.buildkit.v1.frontend.LLBBridge/ReadFileContainer"
+	LLBBridge_ReadDirContainer_FullMethodName   = "/moby.buildkit.v1.frontend.LLBBridge/ReadDirContainer"
+	LLBBridge_StatFileContainer_FullMethodName  = "/moby.buildkit.v1.frontend.LLBBridge/StatFileContainer"
 	LLBBridge_Warn_FullMethodName               = "/moby.buildkit.v1.frontend.LLBBridge/Warn"
 )
 
@@ -60,6 +63,9 @@ type LLBBridgeClient interface {
 	NewContainer(ctx context.Context, in *NewContainerRequest, opts ...grpc.CallOption) (*NewContainerResponse, error)
 	ReleaseContainer(ctx context.Context, in *ReleaseContainerRequest, opts ...grpc.CallOption) (*ReleaseContainerResponse, error)
 	ExecProcess(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[ExecMessage, ExecMessage], error)
+	ReadFileContainer(ctx context.Context, in *ReadFileRequest, opts ...grpc.CallOption) (*ReadFileResponse, error)
+	ReadDirContainer(ctx context.Context, in *ReadDirRequest, opts ...grpc.CallOption) (*ReadDirResponse, error)
+	StatFileContainer(ctx context.Context, in *StatFileRequest, opts ...grpc.CallOption) (*StatFileResponse, error)
 	// apicaps:CapGatewayWarnings
 	Warn(ctx context.Context, in *WarnRequest, opts ...grpc.CallOption) (*WarnResponse, error)
 }
@@ -205,6 +211,36 @@ func (c *lLBBridgeClient) ExecProcess(ctx context.Context, opts ...grpc.CallOpti
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type LLBBridge_ExecProcessClient = grpc.BidiStreamingClient[ExecMessage, ExecMessage]
 
+func (c *lLBBridgeClient) ReadFileContainer(ctx context.Context, in *ReadFileRequest, opts ...grpc.CallOption) (*ReadFileResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ReadFileResponse)
+	err := c.cc.Invoke(ctx, LLBBridge_ReadFileContainer_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *lLBBridgeClient) ReadDirContainer(ctx context.Context, in *ReadDirRequest, opts ...grpc.CallOption) (*ReadDirResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ReadDirResponse)
+	err := c.cc.Invoke(ctx, LLBBridge_ReadDirContainer_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *lLBBridgeClient) StatFileContainer(ctx context.Context, in *StatFileRequest, opts ...grpc.CallOption) (*StatFileResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(StatFileResponse)
+	err := c.cc.Invoke(ctx, LLBBridge_StatFileContainer_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *lLBBridgeClient) Warn(ctx context.Context, in *WarnRequest, opts ...grpc.CallOption) (*WarnResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(WarnResponse)
@@ -240,6 +276,9 @@ type LLBBridgeServer interface {
 	NewContainer(context.Context, *NewContainerRequest) (*NewContainerResponse, error)
 	ReleaseContainer(context.Context, *ReleaseContainerRequest) (*ReleaseContainerResponse, error)
 	ExecProcess(grpc.BidiStreamingServer[ExecMessage, ExecMessage]) error
+	ReadFileContainer(context.Context, *ReadFileRequest) (*ReadFileResponse, error)
+	ReadDirContainer(context.Context, *ReadDirRequest) (*ReadDirResponse, error)
+	StatFileContainer(context.Context, *StatFileRequest) (*StatFileResponse, error)
 	// apicaps:CapGatewayWarnings
 	Warn(context.Context, *WarnRequest) (*WarnResponse, error)
 }
@@ -289,6 +328,15 @@ func (UnimplementedLLBBridgeServer) ReleaseContainer(context.Context, *ReleaseCo
 }
 func (UnimplementedLLBBridgeServer) ExecProcess(grpc.BidiStreamingServer[ExecMessage, ExecMessage]) error {
 	return status.Errorf(codes.Unimplemented, "method ExecProcess not implemented")
+}
+func (UnimplementedLLBBridgeServer) ReadFileContainer(context.Context, *ReadFileRequest) (*ReadFileResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReadFileContainer not implemented")
+}
+func (UnimplementedLLBBridgeServer) ReadDirContainer(context.Context, *ReadDirRequest) (*ReadDirResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReadDirContainer not implemented")
+}
+func (UnimplementedLLBBridgeServer) StatFileContainer(context.Context, *StatFileRequest) (*StatFileResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method StatFileContainer not implemented")
 }
 func (UnimplementedLLBBridgeServer) Warn(context.Context, *WarnRequest) (*WarnResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Warn not implemented")
@@ -536,6 +584,60 @@ func _LLBBridge_ExecProcess_Handler(srv interface{}, stream grpc.ServerStream) e
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type LLBBridge_ExecProcessServer = grpc.BidiStreamingServer[ExecMessage, ExecMessage]
 
+func _LLBBridge_ReadFileContainer_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ReadFileRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(LLBBridgeServer).ReadFileContainer(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: LLBBridge_ReadFileContainer_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(LLBBridgeServer).ReadFileContainer(ctx, req.(*ReadFileRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _LLBBridge_ReadDirContainer_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ReadDirRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(LLBBridgeServer).ReadDirContainer(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: LLBBridge_ReadDirContainer_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(LLBBridgeServer).ReadDirContainer(ctx, req.(*ReadDirRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _LLBBridge_StatFileContainer_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(StatFileRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(LLBBridgeServer).StatFileContainer(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: LLBBridge_StatFileContainer_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(LLBBridgeServer).StatFileContainer(ctx, req.(*StatFileRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _LLBBridge_Warn_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(WarnRequest)
 	if err := dec(in); err != nil {
@@ -608,6 +710,18 @@ var LLBBridge_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ReleaseContainer",
 			Handler:    _LLBBridge_ReleaseContainer_Handler,
+		},
+		{
+			MethodName: "ReadFileContainer",
+			Handler:    _LLBBridge_ReadFileContainer_Handler,
+		},
+		{
+			MethodName: "ReadDirContainer",
+			Handler:    _LLBBridge_ReadDirContainer_Handler,
+		},
+		{
+			MethodName: "StatFileContainer",
+			Handler:    _LLBBridge_StatFileContainer_Handler,
 		},
 		{
 			MethodName: "Warn",

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -448,7 +448,7 @@ github.com/mitchellh/go-wordwrap
 # github.com/mitchellh/hashstructure/v2 v2.0.2
 ## explicit; go 1.14
 github.com/mitchellh/hashstructure/v2
-# github.com/moby/buildkit v0.25.0
+# github.com/moby/buildkit v0.25.0 => ../buildkit
 ## explicit; go 1.24.0
 github.com/moby/buildkit/api/services/control
 github.com/moby/buildkit/api/types
@@ -1343,3 +1343,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
+# github.com/moby/buildkit => ../buildkit


### PR DESCRIPTION

This utilizes the container filesystem for the file explorer instead of
using the reference directly. For the error condition, this allows us to
gain access to the filesystem when the error happened with its current
state at the time of the error rather than before the step even ran.

A better solution for resolving #3410. Relies on functionality in #6262.
