### PR TITLE
build: ref-count policy FS lifecycle

### DIFF
--- a/build/policy_loader_test.go
+++ b/build/policy_loader_test.go
@@ -1,0 +1,85 @@
+package build
+
+import (
+	"io/fs"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemoizedPolicyFSRefCountedClose(t *testing.T) {
+	var initCalls int
+	var closeCalls int
+
+	m := &memoizedPolicyFS{
+		init: func() (fs.StatFS, func() error, error) {
+			initCalls++
+			root := fstest.MapFS{
+				"policy.rego": &fstest.MapFile{Data: []byte("package docker\n")},
+			}
+			return root, func() error {
+				closeCalls++
+				return nil
+			}, nil
+		},
+	}
+
+	first, err := m.get()
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	require.Equal(t, 1, initCalls)
+
+	second, err := m.get()
+	require.NoError(t, err)
+	require.NotNil(t, second)
+	require.Equal(t, 1, initCalls)
+
+	require.NoError(t, m.close())
+	require.Equal(t, 0, closeCalls)
+
+	third, err := m.get()
+	require.NoError(t, err)
+	require.NotNil(t, third)
+	require.Equal(t, 1, initCalls)
+
+	require.NoError(t, m.close())
+	require.Equal(t, 0, closeCalls)
+
+	require.NoError(t, m.close())
+	require.Equal(t, 1, closeCalls)
+}
+
+func TestMemoizedPolicyFSReinitializesAfterAllRefsClosed(t *testing.T) {
+	var initCalls int
+	var closeCalls int
+
+	m := &memoizedPolicyFS{
+		init: func() (fs.StatFS, func() error, error) {
+			initCalls++
+			root := fstest.MapFS{
+				"policy.rego": &fstest.MapFile{Data: []byte("package docker\n")},
+			}
+			return root, func() error {
+				closeCalls++
+				return nil
+			}, nil
+		},
+	}
+
+	first, err := m.get()
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	require.Equal(t, 1, initCalls)
+
+	require.NoError(t, m.close())
+	require.Equal(t, 1, closeCalls)
+
+	second, err := m.get()
+	require.NoError(t, err)
+	require.NotNil(t, second)
+	require.Equal(t, 2, initCalls)
+
+	require.NoError(t, m.close())
+	require.Equal(t, 2, closeCalls)
+}

--- a/policy/funcs.go
+++ b/policy/funcs.go
@@ -486,13 +486,15 @@ func (p *Policy) readFile(path string, limit int64) ([]byte, error) {
 	if p.opt.FS == nil {
 		return nil, errors.Errorf("no policy FS defined for reading context files")
 	}
-	fs, cf, err := p.opt.FS()
+	root, closeFS, err := p.opt.FS()
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get policy FS for reading context files")
 	}
-	defer cf()
+	if closeFS != nil {
+		defer closeFS()
+	}
 
-	f, err := fs.Open(path)
+	f, err := root.Open(path)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed opening file %q", path)
 	}


### PR DESCRIPTION
Make memoized policy FS ref-counted so repeated get()/close() pairs don't prematurely close shared handles.

Current implementation could fail when reading same file twice.