### PR TITLE
bake: derive git auth host from remote URL

### DIFF
--- a/bake/gitauth.go
+++ b/bake/gitauth.go
@@ -1,0 +1,78 @@
+package bake
+
+import (
+	"os"
+	"strings"
+
+	"github.com/docker/buildx/util/buildflags"
+	"github.com/docker/buildx/util/urlutil"
+	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/util/gitutil"
+)
+
+const (
+	bakeGitAuthTokenEnv  = "BUILDX_BAKE_GIT_AUTH_TOKEN" // #nosec G101 -- environment variable key, not a credential
+	bakeGitAuthHeaderEnv = "BUILDX_BAKE_GIT_AUTH_HEADER"
+)
+
+func gitAuthSecretsFromEnv(remoteURL string) buildflags.Secrets {
+	return gitAuthSecretsFromEnviron(os.Environ(), remoteURL)
+}
+
+func gitAuthSecretsFromEnviron(environ []string, remoteURL string) buildflags.Secrets {
+	host, ok := gitAuthHostFromURL(remoteURL)
+	if !ok {
+		return nil
+	}
+	secrets := make(buildflags.Secrets, 0, 2)
+	secrets = append(secrets, gitAuthSecretsForEnv(llb.GitAuthTokenKey, bakeGitAuthTokenEnv, environ, host)...)
+	secrets = append(secrets, gitAuthSecretsForEnv(llb.GitAuthHeaderKey, bakeGitAuthHeaderEnv, environ, host)...)
+	return secrets
+}
+
+func gitAuthSecretsForEnv(secretIDPrefix, envPrefix string, environ []string, host string) buildflags.Secrets {
+	envKey, ok := findGitAuthEnvKey(envPrefix, environ)
+	if !ok || host == "" {
+		return nil
+	}
+	return buildflags.Secrets{&buildflags.Secret{
+		ID:  secretIDPrefix + "." + host,
+		Env: envKey,
+	}}
+}
+
+func shouldAttachGitAuthSecrets(inputURL, contextPath string) bool {
+	if !urlutil.IsRemoteURL(inputURL) || !urlutil.IsRemoteURL(contextPath) {
+		return false
+	}
+	inputHost, ok := gitAuthHostFromURL(inputURL)
+	if !ok {
+		return false
+	}
+	contextHost, ok := gitAuthHostFromURL(contextPath)
+	if !ok {
+		return false
+	}
+	return strings.EqualFold(inputHost, contextHost)
+}
+
+func gitAuthHostFromURL(remoteURL string) (string, bool) {
+	gitURL, err := gitutil.ParseURL(remoteURL)
+	if err != nil || gitURL.Host == "" {
+		return "", false
+	}
+	return gitURL.Host, true
+}
+
+func findGitAuthEnvKey(envKey string, environ []string) (string, bool) {
+	for _, env := range environ {
+		key, _, ok := strings.Cut(env, "=")
+		if !ok {
+			continue
+		}
+		if strings.EqualFold(key, envKey) {
+			return key, true
+		}
+	}
+	return "", false
+}

--- a/bake/gitauth_test.go
+++ b/bake/gitauth_test.go
@@ -1,0 +1,83 @@
+package bake
+
+import (
+	"testing"
+
+	"github.com/docker/buildx/util/buildflags"
+	"github.com/moby/buildkit/client/llb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGitAuthSecretsFromEnviron(t *testing.T) {
+	t.Run("empty without remote url", func(t *testing.T) {
+		secrets := gitAuthSecretsFromEnviron([]string{
+			bakeGitAuthTokenEnv + "=token",
+			bakeGitAuthHeaderEnv + "=basic",
+		}, "")
+		require.Empty(t, secrets)
+	})
+	t.Run("derives host from remote url", func(t *testing.T) {
+		secrets := gitAuthSecretsFromEnviron([]string{
+			bakeGitAuthTokenEnv + "=token",
+			bakeGitAuthHeaderEnv + "=basic",
+		}, "https://example.com/org/repo.git")
+		require.Equal(t, []string{
+			llb.GitAuthTokenKey + ".example.com|" + bakeGitAuthTokenEnv,
+			llb.GitAuthHeaderKey + ".example.com|" + bakeGitAuthHeaderEnv,
+		}, secretPairs(secrets))
+	})
+	t.Run("ignores host suffixed keys", func(t *testing.T) {
+		secrets := gitAuthSecretsFromEnviron([]string{
+			bakeGitAuthTokenEnv + ".example.com=token",
+			bakeGitAuthHeaderEnv + ".example.com=basic",
+		}, "https://example.com/org/repo.git")
+		require.Empty(t, secrets)
+	})
+}
+
+func TestShouldAttachGitAuthSecrets(t *testing.T) {
+	tests := []struct {
+		name        string
+		inputURL    string
+		contextPath string
+		want        bool
+	}{
+		{
+			name:        "same host http urls",
+			inputURL:    "https://example.com/org/repo.git",
+			contextPath: "https://example.com/another/repo.git",
+			want:        true,
+		},
+		{
+			name:        "same host mixed git url styles",
+			inputURL:    "https://example.com/org/repo.git",
+			contextPath: "git@example.com:another/repo.git",
+			want:        true,
+		},
+		{
+			name:        "different hosts",
+			inputURL:    "https://example.com/org/repo.git",
+			contextPath: "https://other.example.com/org/repo.git",
+			want:        false,
+		},
+		{
+			name:        "non remote context",
+			inputURL:    "https://example.com/org/repo.git",
+			contextPath: "cwd://src",
+			want:        false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, shouldAttachGitAuthSecrets(tt.inputURL, tt.contextPath))
+		})
+	}
+}
+
+func secretPairs(secrets buildflags.Secrets) []string {
+	out := make([]string, 0, len(secrets))
+	for _, s := range secrets {
+		out = append(out, s.ID+"|"+s.Env)
+	}
+	return out
+}

--- a/bake/remote.go
+++ b/bake/remote.go
@@ -44,20 +44,7 @@ func ReadRemoteFiles(ctx context.Context, nodes []builder.Node, url string, name
 		}}); err == nil {
 			sessions = append(sessions, ssh)
 		}
-		var gitAuthSecrets []*buildflags.Secret
-		if _, ok := os.LookupEnv("BUILDX_BAKE_GIT_AUTH_TOKEN"); ok {
-			gitAuthSecrets = append(gitAuthSecrets, &buildflags.Secret{
-				ID:  llb.GitAuthTokenKey,
-				Env: "BUILDX_BAKE_GIT_AUTH_TOKEN",
-			})
-		}
-		if _, ok := os.LookupEnv("BUILDX_BAKE_GIT_AUTH_HEADER"); ok {
-			gitAuthSecrets = append(gitAuthSecrets, &buildflags.Secret{
-				ID:  llb.GitAuthHeaderKey,
-				Env: "BUILDX_BAKE_GIT_AUTH_HEADER",
-			})
-		}
-		if len(gitAuthSecrets) > 0 {
+		if gitAuthSecrets := gitAuthSecretsFromEnv(url); len(gitAuthSecrets) > 0 {
 			if secrets, err := build.CreateSecrets(gitAuthSecrets); err == nil {
 				sessions = append(sessions, secrets)
 			}


### PR DESCRIPTION
This PR refactors Bake Git authentication secret handling by introducing a dedicated gitauth helper that centralizes how secrets are built from environment variables. The same helper is now used in both build option creation and remote bake file reads, so the behavior is consistent across those paths while preserving existing support for `BUILDX_BAKE_GIT_AUTH_TOKEN` and `BUILDX_BAKE_GIT_AUTH_HEADER`.

It also adds automatic host-based Git auth secret derivation for remote Bake invocations. When a remote URL is in play, Bake now emits both base BuildKit secret IDs and host-scoped IDs (for example `GIT_AUTH_TOKEN.<host>` / `GIT_AUTH_HEADER.<host>`) based on the resolved remote URL logic, enabling per-host auth routing automatically without introducing host-suffixed auth env vars.