### PR TITLE
build: split out node resolver

### DIFF
--- a/build/resolver/driver_test.go
+++ b/build/resolver/driver_test.go
@@ -1,4 +1,4 @@
-package build
+package resolver
 
 import (
 	"context"
@@ -22,7 +22,7 @@ func TestFindDriverSanity(t *testing.T) {
 	require.Len(t, res, 1)
 	require.Equal(t, 0, res[0].driverIndex)
 	require.Equal(t, "aaa", res[0].Node().Builder)
-	require.Equal(t, []ocispecs.Platform{platforms.DefaultSpec()}, res[0].platforms)
+	require.Equal(t, []ocispecs.Platform{platforms.DefaultSpec()}, res[0].Platforms())
 }
 
 func TestFindDriverEmpty(t *testing.T) {
@@ -228,7 +228,7 @@ func TestSelectNodeNoPlatform(t *testing.T) {
 	require.True(t, perfect)
 	require.Len(t, res, 1)
 	require.Equal(t, "aaa", res[0].Node().Builder)
-	require.Empty(t, res[0].platforms)
+	require.Empty(t, res[0].Platforms())
 }
 
 func TestSelectNodeAdditionalPlatforms(t *testing.T) {


### PR DESCRIPTION
This PR simply splits out the node resolver into a separate sub-package.

I wanted to use the `resolveDrivers` function in some code that interfaces with `buildx` by importing it. It's useful to access the same logic for booting and platform matching that buildx itself uses (since some platform info is only available once the node is booted).

While the `builder` and `drivers` package are easily importable, the `build` package depends on the entire AWS SDK. Splitting the resolver out into it's own package makes the code more reusable, and also hopefully makes it easier to refactor long-term.