### PR TITLE
build: parallelize forced reference evaluation

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -630,7 +630,7 @@ func BuildWithResultHandler(ctx context.Context, nodes []builder.Node, opts map[
 								return nil, err
 							}
 						} else if forceEval {
-							if err := res.EachRef(func(ref gateway.Reference) error {
+							if err := eachRefParallel(ctx, res, func(ctx context.Context, ref gateway.Reference) error {
 								return ref.Evaluate(ctx)
 							}); err != nil {
 								return nil, err
@@ -1319,6 +1319,24 @@ func solve(ctx context.Context, c gateway.Client, req gateway.SolveRequest) (*ga
 		}
 	}
 	return res, nil
+}
+
+func eachRefParallel(ctx context.Context, res *gateway.Result, fn func(context.Context, gateway.Reference) error) error {
+	var refs []gateway.Reference
+	if err := res.EachRef(func(ref gateway.Reference) error {
+		refs = append(refs, ref)
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	eg, ctx := errgroup.WithContext(ctx)
+	for _, ref := range refs {
+		eg.Go(func() error {
+			return fn(ctx, ref)
+		})
+	}
+	return eg.Wait()
 }
 
 func catchFrontendError(retErr, frontendErr *error) {


### PR DESCRIPTION
fix #3543

@nicocrm

Use an errgroup helper to evaluate result refs concurrently during forced evaluation, and fail fast on the first evaluation error.

This mitigates the current case in Bake where chained targets with a multi-platform build could miss secrets and other session properties.

The outline for the issue case:
- Base target is solved, but only lazily and not really loaded/tracked in the build graph yet.
- Child targets are loaded, base target waits.
- Evaluate is called for the base stage (because it might be missing the result condition), the child stage is processed as the build result. This happens in parallel.
- Because `Evaluate()` was called synchronously, it may not have been called yet for the second platform while the child target already needs to run `RUN --mount=type=secret`.

This isn't a completely proper fix, but in practice, it should make the request timings so that the wrong order of steps does not occur. There is still misalignment that buildx seems to assume that after non-evaluated solve result is returned, the associated LLB is reference counted for the duration of the build request. While in reality, the lazy solve just returns the handle to the LLB definition in the request without attempting to load it into the build graph at all. Possible fixes for this would be to make BuildKit load the LLB but not trigger graph evaluation even on lazy solve, or add something new in the gateway API like `ref.Prepare()` that does the same thing explicitly.