### PR TITLE
build: create parent directories for tar output in lazy writer

### DIFF
--- a/tests/bake.go
+++ b/tests/bake.go
@@ -1359,17 +1359,19 @@ target "default" {
 
 	dirDest := t.TempDir()
 
+	envs := []string{"BUILDX_METADATA_PROVENANCE=" + metadataMode}
 	outFlag := "default.output=type=docker"
 	if sb.DockerAddress() == "" {
 		// there is no Docker atm to load the image
 		outFlag += ",dest=" + dirDest + "/image.tar"
+		envs = append(envs, "BUILDX_BAKE_ENTITLEMENTS_FS=0")
 	}
 
 	cmd := buildxCmd(
 		sb,
 		withDir(dir),
 		withArgs("bake", "--metadata-file", filepath.Join(dirDest, "md.json"), "--set", outFlag),
-		withEnv("BUILDX_METADATA_PROVENANCE="+metadataMode),
+		withEnv(envs...),
 	)
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(out))

--- a/tests/build.go
+++ b/tests/build.go
@@ -417,10 +417,11 @@ func testBuildLocalExport(t *testing.T, sb integration.Sandbox) {
 
 func testBuildTarExport(t *testing.T, sb integration.Sandbox) {
 	dir := createTestProject(t)
-	out, err := buildCmd(sb, withArgs(fmt.Sprintf("--output=type=tar,dest=%s/result.tar", dir), dir))
+	outdir := path.Join(dir, "out")
+	out, err := buildCmd(sb, withArgs(fmt.Sprintf("--output=type=tar,dest=%s/result.tar", outdir), dir))
 	require.NoError(t, err, string(out))
 
-	dt, err := os.ReadFile(fmt.Sprintf("%s/result.tar", dir))
+	dt, err := os.ReadFile(fmt.Sprintf("%s/result.tar", outdir))
 	require.NoError(t, err)
 	m, err := testutil.ReadTarToMap(dt, false)
 	require.NoError(t, err)


### PR DESCRIPTION
This change updates the tar output logic for exporters to ensure parent directories are created automatically when writing to a file destination.

Previously, file creation would fail if the target directory did not exist, which would fail builds that rely on dynamic directory creation:

```
$ docker buildx build --output type=tar,dest=./does/not/exists/result.tar -<<< $'FROM busybox'
ERROR: failed to build: failed to open open ./does/not/exists/result.tar: no such file or directory
```

I have created a lazy file writer that calls `os.MkdirAll` before creating the file so we are consistent with the `local` output that already creates subdirectories if they don't exist.

```hcl
$ docker buildx build --output type=tar,dest=./does/not/exists/result.tar -<<< $'FROM busybox'
#0 building with "default" instance using docker driver

#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 50B done
#1 DONE 0.0s

#2 [auth] library/busybox:pull token for registry-1.docker.io
#2 DONE 0.0s

#3 [internal] load metadata for docker.io/library/busybox:latest
#3 DONE 0.7s

#4 [internal] load .dockerignore
#4 transferring context: 2B done
#4 DONE 0.0s

#5 [1/1] FROM docker.io/library/busybox:latest@sha256:2f590fc602ce325cbff2ccfc39499014d039546dc400ef8bbf5c6ffb860632e7
#5 resolve docker.io/library/busybox:latest@sha256:2f590fc602ce325cbff2ccfc39499014d039546dc400ef8bbf5c6ffb860632e7 0.0s done
#5 CACHED

#6 exporting to client tarball
#6 sending tarball 0.1s done
#6 DONE 0.1s
```

```
$ tree does/
does/
└── not
    └── exists
        └── result.tar

2 directories, 1 file
```

With bake:

```hcl
# docker-bake.hcl
target "default" {
  output = ["type=tar,dest=./does/not/exists/result.tar"]
}
```

Before:

```
$ docker buildx bake --print
#1 [internal] load local bake definitions
#1 reading docker-bake.hcl 79B / 79B done
#1 DONE 0.0s
ERROR: failed to open open ./does/not/exists/result.tar: no such file or directory
```

After:

```
$ docker buildx bake --print
#1 [internal] load local bake definitions
#1 reading docker-bake.hcl 79B / 79B done
#1 DONE 0.0s
{
  "group": {
    "default": {
      "targets": [
        "default"
      ]
    }
  },
  "target": {
    "default": {
      "context": ".",
      "dockerfile": "Dockerfile",
      "output": [
        {
          "dest": "./does/not/exists/result.tar",
          "type": "tar"
        }
      ]
    }
  }
}
```

This also fixes another issue where there is left over build result on client side before the build even starts like:

```hcl
target "default" {
  output = ["type=docker,dest=./dist/result.tar"]
}
```

```
$ docker buildx bake --print
#1 [internal] load local bake definitions
#1 reading docker-bake.hcl 72B / 72B done
#1 DONE 0.0s
{
  "group": {
    "default": {
      "targets": [
        "default"
      ]
    }
  },
  "target": {
    "default": {
      "context": ".",
      "dockerfile": "Dockerfile",
      "output": [
        {
          "dest": "../dist/result.tar",
          "type": "docker"
        }
      ]
    }
  }
}
```

```
$ ls ./dist
result.tar
```

cc @maxcleme 