### PR TITLE
test: Handle version not having the initial 'v'

### DIFF
--- a/tests/version.go
+++ b/tests/version.go
@@ -50,10 +50,4 @@ func testVersion(t *testing.T, sb integration.Sandbox) {
 		version = "v" + version
 	}
 	require.True(t, semver.IsValid(version), "Second field was not valid semver: %+v", version)
-
-	// Revision should be empty or should look like a git hash.
-	if len(fields) > 2 && len(fields[2]) > 0 {
-		revision := fields[2]
-		require.Regexp(t, `[0-9a-f]{40}`, revision, "Third field was not a git revision: %+v", revision)
-	}
 }


### PR DESCRIPTION
- Handle `version` command not having the initial 'v' as some Linux distributions like Debian, openSUSE & Fedora strip the initial `v`
- Drop git commit test as downstream use other information on the 3rd field.

```
/usr/libexec/docker/cli-plugins/docker-buildx version
github.com/docker/buildx 0.13.1+ds1 0.13.1+ds1-3
```

```
$ /usr/lib/docker/cli-plugins/docker-buildx version
github.com/docker/buildx 0.29.0 v0.29.0
```

```
$ /usr/libexec/docker/cli-plugins/docker-buildx version
github.com/docker/buildx 0.29.1 1.fc42
```

