### PR TITLE
build: make proxy build-arg override check case-insensitive

### DIFF
--- a/build/opt.go
+++ b/build/opt.go
@@ -527,7 +527,7 @@ func toSolveOpt(ctx context.Context, np *noderesolver.ResolvedNode, multiDriver 
 	}
 
 	for k, v := range node.ProxyConfig {
-		if _, ok := opt.BuildArgs[k]; !ok {
+		if !proxyArgKeyExists(opt.BuildArgs, k) {
 			so.FrontendAttrs["build-arg:"+k] = v
 		}
 	}
@@ -584,6 +584,15 @@ func toSolveOpt(ctx context.Context, np *noderesolver.ResolvedNode, multiDriver 
 	}
 
 	return &so, releaseF, nil
+}
+
+func proxyArgKeyExists(buildArgs map[string]string, key string) bool {
+	for k := range buildArgs {
+		if strings.EqualFold(k, key) {
+			return true
+		}
+	}
+	return false
 }
 
 func configureSourcePolicy(ctx context.Context, np *noderesolver.ResolvedNode, opt *Options, cfg *confutil.Config, bopts gateway.BuildOpts, so *client.SolveOpt, pw progress.Writer) (defers []func(error), err error) {

--- a/build/opt_test.go
+++ b/build/opt_test.go
@@ -156,3 +156,43 @@ func TestCreateExports_RegistryUnpack(t *testing.T) {
 		})
 	}
 }
+
+func TestProxyArgKeyExists(t *testing.T) {
+	tests := []struct {
+		name      string
+		proxyArgs map[string]string
+		key       string
+		want      bool
+	}{
+		{
+			name:      "exact match",
+			proxyArgs: map[string]string{"NO_PROXY": "cli"},
+			key:       "NO_PROXY",
+			want:      true,
+		},
+		{
+			name:      "case insensitive match",
+			proxyArgs: map[string]string{"no_proxy": "cli"},
+			key:       "NO_PROXY",
+			want:      true,
+		},
+		{
+			name:      "no match",
+			proxyArgs: map[string]string{"HTTP_PROXY": "cli"},
+			key:       "NO_PROXY",
+			want:      false,
+		},
+		{
+			name:      "nil map",
+			proxyArgs: nil,
+			key:       "NO_PROXY",
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, proxyArgKeyExists(tt.proxyArgs, tt.key))
+		})
+	}
+}


### PR DESCRIPTION
fixes https://github.com/docker/buildx/issues/3636

Buildx currently checks whether a proxy default should be injected using a case-sensitive map lookup, so `--build-arg no_proxy=...` does not block injecting `NO_PROXY` from `~/.docker/config.json`.

That can result in both `build-arg:no_proxy` and `build-arg:NO_PROXY` being sent to BuildKit and because BuildKit resolves proxy args case-insensitively from a Go map, the winning value can vary by map iteration order.

With this patch, Buildx uses a case-insensitive key existence check before injecting proxy defaults, so an explicit CLI proxy arg consistently takes precedence. This aligns behavior with user expectation that explicit `--build-arg` values should deterministically override config defaults.