### PR TITLE
dap: skip the set breakpoints test because of possible deadlock

### DIFF
--- a/dap/adapter_test.go
+++ b/dap/adapter_test.go
@@ -73,6 +73,8 @@ func TestLaunch(t *testing.T) {
 // TestSetBreakpoints will test sending a setBreakpoints request with no breakpoints.
 // The response should be an empty array instead of null in the JSON.
 func TestSetBreakpoints(t *testing.T) {
+	t.Skip("fixme: test can hit a deadlock that causes it to exit after 30 minutes")
+
 	adapter, conn, client := NewTestAdapter[common.Config](t)
 
 	ctx, cancel := context.WithTimeoutCause(context.Background(), 10*time.Second, context.DeadlineExceeded)


### PR DESCRIPTION

The unit test can potentially deadlock in some way that the go runtime
doesn't detect it and it runs for 30 minutes. Skipping the test until we
either fix it or replace it with an equivalent integration test.
