### PR TITLE
commands: adds metrics associated with the debugger

### DIFF
--- a/commands/dap.go
+++ b/commands/dap.go
@@ -18,6 +18,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	dapEnvUserAgent = "BUILDX_DAP_USER_AGENT"
+)
+
 func dapCmd(dockerCli command.Cli, rootOpts *rootOptions) *cobra.Command {
 	var options dapOptions
 	cmd := &cobra.Command{
@@ -49,6 +53,13 @@ func (d *dapOptions) New(in ioset.In) (debuggerInstance, error) {
 		Adapter: dap.New[LaunchConfig](),
 		conn:    conn,
 	}, nil
+}
+
+func (d *dapOptions) Info() debuggerInfo {
+	return debuggerInfo{
+		Name:      "dap",
+		UserAgent: os.Getenv(dapEnvUserAgent),
+	}
 }
 
 type LaunchConfig struct {

--- a/commands/debug.go
+++ b/commands/debug.go
@@ -26,9 +26,15 @@ type debugOptions struct {
 	OnFlag string
 }
 
+type debuggerInfo struct {
+	Name      string
+	UserAgent string
+}
+
 // debuggerOptions will start a debuggerOptions instance.
 type debuggerOptions interface {
 	New(in ioset.In) (debuggerInstance, error)
+	Info() debuggerInfo
 }
 
 // debuggerInstance is an instance of a Debugger that has been started.
@@ -69,6 +75,12 @@ func (d *debugOptions) New(in ioset.In) (debuggerInstance, error) {
 		cfg: cfg,
 		in:  in.Stdin,
 	}, nil
+}
+
+func (d *debugOptions) Info() debuggerInfo {
+	return debuggerInfo{
+		Name: "debug",
+	}
 }
 
 type monitorDebuggerInstance struct {


### PR DESCRIPTION

Add metrics associated with the debugger that are reported through the
metrics writer. This adds a few attributes that are only added when a
debugger is used with either the `debug` command or `dap` command.

At the moment, these metrics show up the exact same as a build and we
can't identify if something is using `dap` or `debug` since they use the
same code path.

This also adds a new available metric that can be utilized by plugins to
report additional information. The metrics will check if an environment
variable `BUILDX_DAP_USER_AGENT` is sent and that will get included in
the metrics if they are enabled.
