### PR TITLE
Dockerfile: update dev deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -120,11 +120,13 @@ ARG BUILDKIT_SBOM_SCAN_STAGE=true
 FROM gobase AS integration-test-base
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
 RUN apk add --no-cache \
+      bash \
       btrfs-progs \
       e2fsprogs \
       e2fsprogs-extra \
       ip6tables \
       iptables \
+      make \
       openssl \
       shadow-uidmap \
       xfsprogs \

--- a/hack/test
+++ b/hack/test
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eu -o pipefail
+set -eu
 
 : "${GITHUB_ACTIONS=}"
 


### PR DESCRIPTION
Hack scripts require make and bash that was missing in the dev Dockerfile stage.
