### PR TITLE
commands: fix debug flag in standalone mode

### DIFF
--- a/commands/root.go
+++ b/commands/root.go
@@ -57,6 +57,7 @@ func NewRootCmd(name string, isPlugin bool, dockerCli *command.DockerCli) *cobra
 				options := cliflags.NewClientOptions()
 				options.InstallFlags(nflags)
 				options.SetDefaultOptions(nflags)
+				options.Debug = opt.debug || debug.IsEnabled()
 				return dockerCli.Initialize(options)
 			}
 			return plugin.PersistentPreRunE(cmd, args)


### PR DESCRIPTION
The -D/--debug flag was not enabling debug logging in standalone mode.

Root cause: debug.Enable() was called before dockerCli.Initialize(), but Initialize() calls SetLogLevel("") which resets logrus level to Info, and since options.Debug was false, it wasn't re-enabled.

Fix: Pass opt.debug to options.Debug before Initialize() so it properly enables debug level after SetLogLevel().

### Test case

Dockerfile
```dockerfile
FROM alpine:3.19
MAINTAINER test@example.com
```

Before (bug):
```
$ ./docker-buildx -D build .
1 warning found (use docker --debug to expand):
```

After (fix):
```
$ ./docker-buildx -D build .
1 warning found:
The MAINTAINER instruction is deprecated...
More info: https://docs.docker.com/go/dockerfile/rule/maintainer-deprecated/
```