### PR TITLE
docs: remove unnecessary custom anchors and heading in bake stdlib

### DIFF
--- a/docs/bake-stdlib.md
+++ b/docs/bake-stdlib.md
@@ -113,9 +113,7 @@ title: Bake standard library functions
 
 <!---MARKER_STDLIB_END-->
 
-## Examples
-
-### <a name="absolute"></a> `absolute`
+## `absolute`
 
 ```hcl
 # docker-bake.hcl
@@ -128,7 +126,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="add"></a> `add`
+## `add`
 
 ```hcl
 # docker-bake.hcl
@@ -141,7 +139,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="and"></a> `and`
+## `and`
 
 ```hcl
 # docker-bake.hcl
@@ -154,7 +152,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="base64decode"></a> `base64decode`
+## `base64decode`
 
 ```hcl
 # docker-bake.hcl
@@ -167,7 +165,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="base64encode"></a> `base64encode`
+## `base64encode`
 
 ```hcl
 # docker-bake.hcl
@@ -180,7 +178,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="basename"></a> `basename`
+## `basename`
 
 ```hcl
 # docker-bake.hcl
@@ -193,7 +191,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="bcrypt"></a> `bcrypt`
+## `bcrypt`
 
 ```hcl
 # docker-bake.hcl
@@ -206,7 +204,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="byteslen"></a> `byteslen`
+## `byteslen`
 
 ```hcl
 # docker-bake.hcl
@@ -219,7 +217,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="bytesslice"></a> `bytesslice`
+## `bytesslice`
 
 ```hcl
 # docker-bake.hcl
@@ -232,7 +230,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="can"></a> `can`
+## `can`
 
 ```hcl
 # docker-bake.hcl
@@ -245,7 +243,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="ceil"></a> `ceil`
+## `ceil`
 
 ```hcl
 # docker-bake.hcl
@@ -258,7 +256,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="chomp"></a> `chomp`
+## `chomp`
 
 ```hcl
 # docker-bake.hcl
@@ -271,7 +269,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="chunklist"></a> `chunklist`
+## `chunklist`
 
 ```hcl
 # docker-bake.hcl
@@ -284,7 +282,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="cidrhost"></a> `cidrhost`
+## `cidrhost`
 
 ```hcl
 # docker-bake.hcl
@@ -297,7 +295,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="cidrnetmask"></a> `cidrnetmask`
+## `cidrnetmask`
 
 ```hcl
 # docker-bake.hcl
@@ -310,7 +308,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="cidrsubnet"></a> `cidrsubnet`
+## `cidrsubnet`
 
 ```hcl
 # docker-bake.hcl
@@ -323,7 +321,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="cidrsubnets"></a> `cidrsubnets`
+## `cidrsubnets`
 
 ```hcl
 # docker-bake.hcl
@@ -336,7 +334,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="coalesce"></a> `coalesce`
+## `coalesce`
 
 ```hcl
 # docker-bake.hcl
@@ -349,7 +347,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="coalescelist"></a> `coalescelist`
+## `coalescelist`
 
 ```hcl
 # docker-bake.hcl
@@ -362,7 +360,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="compact"></a> `compact`
+## `compact`
 
 ```hcl
 # docker-bake.hcl
@@ -375,7 +373,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="concat"></a> `concat`
+## `concat`
 
 ```hcl
 # docker-bake.hcl
@@ -388,7 +386,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="contains"></a> `contains`
+## `contains`
 
 ```hcl
 # docker-bake.hcl
@@ -401,7 +399,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="convert"></a> `convert`
+## `convert`
 
 ```hcl
 # docker-bake.hcl
@@ -414,7 +412,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="csvdecode"></a> `csvdecode`
+## `csvdecode`
 
 ```hcl
 # docker-bake.hcl
@@ -427,7 +425,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="dirname"></a> `dirname`
+## `dirname`
 
 ```hcl
 # docker-bake.hcl
@@ -440,7 +438,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="distinct"></a> `distinct`
+## `distinct`
 
 ```hcl
 # docker-bake.hcl
@@ -453,7 +451,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="divide"></a> `divide`
+## `divide`
 
 ```hcl
 # docker-bake.hcl
@@ -466,7 +464,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="element"></a> `element`
+## `element`
 
 ```hcl
 # docker-bake.hcl
@@ -479,7 +477,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="equal"></a> `equal`
+## `equal`
 
 ```hcl
 # docker-bake.hcl
@@ -492,7 +490,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="flatten"></a> `flatten`
+## `flatten`
 
 ```hcl
 # docker-bake.hcl
@@ -505,7 +503,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="floor"></a> `floor`
+## `floor`
 
 ```hcl
 # docker-bake.hcl
@@ -518,7 +516,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="format"></a> `format`
+## `format`
 
 ```hcl
 # docker-bake.hcl
@@ -531,7 +529,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="formatdate"></a> `formatdate`
+## `formatdate`
 
 ```hcl
 # docker-bake.hcl
@@ -544,7 +542,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="formatlist"></a> `formatlist`
+## `formatlist`
 
 ```hcl
 # docker-bake.hcl
@@ -557,7 +555,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="greaterthan"></a> `greaterthan`
+## `greaterthan`
 
 ```hcl
 # docker-bake.hcl
@@ -570,7 +568,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="greaterthanorequalto"></a> `greaterthanorequalto`
+## `greaterthanorequalto`
 
 ```hcl
 # docker-bake.hcl
@@ -583,7 +581,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="hasindex"></a> `hasindex`
+## `hasindex`
 
 ```hcl
 # docker-bake.hcl
@@ -597,7 +595,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="homedir"></a> `homedir`
+## `homedir`
 
 ```hcl
 # docker-bake.hcl
@@ -610,7 +608,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="indent"></a> `indent`
+## `indent`
 
 ```hcl
 # docker-bake.hcl
@@ -624,7 +622,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="index"></a> `index`
+## `index`
 
 ```hcl
 # docker-bake.hcl
@@ -637,7 +635,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="indexof"></a> `indexof`
+## `indexof`
 
 ```hcl
 # docker-bake.hcl
@@ -650,7 +648,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="int"></a> `int`
+## `int`
 
 ```hcl
 # docker-bake.hcl
@@ -663,7 +661,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="join"></a> `join`
+## `join`
 
 ```hcl
 # docker-bake.hcl
@@ -676,7 +674,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="jsondecode"></a> `jsondecode`
+## `jsondecode`
 
 ```hcl
 # docker-bake.hcl
@@ -689,7 +687,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="jsonencode"></a> `jsonencode`
+## `jsonencode`
 
 ```hcl
 # docker-bake.hcl
@@ -702,7 +700,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="keys"></a> `keys`
+## `keys`
 
 ```hcl
 # docker-bake.hcl
@@ -716,7 +714,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="length"></a> `length`
+## `length`
 
 ```hcl
 # docker-bake.hcl
@@ -729,7 +727,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="lessthan"></a> `lessthan`
+## `lessthan`
 
 ```hcl
 # docker-bake.hcl
@@ -742,7 +740,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="lessthanorequalto"></a> `lessthanorequalto`
+## `lessthanorequalto`
 
 ```hcl
 # docker-bake.hcl
@@ -755,7 +753,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="log"></a> `log`
+## `log`
 
 ```hcl
 # docker-bake.hcl
@@ -768,7 +766,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="lookup"></a> `lookup`
+## `lookup`
 
 ```hcl
 # docker-bake.hcl
@@ -781,7 +779,7 @@ target "webapp-dev" {
   }
 }
 ```
-### <a name="lower"></a> `lower`
+## `lower`
 
 ```hcl
 # docker-bake.hcl
@@ -794,7 +792,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="max"></a> `max`
+## `max`
 
 ```hcl
 # docker-bake.hcl
@@ -807,7 +805,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="md5"></a> `md5`
+## `md5`
 
 ```hcl
 # docker-bake.hcl
@@ -820,7 +818,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="merge"></a> `merge`
+## `merge`
 
 ```hcl
 # docker-bake.hcl
@@ -833,7 +831,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="min"></a> `min`
+## `min`
 
 ```hcl
 # docker-bake.hcl
@@ -846,7 +844,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="modulo"></a> `modulo`
+## `modulo`
 
 ```hcl
 # docker-bake.hcl
@@ -859,7 +857,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="multiply"></a> `multiply`
+## `multiply`
 
 ```hcl
 # docker-bake.hcl
@@ -872,7 +870,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="negate"></a> `negate`
+## `negate`
 
 ```hcl
 # docker-bake.hcl
@@ -885,7 +883,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="not"></a> `not`
+## `not`
 
 ```hcl
 # docker-bake.hcl
@@ -898,7 +896,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="notequal"></a> `notequal`
+## `notequal`
 
 ```hcl
 # docker-bake.hcl
@@ -911,7 +909,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="or"></a> `or`
+## `or`
 
 ```hcl
 # docker-bake.hcl
@@ -924,7 +922,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="parseint"></a> `parseint`
+## `parseint`
 
 ```hcl
 # docker-bake.hcl
@@ -937,7 +935,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="pow"></a> `pow`
+## `pow`
 
 ```hcl
 # docker-bake.hcl
@@ -950,7 +948,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="range"></a> `range`
+## `range`
 
 ```hcl
 # docker-bake.hcl
@@ -963,7 +961,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="regex"></a> `regex`
+## `regex`
 
 ```hcl
 # docker-bake.hcl
@@ -976,7 +974,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="regex_replace"></a> `regex_replace`
+## `regex_replace`
 
 ```hcl
 # docker-bake.hcl
@@ -989,7 +987,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="regexall"></a> `regexall`
+## `regexall`
 
 ```hcl
 # docker-bake.hcl
@@ -1002,7 +1000,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="replace"></a> `replace`
+## `replace`
 
 ```hcl
 # docker-bake.hcl
@@ -1015,7 +1013,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="reverse"></a> `reverse`
+## `reverse`
 
 ```hcl
 # docker-bake.hcl
@@ -1028,7 +1026,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="reverselist"></a> `reverselist`
+## `reverselist`
 
 ```hcl
 # docker-bake.hcl
@@ -1041,7 +1039,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="rsadecrypt"></a> `rsadecrypt`
+## `rsadecrypt`
 
 ```hcl
 # docker-bake.hcl
@@ -1054,7 +1052,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="sanitize"></a> `sanitize`
+## `sanitize`
 
 ```hcl
 # docker-bake.hcl
@@ -1067,7 +1065,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="sethaselement"></a> `sethaselement`
+## `sethaselement`
 
 ```hcl
 # docker-bake.hcl
@@ -1080,7 +1078,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="setintersection"></a> `setintersection`
+## `setintersection`
 
 ```hcl
 # docker-bake.hcl
@@ -1093,7 +1091,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="setproduct"></a> `setproduct`
+## `setproduct`
 
 ```hcl
 # docker-bake.hcl
@@ -1106,7 +1104,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="setsubtract"></a> `setsubtract`
+## `setsubtract`
 
 ```hcl
 # docker-bake.hcl
@@ -1119,7 +1117,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="setsymmetricdifference"></a> `setsymmetricdifference`
+## `setsymmetricdifference`
 
 ```hcl
 # docker-bake.hcl
@@ -1132,7 +1130,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="setunion"></a> `setunion`
+## `setunion`
 
 ```hcl
 # docker-bake.hcl
@@ -1145,7 +1143,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="sha1"></a> `sha1`
+## `sha1`
 
 ```hcl
 # docker-bake.hcl
@@ -1158,7 +1156,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="sha256"></a> `sha256`
+## `sha256`
 
 ```hcl
 # docker-bake.hcl
@@ -1171,7 +1169,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="sha512"></a> `sha512`
+## `sha512`
 
 ```hcl
 # docker-bake.hcl
@@ -1184,7 +1182,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="signum"></a> `signum`
+## `signum`
 
 ```hcl
 # docker-bake.hcl
@@ -1199,7 +1197,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="slice"></a> `slice`
+## `slice`
 
 ```hcl
 # docker-bake.hcl
@@ -1212,7 +1210,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="sort"></a> `sort`
+## `sort`
 
 ```hcl
 # docker-bake.hcl
@@ -1225,7 +1223,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="split"></a> `split`
+## `split`
 
 ```hcl
 # docker-bake.hcl
@@ -1238,7 +1236,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="strlen"></a> `strlen`
+## `strlen`
 
 ```hcl
 # docker-bake.hcl
@@ -1251,7 +1249,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="substr"></a> `substr`
+## `substr`
 
 ```hcl
 # docker-bake.hcl
@@ -1264,7 +1262,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="subtract"></a> `subtract`
+## `subtract`
 
 ```hcl
 # docker-bake.hcl
@@ -1277,7 +1275,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="timeadd"></a> `timeadd`
+## `timeadd`
 
 ```hcl
 # docker-bake.hcl
@@ -1290,7 +1288,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="timestamp"></a> `timestamp`
+## `timestamp`
 
 ```hcl
 # docker-bake.hcl
@@ -1303,7 +1301,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="title"></a> `title`
+## `title`
 
 ```hcl
 # docker-bake.hcl
@@ -1316,7 +1314,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="trim"></a> `trim`
+## `trim`
 
 ```hcl
 # docker-bake.hcl
@@ -1329,7 +1327,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="trimprefix"></a> `trimprefix`
+## `trimprefix`
 
 ```hcl
 # docker-bake.hcl
@@ -1342,7 +1340,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="trimspace"></a> `trimspace`
+## `trimspace`
 
 ```hcl
 # docker-bake.hcl
@@ -1355,7 +1353,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="trimsuffix"></a> `trimsuffix`
+## `trimsuffix`
 
 ```hcl
 # docker-bake.hcl
@@ -1368,7 +1366,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="try"></a> `try`
+## `try`
 
 ```hcl
 # docker-bake.hcl
@@ -1385,7 +1383,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="upper"></a> `upper`
+## `upper`
 
 ```hcl
 # docker-bake.hcl
@@ -1398,7 +1396,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="urlencode"></a> `urlencode`
+## `urlencode`
 
 ```hcl
 # docker-bake.hcl
@@ -1411,7 +1409,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="uuidv4"></a> `uuidv4`
+## `uuidv4`
 
 ```hcl
 # docker-bake.hcl
@@ -1424,7 +1422,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="uuidv5"></a> `uuidv5`
+## `uuidv5`
 
 ```hcl
 # docker-bake.hcl
@@ -1440,7 +1438,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="values"></a> `values`
+## `values`
 
 ```hcl
 # docker-bake.hcl
@@ -1453,7 +1451,7 @@ target "webapp-dev" {
 }
 ```
 
-### <a name="zipmap"></a> `zipmap`
+## `zipmap`
 
 ```hcl
 # docker-bake.hcl

--- a/docs/generate.go
+++ b/docs/generate.go
@@ -152,7 +152,9 @@ func generateBakeStdlibDocs(filename string) error {
 	sort.Strings(names)
 	for _, name := range names {
 		fname := fmt.Sprintf("`%s`", name)
-		if strings.Contains(currentContent, "<a name=\""+name+"\"></a>") {
+		// Check if there's a heading for this function in the Examples section
+		// Headings are in the format: ### `functionname`
+		if strings.Contains(currentContent, "## `"+name+"`") {
 			fname = fmt.Sprintf("[`%s`](#%s)", name, name)
 		}
 		fdesc := hclparser.StdlibFuncDescription(name)


### PR DESCRIPTION
I noticed the links didn't work in the [rendered](https://docs.docker.com/build/bake/stdlib/) document. And the sidebar is super wonky. These changes should fix it.
