### PR TITLE
build: use builtin frontend for BUILDKIT_SYNTAX=dockerfile.v0

### DIFF
--- a/build/opt.go
+++ b/build/opt.go
@@ -301,11 +301,12 @@ func toSolveOpt(ctx context.Context, np *noderesolver.ResolvedNode, multiDriver 
 		cmdline := strings.TrimSpace(v)
 		if cmdline == "" {
 			return nil, nil, errors.Errorf("empty BUILDKIT_SYNTAX build-arg is invalid, use --build-arg BUILDKIT_SYNTAX without '=' for optional behavior")
+		} else if cmdline != "dockerfile.v0" { // https://github.com/moby/buildkit/pull/6594
+			p := strings.SplitN(cmdline, " ", 2)
+			so.Frontend = "gateway.v0"
+			so.FrontendAttrs["source"] = p[0]
+			so.FrontendAttrs["cmdline"] = v
 		}
-		p := strings.SplitN(cmdline, " ", 2)
-		so.Frontend = "gateway.v0"
-		so.FrontendAttrs["source"] = p[0]
-		so.FrontendAttrs["cmdline"] = v
 	}
 
 	if v, ok := opt.BuildArgs["BUILDKIT_MULTI_PLATFORM"]; ok {


### PR DESCRIPTION
follow-up https://github.com/moby/buildkit/pull/6594

Buildx currently rewrites any `BUILDKIT_SYNTAX` value to `gateway.v0` and passes the syntax image through `source` and `cmdline`.

This change keeps `BUILDKIT_SYNTAX=dockerfile.v0` on the builtin Dockerfile frontend and only uses `gateway.v0` for non-builtin syntax values. This is to preserve the expected frontend identity on the Buildx side so the BuildKit changes in moby/buildkit#6594 can work as intended.