### PR TITLE
util/gitutil: Full/ShortCommit(): replace git show with git rev-parse

### DIFF
--- a/util/gitutil/gitutil.go
+++ b/util/gitutil/gitutil.go
@@ -101,11 +101,11 @@ func (c *Git) RemoteURL() (string, error) {
 }
 
 func (c *Git) FullCommit() (string, error) {
-	return c.clean(c.run("show", "--format=%H", "HEAD", "--quiet", "--"))
+	return c.clean(c.run("rev-parse", "HEAD"))
 }
 
 func (c *Git) ShortCommit() (string, error) {
-	return c.clean(c.run("show", "--format=%h", "HEAD", "--quiet", "--"))
+	return c.clean(c.run("rev-parse", "--short", "HEAD"))
 }
 
 func (c *Git) Tag() (string, error) {
@@ -185,8 +185,11 @@ func IsUnknownRevision(err error) bool {
 		return false
 	}
 	// https://github.com/git/git/blob/a6a323b31e2bcbac2518bddec71ea7ad558870eb/setup.c#L204
+	// https://github.com/git/git/blob/1adf5bca8c3cf778103548b9355777cf2d12efdd/builtin/rev-parse.c#L585
 	errMsg := strings.ToLower(err.Error())
-	return strings.Contains(errMsg, "unknown revision or path not in the working tree") || strings.Contains(errMsg, "bad revision")
+	return strings.Contains(errMsg, "unknown revision or path not in the working tree") ||
+		strings.Contains(errMsg, "bad revision") ||
+		strings.Contains(errMsg, "needed a single revision")
 }
 
 // stripCredentials takes a URL and strips username and password from it.

--- a/util/gitutil/gitutil_test.go
+++ b/util/gitutil/gitutil_test.go
@@ -62,7 +62,7 @@ func TestGitFullCommitErr(t *testing.T) {
 	_, err = c.FullCommit()
 	require.Error(t, err)
 	require.True(t, gitutil.IsUnknownRevision(err))
-	require.False(t, gittestutil.IsAmbiguousArgument(err))
+	require.True(t, gittestutil.IsAmbiguousArgument(err))
 }
 
 func TestGitShortCommitErr(t *testing.T) {


### PR DESCRIPTION
The FullCommit and ShortCommit methods are expected to simply get the hash of HEAD. Using `git show` for this purpose is overkill because `git show` can have side effects that are annoying when `docker build` runs in a CI environment:

1) CI environments (e.g. CircleCI) may use blobless clones, where the target repository is checked out using `git clone --filter=blob:none {url}`.

2) `git show` does more than just discover the hash of a specified revision: in general, it needs parent commits and blobs to compute the diff. When a blobless clone is used, `git show` may try to download these additional blobs from the remote. From my experiments, this happens even when `--quiet` or `--no-patch` is specified.

3) If the `docker build` step runs in an environment where Git is not configured properly to download from the remote, the step may hang indefinitely, as it did in my case with the following prompt:

   The authenticity of host 'github.com (140.82.112.3)' can't be established. ED25519 key fingerprint is SHA256:+.... This key is not known by any other names. Are you sure you want to continue connecting (yes/no/[fingerprint])?