### PR TITLE
Correct no-cache attribute to be a boolean

### DIFF
--- a/docs/bake-reference.md
+++ b/docs/bake-reference.md
@@ -883,7 +883,7 @@ This is the same as the `--no-cache` flag for `docker build`.
 
 ```hcl
 target "default" {
-  no-cache = 1
+  no-cache = true
 }
 ```
 


### PR DESCRIPTION
The documentation is incorrect because `no-cache` needs to be a boolean.

```
$ docker buildx version
github.com/docker/buildx v0.29.1-desktop.1 28f6246ff24e2c05095e8741e48c48dcb2d3b4bc
```
```HCL
target "default" {
  no-cache = 1
}
```
```
$ docker buildx bake --print default
[+] Building 0.0s (1/1) FINISHED
 => [internal] load local bake definitions                                                                                                                                  0.0s
 => => reading docker-bake.hcl 36B / 36B                                                                                                                                    0.0s
docker-bake.hcl:2
--------------------
   1 |     target "default" {
   2 | >>>   no-cache = 1
   3 |     }
   4 |
--------------------
ERROR: docker-bake.hcl:2,14-15: Unsuitable value type; Unsuitable value: bool required, but have number
```