### PR TITLE
revisit: add timeout parameter to cli and driver

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -345,6 +345,7 @@ type CreateOpts struct {
 	Use                 bool
 	Endpoint            string
 	Append              bool
+	Timeout             time.Duration
 }
 
 func Create(ctx context.Context, txn *store.Txn, dockerCli command.Cli, opts CreateOpts) (*Builder, error) {
@@ -525,7 +526,7 @@ func Create(ctx context.Context, txn *store.Txn, dockerCli command.Cli, opts Cre
 	}
 
 	cancelCtx, cancel := context.WithCancelCause(ctx)
-	timeoutCtx, _ := context.WithTimeoutCause(cancelCtx, 20*time.Second, errors.WithStack(context.DeadlineExceeded)) //nolint:govet // no need to manually cancel this context as we already rely on parent
+	timeoutCtx, _ := context.WithTimeoutCause(cancelCtx, opts.Timeout, errors.WithStack(context.DeadlineExceeded)) //nolint:govet // no need to manually cancel this context as we already rely on parent
 	defer func() { cancel(errors.WithStack(context.Canceled)) }()
 
 	nodes, err := b.LoadNodes(timeoutCtx, WithData())

--- a/builder/node.go
+++ b/builder/node.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/containerd/platforms"
 	"github.com/docker/buildx/driver"
@@ -38,6 +39,8 @@ type Node struct {
 	Labels     map[string]string
 	CDIDevices []client.CDIDevice
 }
+
+const defaultDriverTimeout = 120 * time.Second
 
 // Nodes returns nodes for this builder.
 func (b *Builder) Nodes() []Node {
@@ -131,6 +134,7 @@ func (b *Builder) LoadNodes(ctx context.Context, opts ...LoadNodesOption) (_ []N
 					Platforms:       n.Platforms,
 					ContextPathHash: b.opts.contextPathHash,
 					DialMeta:        lno.dialMeta,
+					Timeout:         defaultDriverTimeout,
 				})
 				if err != nil {
 					node.Err = err

--- a/commands/create.go
+++ b/commands/create.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/docker/buildx/builder"
 	"github.com/docker/buildx/driver"
@@ -27,6 +28,7 @@ type createOptions struct {
 	buildkitdFlags      string
 	buildkitdConfigFile string
 	bootstrap           bool
+	timeout             time.Duration
 	// upgrade      bool // perform upgrade of the driver
 }
 
@@ -61,6 +63,7 @@ func runCreate(ctx context.Context, dockerCli command.Cli, in createOptions, arg
 		Use:                 in.use,
 		Endpoint:            ep,
 		Append:              in.actionAppend,
+		Timeout:             in.timeout,
 	})
 	if err != nil {
 		return err
@@ -80,7 +83,7 @@ func runCreate(ctx context.Context, dockerCli command.Cli, in createOptions, arg
 	return nil
 }
 
-func createCmd(dockerCli command.Cli) *cobra.Command {
+func createCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 	var options createOptions
 
 	var drivers bytes.Buffer
@@ -96,6 +99,7 @@ func createCmd(dockerCli command.Cli) *cobra.Command {
 		Short: "Create a new builder instance",
 		Args:  cli.RequiresMaxArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			options.timeout = rootOpts.timeout
 			return runCreate(cmd.Context(), dockerCli, options, args)
 		},
 		ValidArgsFunction:     completion.Disable,

--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -24,6 +24,7 @@ import (
 type inspectOptions struct {
 	bootstrap bool
 	builder   string
+	timeout   time.Duration
 }
 
 func runInspect(ctx context.Context, dockerCli command.Cli, in inspectOptions) error {
@@ -36,7 +37,7 @@ func runInspect(ctx context.Context, dockerCli command.Cli, in inspectOptions) e
 	}
 
 	timeoutCtx, cancel := context.WithCancelCause(ctx)
-	timeoutCtx, _ = context.WithTimeoutCause(timeoutCtx, 20*time.Second, errors.WithStack(context.DeadlineExceeded)) //nolint:govet // no need to manually cancel this context as we already rely on parent
+	timeoutCtx, _ = context.WithTimeoutCause(timeoutCtx, in.timeout, errors.WithStack(context.DeadlineExceeded)) //nolint:govet // no need to manually cancel this context as we already rely on parent
 	defer func() { cancel(errors.WithStack(context.Canceled)) }()
 
 	nodes, err := b.LoadNodes(timeoutCtx, builder.WithData())
@@ -180,6 +181,7 @@ func inspectCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 			if len(args) > 0 {
 				options.builder = args[0]
 			}
+			options.timeout = rootOpts.timeout
 			return runInspect(cmd.Context(), dockerCli, options)
 		},
 		ValidArgsFunction:     completion.BuilderNames(dockerCli),

--- a/commands/rm.go
+++ b/commands/rm.go
@@ -21,6 +21,7 @@ type rmOptions struct {
 	keepDaemon  bool
 	allInactive bool
 	force       bool
+	timeout     time.Duration
 }
 
 const (
@@ -109,6 +110,7 @@ func rmCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 				}
 				options.builders = args
 			}
+			options.timeout = rootOpts.timeout
 			return runRm(cmd.Context(), dockerCli, options)
 		},
 		ValidArgsFunction:     completion.BuilderNames(dockerCli),
@@ -152,7 +154,7 @@ func rmAllInactive(ctx context.Context, txn *store.Txn, dockerCli command.Cli, i
 	}
 
 	timeoutCtx, cancel := context.WithCancelCause(ctx)
-	timeoutCtx, _ = context.WithTimeoutCause(timeoutCtx, 20*time.Second, errors.WithStack(context.DeadlineExceeded)) //nolint:govet // no need to manually cancel this context as we already rely on parent
+	timeoutCtx, _ = context.WithTimeoutCause(timeoutCtx, in.timeout, errors.WithStack(context.DeadlineExceeded)) //nolint:govet // no need to manually cancel this context as we already rely on parent
 	defer func() { cancel(errors.WithStack(context.Canceled)) }()
 
 	eg, _ := errgroup.WithContext(timeoutCtx)

--- a/docs/reference/buildx.md
+++ b/docs/reference/buildx.md
@@ -31,10 +31,11 @@ Extended build capabilities with BuildKit
 
 ### Options
 
-| Name                    | Type     | Default | Description                              |
-|:------------------------|:---------|:--------|:-----------------------------------------|
-| [`--builder`](#builder) | `string` |         | Override the configured builder instance |
-| `-D`, `--debug`         | `bool`   |         | Enable debug logging                     |
+| Name                    | Type       | Default | Description                                                          |
+|:------------------------|:-----------|:--------|:---------------------------------------------------------------------|
+| [`--builder`](#builder) | `string`   |         | Override the configured builder instance                             |
+| `-D`, `--debug`         | `bool`     |         | Enable debug logging                                                 |
+| `--timeout`             | `duration` | `20s`   | Override the default global timeout (as duration, for example 1m20s) |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_bake.md
+++ b/docs/reference/buildx_bake.md
@@ -32,6 +32,7 @@ Build from a file
 | [`--push`](#push)                   | `bool`        |         | Shorthand for `--set=*.output=type=registry`. Conditional.                                                            |
 | [`--sbom`](#sbom)                   | `string`      |         | Shorthand for `--set=*.attest=type=sbom`                                                                              |
 | [`--set`](#set)                     | `stringArray` |         | Override target value (e.g., `targetpattern.key=value`)                                                               |
+| `--timeout`                         | `duration`    | `20s`   | Override the default global timeout (as duration, for example 1m20s)                                                  |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_build.md
+++ b/docs/reference/buildx_build.md
@@ -49,6 +49,7 @@ Start a build
 | [`--ssh`](#ssh)                         | `stringArray` |           | SSH agent socket or keys to expose to the build (format: `default\|<id>[=<socket>\|<key>[,<key>]]`)                   |
 | [`-t`](#tag), [`--tag`](#tag)           | `stringArray` |           | Image identifier (format: `[registry/]repository[:tag]`)                                                              |
 | [`--target`](#target)                   | `string`      |           | Set the target build stage to build                                                                                   |
+| `--timeout`                             | `duration`    | `20s`     | Override the default global timeout (as duration, for example 1m20s)                                                  |
 | [`--ulimit`](#ulimit)                   | `ulimit`      |           | Ulimit options                                                                                                        |
 
 

--- a/docs/reference/buildx_create.md
+++ b/docs/reference/buildx_create.md
@@ -22,6 +22,7 @@ Create a new builder instance
 | [`--name`](#name)                         | `string`      |         | Builder instance name                                                 |
 | [`--node`](#node)                         | `string`      |         | Create/modify node with given name                                    |
 | [`--platform`](#platform)                 | `stringArray` |         | Fixed platforms for current node                                      |
+| `--timeout`                               | `duration`    | `20s`   | Override the default global timeout (as duration, for example 1m20s)  |
 | [`--use`](#use)                           | `bool`        |         | Set the current builder instance                                      |
 
 

--- a/docs/reference/buildx_dap.md
+++ b/docs/reference/buildx_dap.md
@@ -12,10 +12,11 @@ Start debug adapter protocol compatible debugger (EXPERIMENTAL)
 
 ### Options
 
-| Name            | Type     | Default | Description                              |
-|:----------------|:---------|:--------|:-----------------------------------------|
-| `--builder`     | `string` |         | Override the configured builder instance |
-| `-D`, `--debug` | `bool`   |         | Enable debug logging                     |
+| Name            | Type       | Default | Description                                                          |
+|:----------------|:-----------|:--------|:---------------------------------------------------------------------|
+| `--builder`     | `string`   |         | Override the configured builder instance                             |
+| `-D`, `--debug` | `bool`     |         | Enable debug logging                                                 |
+| `--timeout`     | `duration` | `20s`   | Override the default global timeout (as duration, for example 1m20s) |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_dap_build.md
+++ b/docs/reference/buildx_dap_build.md
@@ -41,6 +41,7 @@ Start a build
 | `--ssh`             | `stringArray` |           | SSH agent socket or keys to expose to the build (format: `default\|<id>[=<socket>\|<key>[,<key>]]`)                   |
 | `-t`, `--tag`       | `stringArray` |           | Image identifier (format: `[registry/]repository[:tag]`)                                                              |
 | `--target`          | `string`      |           | Set the target build stage to build                                                                                   |
+| `--timeout`         | `duration`    | `20s`     | Override the default global timeout (as duration, for example 1m20s)                                                  |
 | `--ulimit`          | `ulimit`      |           | Ulimit options                                                                                                        |
 
 

--- a/docs/reference/buildx_debug.md
+++ b/docs/reference/buildx_debug.md
@@ -12,12 +12,13 @@ Start debugger (EXPERIMENTAL)
 
 ### Options
 
-| Name            | Type     | Default | Description                                                      |
-|:----------------|:---------|:--------|:-----------------------------------------------------------------|
-| `--builder`     | `string` |         | Override the configured builder instance                         |
-| `-D`, `--debug` | `bool`   |         | Enable debug logging                                             |
-| `--invoke`      | `string` |         | Launch a monitor with executing specified command (EXPERIMENTAL) |
-| `--on`          | `string` | `error` | When to launch the monitor ([always, error]) (EXPERIMENTAL)      |
+| Name            | Type       | Default | Description                                                          |
+|:----------------|:-----------|:--------|:---------------------------------------------------------------------|
+| `--builder`     | `string`   |         | Override the configured builder instance                             |
+| `-D`, `--debug` | `bool`     |         | Enable debug logging                                                 |
+| `--invoke`      | `string`   |         | Launch a monitor with executing specified command (EXPERIMENTAL)     |
+| `--on`          | `string`   | `error` | When to launch the monitor ([always, error]) (EXPERIMENTAL)          |
+| `--timeout`     | `duration` | `20s`   | Override the default global timeout (as duration, for example 1m20s) |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_debug_build.md
+++ b/docs/reference/buildx_debug_build.md
@@ -45,6 +45,7 @@ Start a build
 | `--ssh`             | `stringArray` |           | SSH agent socket or keys to expose to the build (format: `default\|<id>[=<socket>\|<key>[,<key>]]`)                   |
 | `-t`, `--tag`       | `stringArray` |           | Image identifier (format: `[registry/]repository[:tag]`)                                                              |
 | `--target`          | `string`      |           | Set the target build stage to build                                                                                   |
+| `--timeout`         | `duration`    | `20s`     | Override the default global timeout (as duration, for example 1m20s)                                                  |
 | `--ulimit`          | `ulimit`      |           | Ulimit options                                                                                                        |
 
 

--- a/docs/reference/buildx_dial-stdio.md
+++ b/docs/reference/buildx_dial-stdio.md
@@ -9,12 +9,13 @@ Proxy current stdio streams to builder instance
 
 ### Options
 
-| Name            | Type     | Default | Description                                                                                         |
-|:----------------|:---------|:--------|:----------------------------------------------------------------------------------------------------|
-| `--builder`     | `string` |         | Override the configured builder instance                                                            |
-| `-D`, `--debug` | `bool`   |         | Enable debug logging                                                                                |
-| `--platform`    | `string` |         | Target platform: this is used for node selection                                                    |
-| `--progress`    | `string` | `none`  | Set type of progress output (`auto`, `plain`, `rawjson`, `tty`). Use plain to show container output |
+| Name            | Type       | Default | Description                                                                                         |
+|:----------------|:-----------|:--------|:----------------------------------------------------------------------------------------------------|
+| `--builder`     | `string`   |         | Override the configured builder instance                                                            |
+| `-D`, `--debug` | `bool`     |         | Enable debug logging                                                                                |
+| `--platform`    | `string`   |         | Target platform: this is used for node selection                                                    |
+| `--progress`    | `string`   | `none`  | Set type of progress output (`auto`, `plain`, `rawjson`, `tty`). Use plain to show container output |
+| `--timeout`     | `duration` | `20s`   | Override the default global timeout (as duration, for example 1m20s)                                |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_du.md
+++ b/docs/reference/buildx_du.md
@@ -9,13 +9,14 @@ Disk usage
 
 ### Options
 
-| Name                    | Type     | Default | Description                              |
-|:------------------------|:---------|:--------|:-----------------------------------------|
-| [`--builder`](#builder) | `string` |         | Override the configured builder instance |
-| `-D`, `--debug`         | `bool`   |         | Enable debug logging                     |
-| [`--filter`](#filter)   | `filter` |         | Provide filter values                    |
-| [`--format`](#format)   | `string` |         | Format the output                        |
-| [`--verbose`](#verbose) | `bool`   |         | Shorthand for `--format=pretty`          |
+| Name                    | Type       | Default | Description                                                          |
+|:------------------------|:-----------|:--------|:---------------------------------------------------------------------|
+| [`--builder`](#builder) | `string`   |         | Override the configured builder instance                             |
+| `-D`, `--debug`         | `bool`     |         | Enable debug logging                                                 |
+| [`--filter`](#filter)   | `filter`   |         | Provide filter values                                                |
+| [`--format`](#format)   | `string`   |         | Format the output                                                    |
+| `--timeout`             | `duration` | `20s`   | Override the default global timeout (as duration, for example 1m20s) |
+| [`--verbose`](#verbose) | `bool`     |         | Shorthand for `--format=pretty`                                      |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_history.md
+++ b/docs/reference/buildx_history.md
@@ -23,10 +23,11 @@ Commands to work on build records
 
 ### Options
 
-| Name            | Type     | Default | Description                              |
-|:----------------|:---------|:--------|:-----------------------------------------|
-| `--builder`     | `string` |         | Override the configured builder instance |
-| `-D`, `--debug` | `bool`   |         | Enable debug logging                     |
+| Name            | Type       | Default | Description                                                          |
+|:----------------|:-----------|:--------|:---------------------------------------------------------------------|
+| `--builder`     | `string`   |         | Override the configured builder instance                             |
+| `-D`, `--debug` | `bool`     |         | Enable debug logging                                                 |
+| `--timeout`     | `duration` | `20s`   | Override the default global timeout (as duration, for example 1m20s) |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_history_export.md
+++ b/docs/reference/buildx_history_export.md
@@ -5,13 +5,14 @@ Export build records into Docker Desktop bundle
 
 ### Options
 
-| Name                                   | Type     | Default | Description                                         |
-|:---------------------------------------|:---------|:--------|:----------------------------------------------------|
-| [`--all`](#all)                        | `bool`   |         | Export all build records for the builder            |
-| [`--builder`](#builder)                | `string` |         | Override the configured builder instance            |
-| [`-D`](#debug), [`--debug`](#debug)    | `bool`   |         | Enable debug logging                                |
-| [`--finalize`](#finalize)              | `bool`   |         | Ensure build records are finalized before exporting |
-| [`-o`](#output), [`--output`](#output) | `string` |         | Output file path                                    |
+| Name                                   | Type       | Default | Description                                                          |
+|:---------------------------------------|:-----------|:--------|:---------------------------------------------------------------------|
+| [`--all`](#all)                        | `bool`     |         | Export all build records for the builder                             |
+| [`--builder`](#builder)                | `string`   |         | Override the configured builder instance                             |
+| [`-D`](#debug), [`--debug`](#debug)    | `bool`     |         | Enable debug logging                                                 |
+| [`--finalize`](#finalize)              | `bool`     |         | Ensure build records are finalized before exporting                  |
+| [`-o`](#output), [`--output`](#output) | `string`   |         | Output file path                                                     |
+| `--timeout`                            | `duration` | `20s`   | Override the default global timeout (as duration, for example 1m20s) |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_history_import.md
+++ b/docs/reference/buildx_history_import.md
@@ -9,11 +9,12 @@ Import build records into Docker Desktop
 
 ### Options
 
-| Name                             | Type          | Default | Description                              |
-|:---------------------------------|:--------------|:--------|:-----------------------------------------|
-| `--builder`                      | `string`      |         | Override the configured builder instance |
-| `-D`, `--debug`                  | `bool`        |         | Enable debug logging                     |
-| [`-f`](#file), [`--file`](#file) | `stringArray` |         | Import from a file path                  |
+| Name                             | Type          | Default | Description                                                          |
+|:---------------------------------|:--------------|:--------|:---------------------------------------------------------------------|
+| `--builder`                      | `string`      |         | Override the configured builder instance                             |
+| `-D`, `--debug`                  | `bool`        |         | Enable debug logging                                                 |
+| [`-f`](#file), [`--file`](#file) | `stringArray` |         | Import from a file path                                              |
+| `--timeout`                      | `duration`    | `20s`   | Override the default global timeout (as duration, for example 1m20s) |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_history_inspect.md
+++ b/docs/reference/buildx_history_inspect.md
@@ -16,11 +16,12 @@ Inspect a build record
 
 ### Options
 
-| Name                  | Type     | Default  | Description                              |
-|:----------------------|:---------|:---------|:-----------------------------------------|
-| `--builder`           | `string` |          | Override the configured builder instance |
-| `-D`, `--debug`       | `bool`   |          | Enable debug logging                     |
-| [`--format`](#format) | `string` | `pretty` | Format the output                        |
+| Name                  | Type       | Default  | Description                                                          |
+|:----------------------|:-----------|:---------|:---------------------------------------------------------------------|
+| `--builder`           | `string`   |          | Override the configured builder instance                             |
+| `-D`, `--debug`       | `bool`     |          | Enable debug logging                                                 |
+| [`--format`](#format) | `string`   | `pretty` | Format the output                                                    |
+| `--timeout`           | `duration` | `20s`    | Override the default global timeout (as duration, for example 1m20s) |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_history_inspect_attachment.md
+++ b/docs/reference/buildx_history_inspect_attachment.md
@@ -9,12 +9,13 @@ Inspect a build record attachment
 
 ### Options
 
-| Name                      | Type     | Default | Description                              |
-|:--------------------------|:---------|:--------|:-----------------------------------------|
-| `--builder`               | `string` |         | Override the configured builder instance |
-| `-D`, `--debug`           | `bool`   |         | Enable debug logging                     |
-| [`--platform`](#platform) | `string` |         | Platform of attachment                   |
-| [`--type`](#type)         | `string` |         | Type of attachment                       |
+| Name                      | Type       | Default | Description                                                          |
+|:--------------------------|:-----------|:--------|:---------------------------------------------------------------------|
+| `--builder`               | `string`   |         | Override the configured builder instance                             |
+| `-D`, `--debug`           | `bool`     |         | Enable debug logging                                                 |
+| [`--platform`](#platform) | `string`   |         | Platform of attachment                                               |
+| `--timeout`               | `duration` | `20s`   | Override the default global timeout (as duration, for example 1m20s) |
+| [`--type`](#type)         | `string`   |         | Type of attachment                                                   |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_history_logs.md
+++ b/docs/reference/buildx_history_logs.md
@@ -9,11 +9,12 @@ Print the logs of a build record
 
 ### Options
 
-| Name                      | Type     | Default | Description                                       |
-|:--------------------------|:---------|:--------|:--------------------------------------------------|
-| `--builder`               | `string` |         | Override the configured builder instance          |
-| `-D`, `--debug`           | `bool`   |         | Enable debug logging                              |
-| [`--progress`](#progress) | `string` | `plain` | Set type of progress output (plain, rawjson, tty) |
+| Name                      | Type       | Default | Description                                                          |
+|:--------------------------|:-----------|:--------|:---------------------------------------------------------------------|
+| `--builder`               | `string`   |         | Override the configured builder instance                             |
+| `-D`, `--debug`           | `bool`     |         | Enable debug logging                                                 |
+| [`--progress`](#progress) | `string`   | `plain` | Set type of progress output (plain, rawjson, tty)                    |
+| `--timeout`               | `duration` | `20s`   | Override the default global timeout (as duration, for example 1m20s) |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_history_ls.md
+++ b/docs/reference/buildx_history_ls.md
@@ -9,14 +9,15 @@ List build records
 
 ### Options
 
-| Name                      | Type          | Default | Description                                  |
-|:--------------------------|:--------------|:--------|:---------------------------------------------|
-| `--builder`               | `string`      |         | Override the configured builder instance     |
-| `-D`, `--debug`           | `bool`        |         | Enable debug logging                         |
-| [`--filter`](#filter)     | `stringArray` |         | Provide filter values (e.g., `status=error`) |
-| [`--format`](#format)     | `string`      | `table` | Format the output                            |
-| [`--local`](#local)       | `bool`        |         | List records for current repository only     |
-| [`--no-trunc`](#no-trunc) | `bool`        |         | Don't truncate output                        |
+| Name                      | Type          | Default | Description                                                          |
+|:--------------------------|:--------------|:--------|:---------------------------------------------------------------------|
+| `--builder`               | `string`      |         | Override the configured builder instance                             |
+| `-D`, `--debug`           | `bool`        |         | Enable debug logging                                                 |
+| [`--filter`](#filter)     | `stringArray` |         | Provide filter values (e.g., `status=error`)                         |
+| [`--format`](#format)     | `string`      | `table` | Format the output                                                    |
+| [`--local`](#local)       | `bool`        |         | List records for current repository only                             |
+| [`--no-trunc`](#no-trunc) | `bool`        |         | Don't truncate output                                                |
+| `--timeout`               | `duration`    | `20s`   | Override the default global timeout (as duration, for example 1m20s) |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_history_open.md
+++ b/docs/reference/buildx_history_open.md
@@ -9,10 +9,11 @@ Open a build record in Docker Desktop
 
 ### Options
 
-| Name            | Type     | Default | Description                              |
-|:----------------|:---------|:--------|:-----------------------------------------|
-| `--builder`     | `string` |         | Override the configured builder instance |
-| `-D`, `--debug` | `bool`   |         | Enable debug logging                     |
+| Name            | Type       | Default | Description                                                          |
+|:----------------|:-----------|:--------|:---------------------------------------------------------------------|
+| `--builder`     | `string`   |         | Override the configured builder instance                             |
+| `-D`, `--debug` | `bool`     |         | Enable debug logging                                                 |
+| `--timeout`     | `duration` | `20s`   | Override the default global timeout (as duration, for example 1m20s) |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_history_rm.md
+++ b/docs/reference/buildx_history_rm.md
@@ -9,11 +9,12 @@ Remove build records
 
 ### Options
 
-| Name            | Type     | Default | Description                              |
-|:----------------|:---------|:--------|:-----------------------------------------|
-| [`--all`](#all) | `bool`   |         | Remove all build records                 |
-| `--builder`     | `string` |         | Override the configured builder instance |
-| `-D`, `--debug` | `bool`   |         | Enable debug logging                     |
+| Name            | Type       | Default | Description                                                          |
+|:----------------|:-----------|:--------|:---------------------------------------------------------------------|
+| [`--all`](#all) | `bool`     |         | Remove all build records                                             |
+| `--builder`     | `string`   |         | Override the configured builder instance                             |
+| `-D`, `--debug` | `bool`     |         | Enable debug logging                                                 |
+| `--timeout`     | `duration` | `20s`   | Override the default global timeout (as duration, for example 1m20s) |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_history_trace.md
+++ b/docs/reference/buildx_history_trace.md
@@ -9,12 +9,13 @@ Show the OpenTelemetry trace of a build record
 
 ### Options
 
-| Name                    | Type     | Default       | Description                              |
-|:------------------------|:---------|:--------------|:-----------------------------------------|
-| [`--addr`](#addr)       | `string` | `127.0.0.1:0` | Address to bind the UI server            |
-| `--builder`             | `string` |               | Override the configured builder instance |
-| [`--compare`](#compare) | `string` |               | Compare with another build record        |
-| `-D`, `--debug`         | `bool`   |               | Enable debug logging                     |
+| Name                    | Type       | Default       | Description                                                          |
+|:------------------------|:-----------|:--------------|:---------------------------------------------------------------------|
+| [`--addr`](#addr)       | `string`   | `127.0.0.1:0` | Address to bind the UI server                                        |
+| `--builder`             | `string`   |               | Override the configured builder instance                             |
+| [`--compare`](#compare) | `string`   |               | Compare with another build record                                    |
+| `-D`, `--debug`         | `bool`     |               | Enable debug logging                                                 |
+| `--timeout`             | `duration` | `20s`         | Override the default global timeout (as duration, for example 1m20s) |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_imagetools.md
+++ b/docs/reference/buildx_imagetools.md
@@ -17,10 +17,11 @@ Commands to work on images in registry
 
 ### Options
 
-| Name                    | Type     | Default | Description                              |
-|:------------------------|:---------|:--------|:-----------------------------------------|
-| [`--builder`](#builder) | `string` |         | Override the configured builder instance |
-| `-D`, `--debug`         | `bool`   |         | Enable debug logging                     |
+| Name                    | Type       | Default | Description                                                          |
+|:------------------------|:-----------|:--------|:---------------------------------------------------------------------|
+| [`--builder`](#builder) | `string`   |         | Override the configured builder instance                             |
+| `-D`, `--debug`         | `bool`     |         | Enable debug logging                                                 |
+| `--timeout`             | `duration` | `20s`   | Override the default global timeout (as duration, for example 1m20s) |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_imagetools_create.md
+++ b/docs/reference/buildx_imagetools_create.md
@@ -21,6 +21,7 @@ Create a new image based on source images
 | `--prefer-index`                 | `bool`        | `true`  | When only a single source is specified, prefer outputting an image index or manifest list instead of performing a carbon copy |
 | `--progress`                     | `string`      | `auto`  | Set type of progress output (`auto`, `none`, `plain`, `rawjson`, `tty`). Use plain to show container output                   |
 | [`-t`](#tag), [`--tag`](#tag)    | `stringArray` |         | Set reference for new image                                                                                                   |
+| `--timeout`                      | `duration`    | `20s`   | Override the default global timeout (as duration, for example 1m20s)                                                          |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_imagetools_inspect.md
+++ b/docs/reference/buildx_imagetools_inspect.md
@@ -9,12 +9,13 @@ Show details of an image in the registry
 
 ### Options
 
-| Name                    | Type     | Default         | Description                                   |
-|:------------------------|:---------|:----------------|:----------------------------------------------|
-| [`--builder`](#builder) | `string` |                 | Override the configured builder instance      |
-| `-D`, `--debug`         | `bool`   |                 | Enable debug logging                          |
-| [`--format`](#format)   | `string` | `{{.Manifest}}` | Format the output using the given Go template |
-| [`--raw`](#raw)         | `bool`   |                 | Show original, unformatted JSON manifest      |
+| Name                    | Type       | Default         | Description                                                          |
+|:------------------------|:-----------|:----------------|:---------------------------------------------------------------------|
+| [`--builder`](#builder) | `string`   |                 | Override the configured builder instance                             |
+| `-D`, `--debug`         | `bool`     |                 | Enable debug logging                                                 |
+| [`--format`](#format)   | `string`   | `{{.Manifest}}` | Format the output using the given Go template                        |
+| [`--raw`](#raw)         | `bool`     |                 | Show original, unformatted JSON manifest                             |
+| `--timeout`             | `duration` | `20s`           | Override the default global timeout (as duration, for example 1m20s) |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_inspect.md
+++ b/docs/reference/buildx_inspect.md
@@ -9,11 +9,12 @@ Inspect current builder instance
 
 ### Options
 
-| Name                        | Type     | Default | Description                                 |
-|:----------------------------|:---------|:--------|:--------------------------------------------|
-| [`--bootstrap`](#bootstrap) | `bool`   |         | Ensure builder has booted before inspecting |
-| [`--builder`](#builder)     | `string` |         | Override the configured builder instance    |
-| `-D`, `--debug`             | `bool`   |         | Enable debug logging                        |
+| Name                        | Type       | Default | Description                                                          |
+|:----------------------------|:-----------|:--------|:---------------------------------------------------------------------|
+| [`--bootstrap`](#bootstrap) | `bool`     |         | Ensure builder has booted before inspecting                          |
+| [`--builder`](#builder)     | `string`   |         | Override the configured builder instance                             |
+| `-D`, `--debug`             | `bool`     |         | Enable debug logging                                                 |
+| `--timeout`                 | `duration` | `20s`   | Override the default global timeout (as duration, for example 1m20s) |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_ls.md
+++ b/docs/reference/buildx_ls.md
@@ -9,11 +9,12 @@ List builder instances
 
 ### Options
 
-| Name                  | Type     | Default | Description           |
-|:----------------------|:---------|:--------|:----------------------|
-| `-D`, `--debug`       | `bool`   |         | Enable debug logging  |
-| [`--format`](#format) | `string` | `table` | Format the output     |
-| `--no-trunc`          | `bool`   |         | Don't truncate output |
+| Name                  | Type       | Default | Description                                                          |
+|:----------------------|:-----------|:--------|:---------------------------------------------------------------------|
+| `-D`, `--debug`       | `bool`     |         | Enable debug logging                                                 |
+| [`--format`](#format) | `string`   | `table` | Format the output                                                    |
+| `--no-trunc`          | `bool`     |         | Don't truncate output                                                |
+| `--timeout`           | `duration` | `20s`   | Override the default global timeout (as duration, for example 1m20s) |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_prune.md
+++ b/docs/reference/buildx_prune.md
@@ -9,17 +9,18 @@ Remove build cache
 
 ### Options
 
-| Name                                  | Type     | Default | Description                                            |
-|:--------------------------------------|:---------|:--------|:-------------------------------------------------------|
-| [`-a`](#all), [`--all`](#all)         | `bool`   |         | Include internal/frontend images                       |
-| [`--builder`](#builder)               | `string` |         | Override the configured builder instance               |
-| `-D`, `--debug`                       | `bool`   |         | Enable debug logging                                   |
-| [`--filter`](#filter)                 | `filter` |         | Provide filter values                                  |
-| `-f`, `--force`                       | `bool`   |         | Do not prompt for confirmation                         |
-| [`--max-used-space`](#max-used-space) | `bytes`  | `0`     | Maximum amount of disk space allowed to keep for cache |
-| [`--min-free-space`](#min-free-space) | `bytes`  | `0`     | Target amount of free disk space after pruning         |
-| [`--reserved-space`](#reserved-space) | `bytes`  | `0`     | Amount of disk space always allowed to keep for cache  |
-| `--verbose`                           | `bool`   |         | Provide a more verbose output                          |
+| Name                                  | Type       | Default | Description                                                          |
+|:--------------------------------------|:-----------|:--------|:---------------------------------------------------------------------|
+| [`-a`](#all), [`--all`](#all)         | `bool`     |         | Include internal/frontend images                                     |
+| [`--builder`](#builder)               | `string`   |         | Override the configured builder instance                             |
+| `-D`, `--debug`                       | `bool`     |         | Enable debug logging                                                 |
+| [`--filter`](#filter)                 | `filter`   |         | Provide filter values                                                |
+| `-f`, `--force`                       | `bool`     |         | Do not prompt for confirmation                                       |
+| [`--max-used-space`](#max-used-space) | `bytes`    | `0`     | Maximum amount of disk space allowed to keep for cache               |
+| [`--min-free-space`](#min-free-space) | `bytes`    | `0`     | Target amount of free disk space after pruning                       |
+| [`--reserved-space`](#reserved-space) | `bytes`    | `0`     | Amount of disk space always allowed to keep for cache                |
+| `--timeout`                           | `duration` | `20s`   | Override the default global timeout (as duration, for example 1m20s) |
+| `--verbose`                           | `bool`     |         | Provide a more verbose output                                        |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_rm.md
+++ b/docs/reference/buildx_rm.md
@@ -9,14 +9,15 @@ Remove one or more builder instances
 
 ### Options
 
-| Name                                | Type     | Default | Description                              |
-|:------------------------------------|:---------|:--------|:-----------------------------------------|
-| [`--all-inactive`](#all-inactive)   | `bool`   |         | Remove all inactive builders             |
-| [`--builder`](#builder)             | `string` |         | Override the configured builder instance |
-| `-D`, `--debug`                     | `bool`   |         | Enable debug logging                     |
-| [`-f`](#force), [`--force`](#force) | `bool`   |         | Do not prompt for confirmation           |
-| [`--keep-daemon`](#keep-daemon)     | `bool`   |         | Keep the BuildKit daemon running         |
-| [`--keep-state`](#keep-state)       | `bool`   |         | Keep BuildKit state                      |
+| Name                                | Type       | Default | Description                                                          |
+|:------------------------------------|:-----------|:--------|:---------------------------------------------------------------------|
+| [`--all-inactive`](#all-inactive)   | `bool`     |         | Remove all inactive builders                                         |
+| [`--builder`](#builder)             | `string`   |         | Override the configured builder instance                             |
+| `-D`, `--debug`                     | `bool`     |         | Enable debug logging                                                 |
+| [`-f`](#force), [`--force`](#force) | `bool`     |         | Do not prompt for confirmation                                       |
+| [`--keep-daemon`](#keep-daemon)     | `bool`     |         | Keep the BuildKit daemon running                                     |
+| [`--keep-state`](#keep-state)       | `bool`     |         | Keep BuildKit state                                                  |
+| `--timeout`                         | `duration` | `20s`   | Override the default global timeout (as duration, for example 1m20s) |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_stop.md
+++ b/docs/reference/buildx_stop.md
@@ -9,10 +9,11 @@ Stop builder instance
 
 ### Options
 
-| Name                    | Type     | Default | Description                              |
-|:------------------------|:---------|:--------|:-----------------------------------------|
-| [`--builder`](#builder) | `string` |         | Override the configured builder instance |
-| `-D`, `--debug`         | `bool`   |         | Enable debug logging                     |
+| Name                    | Type       | Default | Description                                                          |
+|:------------------------|:-----------|:--------|:---------------------------------------------------------------------|
+| [`--builder`](#builder) | `string`   |         | Override the configured builder instance                             |
+| `-D`, `--debug`         | `bool`     |         | Enable debug logging                                                 |
+| `--timeout`             | `duration` | `20s`   | Override the default global timeout (as duration, for example 1m20s) |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_use.md
+++ b/docs/reference/buildx_use.md
@@ -9,12 +9,13 @@ Set the current builder instance
 
 ### Options
 
-| Name                    | Type     | Default | Description                                |
-|:------------------------|:---------|:--------|:-------------------------------------------|
-| [`--builder`](#builder) | `string` |         | Override the configured builder instance   |
-| `-D`, `--debug`         | `bool`   |         | Enable debug logging                       |
-| `--default`             | `bool`   |         | Set builder as default for current context |
-| `--global`              | `bool`   |         | Builder persists context changes           |
+| Name                    | Type       | Default | Description                                                          |
+|:------------------------|:-----------|:--------|:---------------------------------------------------------------------|
+| [`--builder`](#builder) | `string`   |         | Override the configured builder instance                             |
+| `-D`, `--debug`         | `bool`     |         | Enable debug logging                                                 |
+| `--default`             | `bool`     |         | Set builder as default for current context                           |
+| `--global`              | `bool`     |         | Builder persists context changes                                     |
+| `--timeout`             | `duration` | `20s`   | Override the default global timeout (as duration, for example 1m20s) |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_version.md
+++ b/docs/reference/buildx_version.md
@@ -9,9 +9,10 @@ Show buildx version information
 
 ### Options
 
-| Name            | Type   | Default | Description          |
-|:----------------|:-------|:--------|:---------------------|
-| `-D`, `--debug` | `bool` |         | Enable debug logging |
+| Name            | Type       | Default | Description                                                          |
+|:----------------|:-----------|:--------|:---------------------------------------------------------------------|
+| `-D`, `--debug` | `bool`     |         | Enable debug logging                                                 |
+| `--timeout`     | `duration` | `20s`   | Override the default global timeout (as duration, for example 1m20s) |
 
 
 <!---MARKER_GEN_END-->

--- a/driver/kubernetes/driver.go
+++ b/driver/kubernetes/driver.go
@@ -55,7 +55,6 @@ type Driver struct {
 	configMapClient  clientcorev1.ConfigMapInterface
 	podChooser       podchooser.PodChooser
 	defaultLoad      bool
-	timeout          time.Duration
 }
 
 func (d *Driver) IsMobyDriver() bool {
@@ -94,7 +93,7 @@ func (d *Driver) Bootstrap(ctx context.Context, l progress.Logger) error {
 			}
 		}
 		return sub.Wrap(
-			fmt.Sprintf("waiting for %d pods to be ready, timeout: %s", d.minReplicas, units.HumanDuration(d.timeout)),
+			fmt.Sprintf("waiting for %d pods to be ready, timeout: %s", d.minReplicas, units.HumanDuration(d.Timeout)),
 			func() error {
 				return d.wait(ctx)
 			})
@@ -108,7 +107,7 @@ func (d *Driver) wait(ctx context.Context) error {
 		depl *appsv1.Deployment
 	)
 
-	timeoutChan := time.After(d.timeout)
+	timeoutChan := time.After(d.Timeout)
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 

--- a/driver/kubernetes/factory.go
+++ b/driver/kubernetes/factory.go
@@ -134,7 +134,7 @@ func (f *factory) New(ctx context.Context, cfg driver.InitConfig) (driver.Driver
 	}
 
 	d.defaultLoad = defaultLoad
-	d.timeout = timeout
+	d.Timeout = timeout
 
 	d.deployment, d.configMaps, err = manifest.NewDeployment(deploymentOpt)
 	if err != nil {

--- a/driver/manager.go
+++ b/driver/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/docker/cli/cli/context/store"
 	"github.com/moby/buildkit/client"
@@ -39,6 +40,7 @@ type InitConfig struct {
 	Platforms       []ocispecs.Platform
 	ContextPathHash string
 	DialMeta        map[string][]string
+	Timeout         time.Duration
 }
 
 var drivers map[string]Factory

--- a/driver/remote/driver.go
+++ b/driver/remote/driver.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/docker/buildx/driver"
 	util "github.com/docker/buildx/driver/remote/util"
@@ -48,7 +47,7 @@ func (d *Driver) Bootstrap(ctx context.Context, l progress.Logger) error {
 	}
 	return progress.Wrap("[internal] waiting for connection", l, func(_ progress.SubLogger) error {
 		cancelCtx, cancel := context.WithCancelCause(ctx)
-		ctx, _ := context.WithTimeoutCause(cancelCtx, 20*time.Second, errors.WithStack(context.DeadlineExceeded)) //nolint:govet // no need to manually cancel this context as we already rely on parent
+		ctx, _ := context.WithTimeoutCause(cancelCtx, d.Timeout, errors.WithStack(context.DeadlineExceeded)) //nolint:govet // no need to manually cancel this context as we already rely on parent
 		defer func() { cancel(errors.WithStack(context.Canceled)) }()
 		return c.Wait(ctx)
 	})


### PR DESCRIPTION
this is to revisit unfinished work to bring consistent timeout across all commands:
- https://github.com/docker/buildx/issues/358
- https://github.com/moby/buildkit/issues/5946
- https://github.com/docker/buildx/pull/2586
- https://github.com/docker/buildx/pull/3159