### PR TITLE
build: Don't unpack by default when pushing

### DIFF
--- a/build/opt.go
+++ b/build/opt.go
@@ -831,6 +831,10 @@ func CreateExports(entries []*buildflags.ExportEntry) ([]client.ExportEntry, []s
 		case "registry":
 			out.Type = client.ExporterImage
 			out.Attrs["push"] = "true"
+			// Skip unpacking when only pushing to registry (unless explicitly set)
+			if _, ok := out.Attrs["unpack"]; !ok {
+				out.Attrs["unpack"] = "false"
+			}
 		}
 
 		if supportDir {

--- a/commands/build.go
+++ b/commands/build.go
@@ -542,7 +542,7 @@ func buildCmd(dockerCli command.Cli, rootOpts *rootOptions, debugger debuggerOpt
 
 	flags.StringArrayVar(&options.platforms, "platform", platformsDefault, "Set target platform for build")
 
-	flags.BoolVar(&options.exportPush, "push", false, `Shorthand for "--output=type=registry"`)
+	flags.BoolVar(&options.exportPush, "push", false, `Shorthand for "--output=type=registry,unpack=false"`)
 
 	flags.BoolVarP(&options.quiet, "quiet", "q", false, "Suppress the build output and print image ID on success")
 
@@ -1048,6 +1048,10 @@ func RunBuild(ctx context.Context, dockerCli command.Cli, in *BuildOptions, inSt
 		for i := range outputs {
 			if outputs[i].Type == client.ExporterImage {
 				outputs[i].Attrs["push"] = "true"
+				// Skip unpacking when only pushing to registry (unless explicitly set)
+				if _, ok := outputs[i].Attrs["unpack"]; !ok {
+					outputs[i].Attrs["unpack"] = "false"
+				}
 				pushUsed = true
 			}
 		}
@@ -1056,6 +1060,8 @@ func RunBuild(ctx context.Context, dockerCli command.Cli, in *BuildOptions, inSt
 				Type: client.ExporterImage,
 				Attrs: map[string]string{
 					"push": "true",
+					// Skip unpacking when only pushing to registry
+					"unpack": "false",
 				},
 			})
 		}

--- a/docs/reference/buildx_build.md
+++ b/docs/reference/buildx_build.md
@@ -41,7 +41,7 @@ Start a build
 | [`--progress`](#progress)               | `string`      | `auto`    | Set type of progress output (`auto`, `none`,  `plain`, `quiet`, `rawjson`, `tty`). Use plain to show container output |
 | [`--provenance`](#provenance)           | `string`      |           | Shorthand for `--attest=type=provenance`                                                                              |
 | `--pull`                                | `bool`        |           | Always attempt to pull all referenced images                                                                          |
-| [`--push`](#push)                       | `bool`        |           | Shorthand for `--output=type=registry`                                                                                |
+| [`--push`](#push)                       | `bool`        |           | Shorthand for `--output=type=registry,unpack=false`                                                                   |
 | `-q`, `--quiet`                         | `bool`        |           | Suppress the build output and print image ID on success                                                               |
 | [`--sbom`](#sbom)                       | `string`      |           | Shorthand for `--attest=type=sbom`                                                                                    |
 | [`--secret`](#secret)                   | `stringArray` |           | Secret to expose to the build (format: `id=mysecret[,src=/local/secret]`)                                             |

--- a/docs/reference/buildx_dap_build.md
+++ b/docs/reference/buildx_dap_build.md
@@ -33,7 +33,7 @@ Start a build
 | `--progress`        | `string`      | `auto`    | Set type of progress output (`auto`, `none`,  `plain`, `quiet`, `rawjson`, `tty`). Use plain to show container output |
 | `--provenance`      | `string`      |           | Shorthand for `--attest=type=provenance`                                                                              |
 | `--pull`            | `bool`        |           | Always attempt to pull all referenced images                                                                          |
-| `--push`            | `bool`        |           | Shorthand for `--output=type=registry`                                                                                |
+| `--push`            | `bool`        |           | Shorthand for `--output=type=registry,unpack=false`                                                                   |
 | `-q`, `--quiet`     | `bool`        |           | Suppress the build output and print image ID on success                                                               |
 | `--sbom`            | `string`      |           | Shorthand for `--attest=type=sbom`                                                                                    |
 | `--secret`          | `stringArray` |           | Secret to expose to the build (format: `id=mysecret[,src=/local/secret]`)                                             |

--- a/docs/reference/buildx_debug_build.md
+++ b/docs/reference/buildx_debug_build.md
@@ -37,7 +37,7 @@ Start a build
 | `--progress`        | `string`      | `auto`    | Set type of progress output (`auto`, `none`,  `plain`, `quiet`, `rawjson`, `tty`). Use plain to show container output |
 | `--provenance`      | `string`      |           | Shorthand for `--attest=type=provenance`                                                                              |
 | `--pull`            | `bool`        |           | Always attempt to pull all referenced images                                                                          |
-| `--push`            | `bool`        |           | Shorthand for `--output=type=registry`                                                                                |
+| `--push`            | `bool`        |           | Shorthand for `--output=type=registry,unpack=false`                                                                   |
 | `-q`, `--quiet`     | `bool`        |           | Suppress the build output and print image ID on success                                                               |
 | `--sbom`            | `string`      |           | Shorthand for `--attest=type=sbom`                                                                                    |
 | `--secret`          | `stringArray` |           | Secret to expose to the build (format: `id=mysecret[,src=/local/secret]`)                                             |


### PR DESCRIPTION
- alternative to: https://github.com/moby/moby/pull/51494
- fixes https://github.com/moby/moby/issues/51442

Automatically set `unpack=false` for registry exports unless explicitly overridden by the user.

This applies to:

- `registry` exporter type (converted to `image` exporter with `push=true`)
- `--push` flag usage with image exporters

Users can still explicitly set `unpack=true` if they need local image storage alongside registry push.