### PR TITLE
docs: clarify Bake environment variable override behavior

### DIFF
--- a/docs/bake-reference.md
+++ b/docs/bake-reference.md
@@ -1350,11 +1350,17 @@ to define them.
 
 ### Use environment variable as default
 
-You can set a Bake variable to use the value of an environment variable as a default value:
+If an environment variable exists with the same name as a declared Bake
+variable, Bake uses that environment variable value instead of the declared
+default.
+
+To disable this environment-based variable lookup, set
+`BUILDX_BAKE_DISABLE_VARS_ENV_LOOKUP=1`.
+
 
 ```hcl
 variable "HOME" {
-  default = "$HOME"
+  default = "/root"
 }
 ```
 


### PR DESCRIPTION
## Summary

Clarifies the Bake reference docs for environment variable behavior.

The previous wording and example suggested that values like `$HOME` are
interpolated in the `default` field. In practice, Bake overrides a declared
variable when an environment variable with the same name is set.

## Changes

- Reworded the section to describe name-based environment variable override
- Replaced the ambiguous `default = "$HOME"` example
- Added a pointer to the overrides documentation

Related:
- docker/docs#23762