### PR TITLE
docs: add a link from the cli reference to the bake file reference for variables

### DIFF
--- a/docs/reference/buildx_bake.md
+++ b/docs/reference/buildx_bake.md
@@ -458,3 +458,7 @@ You can append using `+=` operator for the following fields:
 
 > [!NOTE]
 > ¹ These fields already append by default.
+
+### <a name="variables"></a> Override variables in a Bake file
+
+See the [Variable](buildx_bake.md#variable) section in the Bake file reference.


### PR DESCRIPTION

I spent some time looking how to override a variable in a bakefile. My
assumption was that there would be a CLI option to do that and was
confused when I couldn't find it. This adds a reference to point someone
in the correct direction of using environment variables which is present
in the bake file reference but isn't in the CLI documentation.
