### PR TITLE
history: deduplicate node clients during export

### DIFF
--- a/commands/history/export.go
+++ b/commands/history/export.go
@@ -102,6 +102,7 @@ func runExport(ctx context.Context, dockerCli command.Cli, opts exportOptions) e
 		if err != nil {
 			return err
 		}
+		visited[rec.node] = struct{}{}
 		clients = append(clients, c)
 	}
 


### PR DESCRIPTION
updates history export to deduplicate node clients correctly