### PR TITLE
build: reuse build session for policy source resolution

### DIFF
--- a/build/opt.go
+++ b/build/opt.go
@@ -619,7 +619,7 @@ func configureSourcePolicy(ctx context.Context, np *noderesolver.ResolvedNode, o
 	if err != nil {
 		return nil, err
 	}
-	sourceResolver := sourcemeta.NewResolver(c, sourcemeta.WithProgressWriter(pw))
+	sourceResolver := sourcemeta.NewResolver(c, sourcemeta.WithProgressWriter(pw), sourcemeta.WithSession(so.Session))
 	defers = []func(error){
 		func(error) {
 			_ = sourceResolver.Close()

--- a/tests/build.go
+++ b/tests/build.go
@@ -48,6 +48,7 @@ var buildTests = []func(t *testing.T, sb integration.Sandbox){
 	testBuildAlias,
 	testBuildStdin,
 	testBuildRemote,
+	testBuildRemoteAuth,
 	testBuildLocalState,
 	testBuildLocalStateStdin,
 	testBuildLocalStateRemote,
@@ -265,6 +266,41 @@ COPY foo /foo
 			require.Contains(t, out, "current frontend does not support Git URLs with query string components")
 		}
 	})
+}
+
+func testBuildRemoteAuth(t *testing.T, sb integration.Sandbox) {
+	dockerfile := []byte(`
+FROM busybox:latest
+COPY foo /foo
+`)
+	dir := tmpdir(
+		t,
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+		fstest.CreateFile("foo", []byte("foo"), 0600),
+	)
+	dirDest := t.TempDir()
+
+	git, err := gitutil.New(gitutil.WithWorkingDir(dir))
+	require.NoError(t, err)
+
+	gittestutil.GitInit(git, t)
+	gittestutil.GitAdd(git, t, "Dockerfile", "foo")
+	gittestutil.GitCommit(git, t, "initial commit")
+
+	token := identity.NewID()
+	addr := gittestutil.GitServeHTTP(git, t, gittestutil.WithAccessToken(token))
+
+	out, err := buildCmd(sb, withDir(dir),
+		withEnv("GIT_AUTH_TOKEN="+token),
+		withArgs(
+			"--secret", "id=GIT_AUTH_TOKEN,env=GIT_AUTH_TOKEN",
+			"--output=type=local,dest="+dirDest,
+			addr,
+		),
+	)
+	require.NoError(t, err, out)
+
+	require.FileExists(t, filepath.Join(dirDest, "foo"))
 }
 
 func testBuildLocalState(t *testing.T, sb integration.Sandbox) {

--- a/util/sourcemeta/resolver.go
+++ b/util/sourcemeta/resolver.go
@@ -3,6 +3,7 @@ package sourcemeta
 import (
 	"context"
 	"errors"
+	"slices"
 	"sync"
 	"sync/atomic"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/client/llb/sourceresolver"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver/pb"
 )
 
@@ -44,11 +46,18 @@ type Option func(*newResolverOpts)
 
 type newResolverOpts struct {
 	progressWriter progress.Writer
+	session        []session.Attachable
 }
 
 func WithProgressWriter(pw progress.Writer) Option {
 	return func(o *newResolverOpts) {
 		o.progressWriter = pw
+	}
+}
+
+func WithSession(session []session.Attachable) Option {
+	return func(o *newResolverOpts) {
+		o.session = slices.Clone(session)
 	}
 }
 
@@ -72,7 +81,14 @@ func NewResolver(c *client.Client, opts ...Option) *Resolver {
 			}()
 		}
 
-		_, err := c.Build(ctx, client.SolveOpt{Internal: true}, "buildx", func(ctx context.Context, gw gwclient.Client) (*gwclient.Result, error) {
+		solveOpt := client.SolveOpt{
+			Internal: true,
+		}
+		if len(cfg.session) > 0 {
+			solveOpt.Session = cfg.session
+		}
+
+		_, err := c.Build(ctx, solveOpt, "buildx", func(ctx context.Context, gw gwclient.Client) (*gwclient.Result, error) {
 			ready <- gw
 			<-ctx.Done()
 			return nil, context.Cause(ctx)


### PR DESCRIPTION
fixes https://github.com/docker/build-push-action/issues/1477

Forward main solve session attachables (secrets) to the internal sourcemeta resolver solve used for remote policy/context probing. This fixes private remote git contexts in build where `GIT_AUTH_TOKEN` was not available during policy file lookup.