### PR TITLE
build: reject empty BUILDKIT_SYNTAX overrides

### DIFF
--- a/build/opt.go
+++ b/build/opt.go
@@ -298,7 +298,11 @@ func toSolveOpt(ctx context.Context, np *noderesolver.ResolvedNode, multiDriver 
 	}
 
 	if v, ok := opt.BuildArgs["BUILDKIT_SYNTAX"]; ok {
-		p := strings.SplitN(strings.TrimSpace(v), " ", 2)
+		cmdline := strings.TrimSpace(v)
+		if cmdline == "" {
+			return nil, nil, errors.Errorf("empty BUILDKIT_SYNTAX build-arg is invalid, use --build-arg BUILDKIT_SYNTAX without '=' for optional behavior")
+		}
+		p := strings.SplitN(cmdline, " ", 2)
 		so.Frontend = "gateway.v0"
 		so.FrontendAttrs["source"] = p[0]
 		so.FrontendAttrs["cmdline"] = v

--- a/tests/build.go
+++ b/tests/build.go
@@ -62,6 +62,7 @@ var buildTests = []func(t *testing.T, sb integration.Sandbox){
 	testBuildProgress,
 	testBuildAnnotations,
 	testBuildBuildArgNoKey,
+	testBuildBuildKitSyntaxEmpty,
 	testBuildLabelNoKey,
 	testBuildCacheExportNotSupported,
 	testBuildOCIExportNotSupported,
@@ -757,6 +758,14 @@ func testBuildBuildArgNoKey(t *testing.T, sb integration.Sandbox) {
 	out, err := cmd.CombinedOutput()
 	require.Error(t, err, string(out))
 	require.Equal(t, `ERROR: invalid key-value pair "=TEST_STRING": empty key`, strings.TrimSpace(string(out)))
+}
+
+func testBuildBuildKitSyntaxEmpty(t *testing.T, sb integration.Sandbox) {
+	dir := createTestProject(t)
+	cmd := buildxCmd(sb, withArgs("build", "--build-arg", "BUILDKIT_SYNTAX=", dir))
+	out, err := cmd.CombinedOutput()
+	require.Error(t, err, string(out))
+	require.Contains(t, string(out), `empty BUILDKIT_SYNTAX build-arg is invalid, use --build-arg BUILDKIT_SYNTAX without '=' for optional behavior`)
 }
 
 func testBuildLabelNoKey(t *testing.T, sb integration.Sandbox) {


### PR DESCRIPTION
Reject empty `BUILDKIT_SYNTAX` build args.

`--build-arg BUILDKIT_SYNTAX` without `=` already supports optional behavior, since the value is only taken from the environment when it is set. `--build-arg BUILDKIT_SYNTAX=` is an explicit empty override, and buildx should not treat that like omission.

This change makes it fail early with a clear error message telling users to use `--build-arg BUILDKIT_SYNTAX` without `=` when they want optional behavior.

Before:

```
$ docker buildx build --build-arg BUILDKIT_SYNTAX="" https://github.com/docker/compose.git
#0 building with "default" instance using docker driver

#1 [internal] load git source https://github.com/docker/compose.git
#1 0.896 ref: refs/heads/main   HEAD
#1 0.896 b043368028e9fcb4545fa340c8ad635c370825da       HEAD
#1 1.496 b043368028e9fcb4545fa340c8ad635c370825da       refs/heads/main
#1 0.051 Initialized empty Git repository in /var/lib/desktop-containerd/daemon/io.containerd.snapshotter.v1.overlayfs/snapshots/24841/fs/
#1 0.498 ref: refs/heads/main   HEAD
#1 0.498 b043368028e9fcb4545fa340c8ad635c370825da       HEAD
#1 1.353 From https://github.com/docker/compose
#1 1.353  * [new branch]      main       -> main
#1 1.354  * [new branch]      main       -> origin/main
#1 1.358 b043368028e9fcb4545fa340c8ad635c370825da
#1 DONE 3.1s
ERROR: failed to build: failed to solve: invalid context name : invalid reference format
```

After:

```
$ docker buildx build --build-arg BUILDKIT_SYNTAX="" https://github.com/docker/compose.git
ERROR: failed to build: empty BUILDKIT_SYNTAX build-arg is invalid, use --build-arg BUILDKIT_SYNTAX without '=' for optional behavior
```