### PR TITLE
commands: make builder status timeouts configurable across cli flows

### DIFF
--- a/commands/create.go
+++ b/commands/create.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/docker/buildx/builder"
 	"github.com/docker/buildx/driver"
@@ -27,6 +28,7 @@ type createOptions struct {
 	buildkitdFlags      string
 	buildkitdConfigFile string
 	bootstrap           bool
+	timeout             time.Duration
 	// upgrade      bool // perform upgrade of the driver
 }
 
@@ -61,6 +63,7 @@ func runCreate(ctx context.Context, dockerCli command.Cli, in createOptions, arg
 		Use:                 in.use,
 		Endpoint:            ep,
 		Append:              in.actionAppend,
+		Timeout:             in.timeout,
 	})
 	if err != nil {
 		return err
@@ -120,6 +123,7 @@ func createCmd(dockerCli command.Cli) *cobra.Command {
 	flags.BoolVar(&options.actionAppend, "append", false, "Append a node to builder instead of changing it")
 	flags.BoolVar(&options.actionLeave, "leave", false, "Remove a node from builder instead of changing it")
 	flags.BoolVar(&options.use, "use", false, "Set the current builder instance")
+	setBuilderStatusTimeoutFlag(flags, &options.timeout)
 
 	// hide builder persistent flag for this command
 	cobrautil.HideInheritedFlags(cmd, "builder")

--- a/commands/root.go
+++ b/commands/root.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"os"
+	"time"
 
 	historycmd "github.com/docker/buildx/commands/history"
 	imagetoolscmd "github.com/docker/buildx/commands/imagetools"
@@ -141,4 +142,8 @@ func addCommands(cmd *cobra.Command, opts *rootOptions, dockerCli command.Cli) {
 func rootFlags(options *rootOptions, flags *pflag.FlagSet) {
 	flags.StringVar(&options.builder, "builder", os.Getenv("BUILDX_BUILDER"), "Override the configured builder instance")
 	flags.BoolVarP(&options.debug, "debug", "D", debug.IsEnabled(), "Enable debug logging")
+}
+
+func setBuilderStatusTimeoutFlag(flags *pflag.FlagSet, target *time.Duration) {
+	flags.DurationVar(target, "timeout", 20*time.Second, "Override the default timeout for loading builder status")
 }

--- a/docs/reference/buildx_create.md
+++ b/docs/reference/buildx_create.md
@@ -22,6 +22,7 @@ Create a new builder instance
 | [`--name`](#name)                         | `string`      |         | Builder instance name                                                 |
 | [`--node`](#node)                         | `string`      |         | Create/modify node with given name                                    |
 | [`--platform`](#platform)                 | `stringArray` |         | Fixed platforms for current node                                      |
+| `--timeout`                               | `duration`    | `20s`   | Override the default timeout for loading builder status               |
 | [`--use`](#use)                           | `bool`        |         | Set the current builder instance                                      |
 
 

--- a/docs/reference/buildx_du.md
+++ b/docs/reference/buildx_du.md
@@ -9,13 +9,14 @@ Disk usage
 
 ### Options
 
-| Name                    | Type     | Default | Description                              |
-|:------------------------|:---------|:--------|:-----------------------------------------|
-| [`--builder`](#builder) | `string` |         | Override the configured builder instance |
-| `-D`, `--debug`         | `bool`   |         | Enable debug logging                     |
-| [`--filter`](#filter)   | `filter` |         | Provide filter values                    |
-| [`--format`](#format)   | `string` |         | Format the output                        |
-| [`--verbose`](#verbose) | `bool`   |         | Shorthand for `--format=pretty`          |
+| Name                    | Type       | Default | Description                                             |
+|:------------------------|:-----------|:--------|:--------------------------------------------------------|
+| [`--builder`](#builder) | `string`   |         | Override the configured builder instance                |
+| `-D`, `--debug`         | `bool`     |         | Enable debug logging                                    |
+| [`--filter`](#filter)   | `filter`   |         | Provide filter values                                   |
+| [`--format`](#format)   | `string`   |         | Format the output                                       |
+| `--timeout`             | `duration` | `20s`   | Override the default timeout for loading builder status |
+| [`--verbose`](#verbose) | `bool`     |         | Shorthand for `--format=pretty`                         |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_inspect.md
+++ b/docs/reference/buildx_inspect.md
@@ -9,11 +9,12 @@ Inspect current builder instance
 
 ### Options
 
-| Name                        | Type     | Default | Description                                 |
-|:----------------------------|:---------|:--------|:--------------------------------------------|
-| [`--bootstrap`](#bootstrap) | `bool`   |         | Ensure builder has booted before inspecting |
-| [`--builder`](#builder)     | `string` |         | Override the configured builder instance    |
-| `-D`, `--debug`             | `bool`   |         | Enable debug logging                        |
+| Name                        | Type       | Default | Description                                             |
+|:----------------------------|:-----------|:--------|:--------------------------------------------------------|
+| [`--bootstrap`](#bootstrap) | `bool`     |         | Ensure builder has booted before inspecting             |
+| [`--builder`](#builder)     | `string`   |         | Override the configured builder instance                |
+| `-D`, `--debug`             | `bool`     |         | Enable debug logging                                    |
+| `--timeout`                 | `duration` | `20s`   | Override the default timeout for loading builder status |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_ls.md
+++ b/docs/reference/buildx_ls.md
@@ -9,11 +9,12 @@ List builder instances
 
 ### Options
 
-| Name                  | Type     | Default | Description           |
-|:----------------------|:---------|:--------|:----------------------|
-| `-D`, `--debug`       | `bool`   |         | Enable debug logging  |
-| [`--format`](#format) | `string` | `table` | Format the output     |
-| `--no-trunc`          | `bool`   |         | Don't truncate output |
+| Name                  | Type       | Default | Description                                             |
+|:----------------------|:-----------|:--------|:--------------------------------------------------------|
+| `-D`, `--debug`       | `bool`     |         | Enable debug logging                                    |
+| [`--format`](#format) | `string`   | `table` | Format the output                                       |
+| `--no-trunc`          | `bool`     |         | Don't truncate output                                   |
+| `--timeout`           | `duration` | `20s`   | Override the default timeout for loading builder status |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_prune.md
+++ b/docs/reference/buildx_prune.md
@@ -9,17 +9,18 @@ Remove build cache
 
 ### Options
 
-| Name                                  | Type     | Default | Description                                            |
-|:--------------------------------------|:---------|:--------|:-------------------------------------------------------|
-| [`-a`](#all), [`--all`](#all)         | `bool`   |         | Include internal/frontend images                       |
-| [`--builder`](#builder)               | `string` |         | Override the configured builder instance               |
-| `-D`, `--debug`                       | `bool`   |         | Enable debug logging                                   |
-| [`--filter`](#filter)                 | `filter` |         | Provide filter values                                  |
-| `-f`, `--force`                       | `bool`   |         | Do not prompt for confirmation                         |
-| [`--max-used-space`](#max-used-space) | `bytes`  | `0`     | Maximum amount of disk space allowed to keep for cache |
-| [`--min-free-space`](#min-free-space) | `bytes`  | `0`     | Target amount of free disk space after pruning         |
-| [`--reserved-space`](#reserved-space) | `bytes`  | `0`     | Amount of disk space always allowed to keep for cache  |
-| `--verbose`                           | `bool`   |         | Provide a more verbose output                          |
+| Name                                  | Type       | Default | Description                                             |
+|:--------------------------------------|:-----------|:--------|:--------------------------------------------------------|
+| [`-a`](#all), [`--all`](#all)         | `bool`     |         | Include internal/frontend images                        |
+| [`--builder`](#builder)               | `string`   |         | Override the configured builder instance                |
+| `-D`, `--debug`                       | `bool`     |         | Enable debug logging                                    |
+| [`--filter`](#filter)                 | `filter`   |         | Provide filter values                                   |
+| `-f`, `--force`                       | `bool`     |         | Do not prompt for confirmation                          |
+| [`--max-used-space`](#max-used-space) | `bytes`    | `0`     | Maximum amount of disk space allowed to keep for cache  |
+| [`--min-free-space`](#min-free-space) | `bytes`    | `0`     | Target amount of free disk space after pruning          |
+| [`--reserved-space`](#reserved-space) | `bytes`    | `0`     | Amount of disk space always allowed to keep for cache   |
+| `--timeout`                           | `duration` | `20s`   | Override the default timeout for loading builder status |
+| `--verbose`                           | `bool`     |         | Provide a more verbose output                           |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/buildx_rm.md
+++ b/docs/reference/buildx_rm.md
@@ -9,14 +9,15 @@ Remove one or more builder instances
 
 ### Options
 
-| Name                                | Type     | Default | Description                              |
-|:------------------------------------|:---------|:--------|:-----------------------------------------|
-| [`--all-inactive`](#all-inactive)   | `bool`   |         | Remove all inactive builders             |
-| [`--builder`](#builder)             | `string` |         | Override the configured builder instance |
-| `-D`, `--debug`                     | `bool`   |         | Enable debug logging                     |
-| [`-f`](#force), [`--force`](#force) | `bool`   |         | Do not prompt for confirmation           |
-| [`--keep-daemon`](#keep-daemon)     | `bool`   |         | Keep the BuildKit daemon running         |
-| [`--keep-state`](#keep-state)       | `bool`   |         | Keep BuildKit state                      |
+| Name                                | Type       | Default | Description                                             |
+|:------------------------------------|:-----------|:--------|:--------------------------------------------------------|
+| [`--all-inactive`](#all-inactive)   | `bool`     |         | Remove all inactive builders                            |
+| [`--builder`](#builder)             | `string`   |         | Override the configured builder instance                |
+| `-D`, `--debug`                     | `bool`     |         | Enable debug logging                                    |
+| [`-f`](#force), [`--force`](#force) | `bool`     |         | Do not prompt for confirmation                          |
+| [`--keep-daemon`](#keep-daemon)     | `bool`     |         | Keep the BuildKit daemon running                        |
+| [`--keep-state`](#keep-state)       | `bool`     |         | Keep BuildKit state                                     |
+| `--timeout`                         | `duration` | `20s`   | Override the default timeout for loading builder status |
 
 
 <!---MARKER_GEN_END-->


### PR DESCRIPTION
* fixes https://github.com/docker/buildx/issues/358
* fixes https://github.com/moby/buildkit/issues/5946
* closes https://github.com/docker/buildx/pull/3585

Adds a command-scoped `--timeout` duration flag to buildx commands depending on builder status, and wires it into existing status-loading timeout contexts. Defaults remain unchanged at `20s` when the flag is not set. This addresses user-facing timeout control for the CLI command paths discussed in https://github.com/docker/buildx/issues/358 and https://github.com/moby/buildkit/issues/5946, and follows up on previous attempts in https://github.com/docker/buildx/pull/2586, https://github.com/docker/buildx/pull/3159, and https://github.com/docker/buildx/pull/3585.

Driver-level timeout behavior (for example remote-driver/bootstrap specifics) is intentionally out of scope here and will be handled in a separate follow-up PR.