### PR TITLE
bake: preserve git subdir in remote bake context paths

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -29,6 +30,7 @@ import (
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/frontend/dockerfile/dfgitutil"
 	"github.com/pkg/errors"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/convert"
@@ -1310,7 +1312,7 @@ func updateContext(t *build.Inputs, inp *Input) {
 		st := llb.Scratch().File(llb.Copy(*inp.State, v.Path, "/", &llb.CopyInfo{
 			CopyDirContentsOnly: true,
 		}), llb.WithCustomNamef("set context %s to %s", k, v.Path))
-		t.NamedContexts[k] = build.NamedContext{State: &st, Path: inp.URL}
+		t.NamedContexts[k] = build.NamedContext{State: &st, Path: remoteURLWithSubdir(inp.URL, v.Path)}
 	}
 
 	if t.ContextPath == "." {
@@ -1330,7 +1332,44 @@ func updateContext(t *build.Inputs, inp *Input) {
 		llb.WithCustomNamef("set context to %s", t.ContextPath),
 	)
 	t.ContextState = &st
-	t.ContextPath = inp.URL
+	t.ContextPath = remoteURLWithSubdir(inp.URL, t.ContextPath)
+}
+
+func remoteURLWithSubdir(remoteURL, subdir string) string {
+	subdir = path.Clean(subdir)
+	if subdir == "." || remoteURL == "" {
+		return remoteURL
+	}
+
+	// only relevant for git urls
+	parsed, ok, err := dfgitutil.ParseGitRef(remoteURL)
+	if err != nil || !ok {
+		return remoteURL
+	}
+	if parsed.SubDir != "" {
+		subdir = path.Clean(path.Join(parsed.SubDir, subdir))
+	}
+
+	// keep query string and transport style untouched nad only append/adjust
+	// fragment subdir
+	if !strings.Contains(remoteURL, "#") && subdir != "" {
+		if u, err := url.Parse(remoteURL); err == nil {
+			q := u.Query()
+			if q.Has("subdir") {
+				q.Set("subdir", subdir)
+				u.RawQuery = q.Encode()
+				return u.String()
+			}
+		}
+	}
+
+	// otherwise, we adjust the fragment part to add/replace subdir
+	base, frag, _ := strings.Cut(remoteURL, "#")
+	ref, _, _ := strings.Cut(frag, ":")
+	if ref == "" {
+		return base + "#:" + subdir
+	}
+	return base + "#" + ref + ":" + subdir
 }
 
 func collectLocalPaths(t build.Inputs) []string {

--- a/bake/bake_test.go
+++ b/bake/bake_test.go
@@ -2415,6 +2415,52 @@ target "mtx" {
 	}
 }
 
+func TestRemoteURLWithSubdir(t *testing.T) {
+	tests := []struct {
+		name   string
+		remote string
+		subdir string
+		want   string
+	}{
+		{
+			name:   "git no ref",
+			remote: "https://github.com/docker/buildx.git",
+			subdir: "components/interface",
+			want:   "https://github.com/docker/buildx.git#:components/interface",
+		},
+		{
+			name:   "git with ref",
+			remote: "https://github.com/docker/buildx.git#main",
+			subdir: "components/interface",
+			want:   "https://github.com/docker/buildx.git#main:components/interface",
+		},
+		{
+			name:   "git with existing subdir",
+			remote: "https://github.com/docker/buildx.git#main:base",
+			subdir: "components/interface",
+			want:   "https://github.com/docker/buildx.git#main:base/components/interface",
+		},
+		{
+			name:   "git query ref",
+			remote: "https://github.com/docker/buildx.git?branch=main",
+			subdir: "components/interface",
+			want:   "https://github.com/docker/buildx.git?branch=main#:components/interface",
+		},
+		{
+			name:   "non git",
+			remote: "https://example.com/context.tar.gz",
+			subdir: "components/interface",
+			want:   "https://example.com/context.tar.gz",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := remoteURLWithSubdir(tt.remote, tt.subdir)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func stringify[V fmt.Stringer](values []V) []string {
 	s := make([]string, len(values))
 	for i, v := range values {

--- a/tests/bake.go
+++ b/tests/bake.go
@@ -565,12 +565,12 @@ COPY super-cool.txt /
 	}{
 		{
 			name:            "no ref",
-			expectedContext: addr,
+			expectedContext: addr + "#:bar",
 		},
 		{
 			name:            "branch ref",
 			ref:             "main",
-			expectedContext: addr + "#main",
+			expectedContext: addr + "#main:bar",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
The repro shown in #3462 was not correct and didn't handle `subdir`. With this change it supports both fragment and query format with a subdir.

```
$ docker buildx bake "https://github.com/tonistiigi/xx.git#refs/tags/v1.9.0" xx --print
#0 building with "default" instance using docker driver

#1 [internal] load git source https://github.com/tonistiigi/xx.git#refs/tags/v1.9.0
#1 0.625 a5592eab7a57895e8d385394ff12241bc65ecd50       refs/tags/v1.9.0
#1 0.051 Initialized empty Git repository in /var/lib/desktop-containerd/daemon/io.containerd.snapshotter.v1.overlayfs/snapshots/23414/fs/
#1 0.699 From https://github.com/tonistiigi/xx
#1 0.699  * [new tag]         v1.9.0     -> v1.9.0
#1 0.703 a5592eab7a57895e8d385394ff12241bc65ecd50
#1 DONE 1.4s
{
  "group": {
    "default": {
      "targets": [
        "xx"
      ]
    }
  },
  "target": {
    "xx": {
      "context": "https://github.com/tonistiigi/xx.git#refs/tags/v1.9.0:src",
      "dockerfile": "Dockerfile",
      "tags": [
        "tonistiigi/xx:test"
      ],
      "target": "xx"
    }
  }
}
```

```
docker buildx bake "https://github.com/tonistiigi/xx.git?tag=v1.9.0" xx --print
#0 building with "default" instance using docker driver

#1 [internal] load git source https://github.com/tonistiigi/xx.git?tag=v1.9.0
#1 0.493 a5592eab7a57895e8d385394ff12241bc65ecd50       refs/tags/v1.9.0
#1 CACHED
{
  "group": {
    "default": {
      "targets": [
        "xx"
      ]
    }
  },
  "target": {
    "xx": {
      "context": "https://github.com/tonistiigi/xx.git?tag=v1.9.0#:src",
      "dockerfile": "Dockerfile",
      "tags": [
        "tonistiigi/xx:test"
      ],
      "target": "xx"
    }
  }
}
```

```
$ docker buildx bake "https://github.com/crazy-max/buildx-buildkit-tests.git#:buildx-3682" --print
#0 building with "default" instance using docker driver

#1 [internal] load git source https://github.com/crazy-max/buildx-buildkit-tests.git#:buildx-3682
#1 0.501 ref: refs/heads/main   HEAD
#1 0.501 848d0e37436a9228dede5abd71f447d63ec380c9       HEAD
#1 0.881 848d0e37436a9228dede5abd71f447d63ec380c9       refs/heads/main
#1 0.051 Initialized empty Git repository in /var/lib/desktop-containerd/daemon/io.containerd.snapshotter.v1.overlayfs/snapshots/23416/fs/
#1 0.389 ref: refs/heads/main   HEAD
#1 0.389 848d0e37436a9228dede5abd71f447d63ec380c9       HEAD
#1 0.940 From https://github.com/crazy-max/buildx-buildkit-tests
#1 0.940  * [new branch]      main       -> main
#1 0.941  * [new branch]      main       -> origin/main
#1 0.944 848d0e37436a9228dede5abd71f447d63ec380c9
#1 DONE 2.0s
{
  "group": {
    "default": {
      "targets": [
        "default"
      ]
    }
  },
  "target": {
    "default": {
      "context": "https://github.com/crazy-max/buildx-buildkit-tests.git#:buildx-3682/src",
      "dockerfile": "Dockerfile"
    }
  }
}
```

```
$ docker buildx bake "https://github.com/crazy-max/buildx-buildkit-tests.git?subdir=buildx-3682" --print
#0 building with "default" instance using docker driver

#1 [internal] load git source https://github.com/crazy-max/buildx-buildkit-tests.git?subdir=buildx-3682
#1 0.391 ref: refs/heads/main   HEAD
#1 0.391 848d0e37436a9228dede5abd71f447d63ec380c9       HEAD
#1 0.768 848d0e37436a9228dede5abd71f447d63ec380c9       refs/heads/main
#1 CACHED
{
  "group": {
    "default": {
      "targets": [
        "default"
      ]
    }
  },
  "target": {
    "default": {
      "context": "https://github.com/crazy-max/buildx-buildkit-tests.git?subdir=buildx-3682%2Fsrc",
      "dockerfile": "Dockerfile"
    }
  }
}
```