### PR TITLE
store: increase test timeouts for CI reliability

### DIFF
--- a/store/store_test.go
+++ b/store/store_test.go
@@ -51,14 +51,14 @@ func TestNodeLocking(t *testing.T) {
 	}()
 
 	select {
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(200 * time.Millisecond):
 	case <-ready:
 		require.Fail(t, "transaction should have waited")
 	}
 
 	release()
 	select {
-	case <-time.After(200 * time.Millisecond):
+	case <-time.After(5 * time.Second):
 		require.Fail(t, "transaction should have completed")
 	case <-ready:
 	}


### PR DESCRIPTION
Bump timing thresholds in TestNodeLocking to avoid flaky failures on slow CI runners (e.g. Windows).

Spotted in https://github.com/docker/buildx/actions/runs/22633029183/job/65592266320#step:7:1758