### PR TITLE
deprecate `docker buildx install` and `docker buildx uninstall`

### DIFF
--- a/commands/install.go
+++ b/commands/install.go
@@ -47,6 +47,7 @@ func installCmd(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runInstall(dockerCli, options)
 		},
+		Deprecated:            "use 'docker buildx' directly, without relying on the 'docker builder' alias",
 		Hidden:                true,
 		ValidArgsFunction:     completion.Disable,
 		DisableFlagsInUseLine: true,

--- a/commands/uninstall.go
+++ b/commands/uninstall.go
@@ -53,6 +53,7 @@ func uninstallCmd(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runUninstall(dockerCli, options)
 		},
+		Deprecated:            "use 'docker buildx' directly, without relying on the 'docker builder' alias",
 		Hidden:                true,
 		ValidArgsFunction:     completion.Disable,
 		DisableFlagsInUseLine: true,


### PR DESCRIPTION
Deprecate these commands in favor of using `docker buildx` directly, without relying on the `docker builder` alias.

The commands have been hidden since the beginning.