### PR TITLE
build: handle at symbols in an oci-layout path

### DIFF
--- a/build/opt_test.go
+++ b/build/opt_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/docker/buildx/util/buildflags"
 	"github.com/moby/buildkit/client"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -37,4 +38,46 @@ func TestCacheOptions_DerivedVars(t *testing.T) {
 			},
 		},
 	}, CreateCaches(cacheFrom))
+}
+
+func TestParseOCILayoutPath(t *testing.T) {
+	for _, tt := range []struct {
+		s    string
+		path string
+		dgst string
+		tag  string
+	}{
+		{
+			s:    "/path/to/oci/layout",
+			path: "/path/to/oci/layout",
+			tag:  "latest",
+		},
+		{
+			s:    "/path/to/oci/layout:1.3",
+			path: "/path/to/oci/layout",
+			tag:  "1.3",
+		},
+		{
+			s:    "/path/to/oci/layout@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			path: "/path/to/oci/layout",
+			dgst: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			tag:  "latest",
+		},
+		{
+			s:    "/path/to/oci/@/layout@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			path: "/path/to/oci/@/layout",
+			dgst: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			tag:  "latest",
+		},
+		{
+			s:    "/path/to/oci/@/layout",
+			path: "/path/to/oci/@/layout",
+			tag:  "latest",
+		},
+	} {
+		path, dgst, tag := parseOCILayoutPath(tt.s)
+		assert.Equal(t, tt.path, path, "comparing path: %s", tt.s)
+		assert.Equal(t, tt.dgst, dgst, "comparing digest: %s", tt.s)
+		assert.Equal(t, tt.tag, tag, "comparing tag: %s", tt.s)
+	}
 }


### PR DESCRIPTION

The buildx command line will now handle `@` symbols in the
`oci-layout://` path when used with named contexts. Instead of
assuming the `@` symbol is part of the reference digest, it will first
check that it is a valid reference digest. Otherwise, it will assume
it's part of the file path.

Fixes moby/buildkit#6447.
