### PR TITLE
ci(zizmor): use latest version and enable online audits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,11 +7,10 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 2
-    ignore:
-      # ignore this dependency
-      # it seems a bug with dependabot as pining to commit sha should not
-      # trigger a new version: https://github.com/docker/buildx/pull/2222#issuecomment-1919092153
-      - dependency-name: "docker/docs"
+    groups:
+      crazy-max-dot-github:
+        patterns:
+          - "crazy-max/.github/*"
     labels:
       - "area/dependencies"
       - "bot"

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -26,8 +26,6 @@ jobs:
       contents: read
       security-events: write
     with:
-      version: v1.22.0
       min-severity: medium
       min-confidence: medium
       persona: pedantic
-      no-online-audits: true

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,4 @@
+# https://docs.zizmor.sh/configuration/
+rules:
+  secrets-outside-env: # FIXME: remove this rule when zizmor 1.24.0 is released, fixing the right persona attached to this rule: https://github.com/zizmorcore/zizmor/pull/1783
+    disable: true


### PR DESCRIPTION
similar to https://github.com/moby/buildkit/pull/6623