### PR TITLE
build: avoid panic on linking to nil target

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -1074,9 +1074,12 @@ func waitContextDeps(ctx context.Context, index int, results *waitmap.Map, so *c
 		for _, v := range contexts {
 			if len(rr.Refs) > 0 {
 				for platform, r := range rr.Refs {
-					st, err := r.ToState()
-					if err != nil {
-						return err
+					st := llb.Scratch()
+					if r != nil {
+						st, err = r.ToState()
+						if err != nil {
+							return err
+						}
 					}
 					so.FrontendInputs[k+"::"+platform] = st
 					so.FrontendAttrs[v+"::"+platform] = "input:" + k + "::" + platform


### PR DESCRIPTION
improves #3508

Note that nil targets still do not work as buildkit does not currently support build inputs with nil values.

But this gives cleaner error from buildkit instead of panic on the client side.