### PR TITLE
hack/openbsd: use cdn.openbsd.org for PKG_PATH

### DIFF
--- a/hack/Vagrantfile.openbsd
+++ b/hack/Vagrantfile.openbsd
@@ -3,7 +3,7 @@
 
 Vagrant.configure("2") do |config|
   config.vm.box = "pygolo/openbsd7"
-  config.vm.box_version = "7.5"
+  config.vm.box_version = "7.7"
   config.vm.boot_timeout = 900
   config.vm.synced_folder ".", "/vagrant", type: "rsync"
   config.ssh.keep_alive = true
@@ -11,7 +11,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "init", type: "shell", run: "once" do |sh|
     sh.inline = <<~SHELL
       set -ex
-      export PKG_PATH=https://mirrors.ocf.berkeley.edu/pub/OpenBSD/7.5/packages/amd64/
+      export PKG_PATH=https://cdn.openbsd.org/pub/OpenBSD/$(uname -r)/packages/$(machine -a)/
       pkg_add -x git
 
       ftp https://go.dev/dl/go#{ENV['GO_VERSION']}.openbsd-amd64.tar.gz


### PR DESCRIPTION
relates to https://github.com/docker/buildx/actions/runs/22510011639/job/65378564119?pr=3678#step:6:73

```
==> default: Running provisioner: init (shell)...
    default: Running: inline script
    default: ++ export PKG_PATH=https://mirrors.ocf.berkeley.edu/pub/OpenBSD/7.5/packages/amd64/
    default: ++ PKG_PATH=https://mirrors.ocf.berkeley.edu/pub/OpenBSD/7.5/packages/amd64/
    default: ++ pkg_add -x git
    default: https://mirrors.ocf.berkeley.edu/pub/OpenBSD/7.5/packages/amd64/: no such dir
    default: Can't find git
```