### PR TITLE
bake: allow disabling env lookup for bake

### DIFF
--- a/bake/compose.go
+++ b/bake/compose.go
@@ -304,7 +304,11 @@ func validateCompose(dt []byte, envs map[string]string) error {
 }
 
 func composeEnv() (map[string]string, error) {
-	envs := sliceToMap(os.Environ())
+	var env []string
+	if envLookupAllowed() {
+		env = os.Environ()
+	}
+	envs := sliceToMap(env)
 	if wd, err := os.Getwd(); err == nil {
 		envs, err = loadDotEnv(envs, wd)
 		if err != nil {


### PR DESCRIPTION
Allow bake to be run in a mode where the local environment variable values can't be captured by bake definition.

In the future, we will likely also add `--var k=v` for an alternative way to pass values to variables.

This is based on https://github.com/moby/buildkit/pull/6463/files#r2690936348