### PR TITLE
chore: update target path for cli yaml in docs-release workflow

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -68,7 +68,7 @@ jobs:
       -
         name: Copy yaml
         run: |
-          cp /tmp/buildx-docs/out/reference/*.yaml ./data/buildx/
+          cp /tmp/buildx-docs/out/reference/*.yaml ./data/cli/buildx/
       -
         name: Update vendor
         run: |


### PR DESCRIPTION
docker/docs#24191 changed the filepath for cli reference yaml from `data/buildx` to `data/cli/buildx`