### PR TITLE
Ensure typed variables with no value still carry type

### DIFF
--- a/bake/hclparser/hclparser.go
+++ b/bake/hclparser/hclparser.go
@@ -304,17 +304,21 @@ func (p *parser) resolveValue(ectx *hcl.EvalContext, name string) (err error) {
 		}
 	}
 
+	var vv cty.Value
 	if def == nil {
 		// Lack of specified value, when untyped is considered to have an empty string value.
 		// A typed variable with no value will result in (typed) nil.
-		if _, ok, _ := p.valueHasOverride(name, false); !ok && !typeSpecified {
-			vv := cty.StringVal("")
+		if _, ok, _ := p.valueHasOverride(name, false); !ok {
+			if typeSpecified {
+				vv = cty.NullVal(varType)
+			} else {
+				vv = cty.StringVal("")
+			}
 			v = &vv
 			return
 		}
 	}
 
-	var vv cty.Value
 	if def != nil {
 		if diags := p.loadDeps(ectx, def.Expr, nil, true); diags.HasErrors() {
 			return diags


### PR DESCRIPTION
Fixes #3463 

A value-less, untyped variable has always been converted to an empty string.  The *intention* was that value-less, typed variables convert to a  typed null, which was even specified in a code comment, but was never actually implemented.

This resulted in a null value with a nil type.  A value with a nil type cannot be coerced ("unified") with any other standard types.  When this mismatch occurs, HCL attempts to return a diagnostic error, which in turn panics as the nil type is literally a nil pointer.

---

There were existing tests that covered value-less, typed variables, but those were centered around ensuring that bake could handle them and didn't alter their value (unlike untyped variables); they treated no value (or explicit null) more as an error condition/edge case and didn't cover intentional uses.

Also, I noticed at some point some JSON-specific tests were added to complement the HCL-specific tests around typing; let me know if this PR should have equivalent JSON tests as well.
