### PR TITLE
build: avoid empty line when -q used with --call

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -411,7 +411,7 @@ func runBuild(ctx context.Context, dockerCli command.Cli, debugOpts debuggerOpti
 	case progressui.RawJSONMode:
 		// no additional display
 	case progressui.QuietMode:
-		if options.quiet {
+		if options.quiet && opts.CallFunc == nil {
 			fmt.Println(getImageID(resp.ExporterResponse))
 		}
 	default:


### PR DESCRIPTION
fix #3651