### PR TITLE
bake: accept "platforms" as alias for "platform" in `--set` overrides

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -588,6 +588,11 @@ func (c Config) newOverrides(v []string) (map[string]map[string]Override, error)
 			return nil, err
 		}
 
+		// Normalize plural alias so both "platform" and "platforms" are accepted.
+		if keys[1] == "platforms" {
+			keys[1] = "platform"
+		}
+
 		okey := strings.Join(keys[1:], ".")
 		for _, name := range names {
 			t, ok := m[name]

--- a/bake/bake_test.go
+++ b/bake/bake_test.go
@@ -201,6 +201,25 @@ target "webapp" {
 		require.Equal(t, []string{"linux/arm64", "linux/riscv64"}, m["webapp"].Platforms)
 	})
 
+	t.Run("PlatformsOverride", func(t *testing.T) {
+		m, _, err := ReadTargets(ctx, []File{fp}, []string{"webapp"}, []string{"webapp.platforms=linux/arm64"}, nil, nil, &EntitlementConf{})
+		require.NoError(t, err)
+		require.Equal(t, []string{"linux/arm64"}, m["webapp"].Platforms)
+	})
+
+	t.Run("PlatformsAppend", func(t *testing.T) {
+		m, _, err := ReadTargets(ctx, []File{fp}, []string{"webapp"}, []string{"webapp.platforms+=linux/arm64"}, nil, nil, &EntitlementConf{})
+		require.NoError(t, err)
+		require.Equal(t, []string{"linux/amd64", "linux/arm64"}, m["webapp"].Platforms)
+	})
+
+	t.Run("PlatformsMixedForms", func(t *testing.T) {
+		// Both singular and plural forms should map to the same field and accumulate identically.
+		m, _, err := ReadTargets(ctx, []File{fp}, []string{"webapp"}, []string{"webapp.platform=linux/arm64", "webapp.platforms=linux/riscv64"}, nil, nil, &EntitlementConf{})
+		require.NoError(t, err)
+		require.Equal(t, []string{"linux/arm64", "linux/riscv64"}, m["webapp"].Platforms)
+	})
+
 	t.Run("SecretsOverride", func(t *testing.T) {
 		t.Setenv("FOO", "foo")
 		t.Setenv("BAR", "bar")

--- a/docs/reference/buildx_bake.md
+++ b/docs/reference/buildx_bake.md
@@ -455,7 +455,7 @@ You can override the following fields:
 * `no-cache`
 * `no-cache-filter`
 * `output`
-* `platform`
+* `platform` (also accepted as `platforms`)
 * `pull`
 * `push`
 * `secrets`
@@ -472,7 +472,7 @@ You can append using `+=` operator for the following fields:
 * `entitlements`¹
 * `no-cache-filter`
 * `output`
-* `platform`
+* `platform` (also accepted as `platforms`)
 * `secrets`
 * `ssh`
 * `tags`


### PR DESCRIPTION
closes #2870 

Normalizes the plural form to match the HCL attribute name, so `--set 'target.platforms=...'` works alongside the existing singular form. This approach was selected to minimize disruption for users. Likely docs change as well. 