### PR TITLE
bake: add semvercmp func to stdlib

### DIFF
--- a/docs/bake-stdlib.md
+++ b/docs/bake-stdlib.md
@@ -79,6 +79,7 @@ title: Bake standard library functions
 | [`reverselist`](#reverselist)                       | Returns the given list with its elements in reverse order.                                                                                                                                                   |
 | [`rsadecrypt`](#rsadecrypt)                         | Decrypts an RSA-encrypted ciphertext.                                                                                                                                                                        |
 | [`sanitize`](#sanitize)                             | Replaces all non-alphanumeric characters with a underscore, leaving only characters that are valid for a Bake target name.                                                                                   |
+| [`semvercmp`](#semvercmp)                           | Returns true if version satisfies a constraint.                                                                                                                                                              |
 | [`sethaselement`](#sethaselement)                   | Returns true if the given set contains the given element, or false otherwise.                                                                                                                                |
 | [`setintersection`](#setintersection)               | Returns the intersection of all given sets.                                                                                                                                                                  |
 | [`setproduct`](#setproduct)                         | Calculates the cartesian product of two or more sets.                                                                                                                                                        |
@@ -1062,6 +1063,31 @@ target "webapp-dev" {
   args = {
     result = "${sanitize("My App! v1.0")}" # => "My_App__v1_0"
   }
+}
+```
+
+## `semvercmp`
+
+This function checks if a semantic version fits within a set of constraints.
+See [Checking Version Constraints](https://github.com/Masterminds/semver?tab=readme-ov-file#checking-version-constraints)
+for details.
+
+```hcl
+# docker-bake.hcl
+variable "ALPINE_VERSION" {
+  default = "3.23"
+}
+
+target "webapp-dev" {
+  dockerfile = "Dockerfile.webapp"
+  platforms = semvercmp(ALPINE_VERSION, ">= 3.20") ? [
+    "linux/amd64",
+    "linux/arm64",
+    "linux/riscv64"
+  ] : [
+    "linux/amd64",
+    "linux/arm64"
+  ]
 }
 ```
 


### PR DESCRIPTION
```hcl
variable "ALPINE_VERSION" {
  default = "3.23"
}

target "default" {
  dockerfile = "Dockerfile.webapp"
  platforms = semvercmp(ALPINE_VERSION, ">= 3.20") ? [
    "linux/amd64",
    "linux/arm64",
    "linux/riscv64"
  ] : [
    "linux/amd64",
    "linux/arm64"
  ]
}
```

```
$ docker buildx bake --print
#1 [internal] load local bake definitions
#1 reading docker-bake.hcl 275B / 275B done
#1 DONE 0.0s
{
  "group": {
    "default": {
      "targets": [
        "default"
      ]
    }
  },
  "target": {
    "default": {
      "context": ".",
      "dockerfile": "Dockerfile.webapp",
      "platforms": [
        "linux/amd64",
        "linux/arm64",
        "linux/riscv64"
      ]
    }
  }
}
```

```
$ ALPINE_VERSION=3.19 docker buildx bake --print
#1 [internal] load local bake definitions
#1 reading docker-bake.hcl 275B / 275B done
#1 DONE 0.0s
{
  "group": {
    "default": {
      "targets": [
        "default"
      ]
    }
  },
  "target": {
    "default": {
      "context": ".",
      "dockerfile": "Dockerfile.webapp",
      "platforms": [
        "linux/amd64",
        "linux/arm64"
      ]
    }
  }
}
```

```
$ ALPINE_VERSION=latest docker buildx bake --print
#1 [internal] load local bake definitions
#1 reading docker-bake.hcl 275B / 275B done
#1 DONE 0.0s
docker-bake.hcl:7
--------------------
   5 |     target "default" {
   6 |       dockerfile = "Dockerfile.webapp"
   7 | >>>   platforms = semvercmp(ALPINE_VERSION, ">= 3.20") ? [
   8 |         "linux/amd64",
   9 |         "linux/arm64",
--------------------
ERROR: docker-bake.hcl:7,15-32: Error in function call; Call to function "semvercmp" failed: invalid semantic version., and 1 other diagnostic(s)
```