### PR TITLE
[v0.30] vendor: update buildkit to v0.26.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/in-toto/in-toto-golang v0.9.0
 	github.com/mitchellh/hashstructure/v2 v2.0.2
-	github.com/moby/buildkit v0.26.0
+	github.com/moby/buildkit v0.26.1
 	github.com/moby/go-archive v0.1.0
 	github.com/moby/sys/atomicwriter v0.1.0
 	github.com/moby/sys/mountinfo v0.7.2

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,8 @@ github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTS
 github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
 github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/mitchellh/mapstructure v0.0.0-20150613213606-2caf8efc9366/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
-github.com/moby/buildkit v0.26.0 h1:OSugMZoGqpVgrlpDx+OkiPRgYCIxR3XUP6wr7brDCpo=
-github.com/moby/buildkit v0.26.0/go.mod h1:ylDa7IqzVJgLdi/wO7H1qLREFQpmhFbw2fbn4yoTw40=
+github.com/moby/buildkit v0.26.1 h1:Cf/AB/8/5N+GBQnVPBW+hR2tDWoImuZ28ciqaF+mzgs=
+github.com/moby/buildkit v0.26.1/go.mod h1:ylDa7IqzVJgLdi/wO7H1qLREFQpmhFbw2fbn4yoTw40=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/go-archive v0.1.0 h1:Kk/5rdW/g+H8NHdJW2gsXyZ7UnzvJNOy6VKJqueWdcQ=

--- a/vendor/github.com/moby/buildkit/util/contentutil/fetcher.go
+++ b/vendor/github.com/moby/buildkit/util/contentutil/fetcher.go
@@ -51,10 +51,6 @@ type readerAt struct {
 }
 
 func (r *readerAt) ReadAt(b []byte, off int64) (int, error) {
-	if ra, ok := r.Reader.(io.ReaderAt); ok {
-		return ra.ReadAt(b, off)
-	}
-
 	if r.offset != off {
 		if seeker, ok := r.Reader.(io.Seeker); ok {
 			if _, err := seeker.Seek(off, io.SeekStart); err != nil {
@@ -62,6 +58,9 @@ func (r *readerAt) ReadAt(b []byte, off int64) (int, error) {
 			}
 			r.offset = off
 		} else {
+			if ra, ok := r.Reader.(io.ReaderAt); ok {
+				return ra.ReadAt(b, off)
+			}
 			return 0, errors.Errorf("unsupported offset")
 		}
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -443,7 +443,7 @@ github.com/mitchellh/go-wordwrap
 # github.com/mitchellh/hashstructure/v2 v2.0.2
 ## explicit; go 1.14
 github.com/mitchellh/hashstructure/v2
-# github.com/moby/buildkit v0.26.0
+# github.com/moby/buildkit v0.26.1
 ## explicit; go 1.24.3
 github.com/moby/buildkit/api/services/control
 github.com/moby/buildkit/api/types


### PR DESCRIPTION
cherry-pick https://github.com/docker/buildx/pull/3529

(cherry picked from commit 42a2be1c4ba4f8eb737a976d5d46b5eedfe7069b)