### PR TITLE
imagetools: use regex for manifest template matching

### DIFF
--- a/util/imagetools/printers.go
+++ b/util/imagetools/printers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"strings"
 	"text/tabwriter"
 	"text/template"
@@ -162,7 +163,7 @@ func (p *Printer) Print(raw bool, out io.Writer) error {
 }
 
 func isWholeManifestTemplate(format string) bool {
-	return strings.TrimSpace(format) == "{{.Manifest}}"
+	return regexp.MustCompile(`^\{\{\s*\.Manifest\s*\}\}$`).MatchString(strings.TrimSpace(format))
 }
 
 func (p *Printer) printManifestList(out io.Writer) error {

--- a/util/imagetools/printers_test.go
+++ b/util/imagetools/printers_test.go
@@ -1,0 +1,53 @@
+package imagetools
+
+import "testing"
+
+func TestIsWholeManifestTemplate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		format string
+		match  bool
+	}{
+		{
+			name:   "exact",
+			format: "{{.Manifest}}",
+			match:  true,
+		},
+		{
+			name:   "trimmed-whitespace",
+			format: "  {{.Manifest}}  ",
+			match:  true,
+		},
+		{
+			name:   "inner-whitespace",
+			format: "{{ .Manifest }}",
+			match:  true,
+		},
+		{
+			name:   "not-whole-template",
+			format: "{{.Manifest.Digest}}",
+			match:  false,
+		},
+		{
+			name:   "split-field-name-does-not-match",
+			format: "{{.Mani   fest   }}",
+			match:  false,
+		},
+		{
+			name:   "extra-text",
+			format: "{{.Manifest}}\n",
+			match:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isWholeManifestTemplate(tc.format); got != tc.match {
+				t.Fatalf("isWholeManifestTemplate(%q) = %v, want %v", tc.format, got, tc.match)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Allow optional whitespace inside the {{.Manifest}} template delimiters when detecting whole-manifest format strings.