### PR TITLE
driver/kubernetes: change DeploymentOpt.Replicas to int32

### DIFF
--- a/driver/kubernetes/factory.go
+++ b/driver/kubernetes/factory.go
@@ -141,7 +141,7 @@ func (f *factory) New(ctx context.Context, cfg driver.InitConfig) (driver.Driver
 		return nil, err
 	}
 
-	d.minReplicas = deploymentOpt.Replicas
+	d.minReplicas = int(deploymentOpt.Replicas)
 
 	d.deploymentClient = clientset.AppsV1().Deployments(namespace)
 	d.podClient = clientset.CoreV1().Pods(namespace)
@@ -189,10 +189,11 @@ func (f *factory) processDriverOpts(deploymentName string, namespace string, cfg
 		case k == "namespace":
 			namespace = v
 		case k == "replicas":
-			deploymentOpt.Replicas, err = strconv.Atoi(v)
+			r, err := strconv.ParseInt(v, 10, 32)
 			if err != nil {
 				return nil, "", "", false, 0, err
 			}
+			deploymentOpt.Replicas = int32(r)
 		case k == "requests.cpu":
 			deploymentOpt.RequestsCPU = v
 		case k == "requests.memory":

--- a/driver/kubernetes/factory_test.go
+++ b/driver/kubernetes/factory_test.go
@@ -91,7 +91,7 @@ func TestFactory_processDriverOpts(t *testing.T) {
 
 			require.Equal(t, "test-ns", ns)
 			require.Equal(t, "test:latest", r.Image)
-			require.Equal(t, 2, r.Replicas)
+			require.Equal(t, int32(2), r.Replicas)
 			require.Equal(t, "100m", r.RequestsCPU)
 			require.Equal(t, "32Mi", r.RequestsMemory)
 			require.Equal(t, "200m", r.LimitsCPU)
@@ -119,7 +119,7 @@ func TestFactory_processDriverOpts(t *testing.T) {
 
 			require.Equal(t, "test", ns)
 			require.Equal(t, bkimage.DefaultImage, r.Image)
-			require.Equal(t, 1, r.Replicas)
+			require.Equal(t, int32(1), r.Replicas)
 			require.Equal(t, "", r.RequestsCPU)
 			require.Equal(t, "", r.RequestsMemory)
 			require.Equal(t, "", r.LimitsCPU)
@@ -150,7 +150,7 @@ func TestFactory_processDriverOpts(t *testing.T) {
 
 			require.Equal(t, "test", ns)
 			require.Equal(t, bkimage.DefaultRootlessImage, r.Image)
-			require.Equal(t, 1, r.Replicas)
+			require.Equal(t, int32(1), r.Replicas)
 			require.Equal(t, "", r.RequestsCPU)
 			require.Equal(t, "", r.RequestsMemory)
 			require.Equal(t, "", r.LimitsCPU)

--- a/driver/kubernetes/manifest/manifest.go
+++ b/driver/kubernetes/manifest/manifest.go
@@ -17,7 +17,7 @@ type DeploymentOpt struct {
 	Namespace          string
 	Name               string
 	Image              string
-	Replicas           int
+	Replicas           int32
 	ServiceAccountName string
 	SchedulerName      string
 
@@ -73,7 +73,7 @@ func NewDeployment(opt *DeploymentOpt) (d *appsv1.Deployment, c []*corev1.Config
 		LabelApp: opt.Name,
 	}
 	annotations := map[string]string{}
-	replicas := int32(opt.Replicas)
+	replicas := opt.Replicas
 	privileged := true
 	args := opt.BuildkitFlags
 


### PR DESCRIPTION
Directly convert to a int32 instead of later conversion so that we can return an error if the value is out of range.


- This should hopefully silence https://github.com/docker/buildx/security/code-scanning/1
