### PR TITLE
bake: sort extra-hosts before generating build options

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -1513,7 +1513,8 @@ func toBuildOpt(t *Target, inp *Input) (*build.Options, error) {
 	}
 
 	var extraHosts []string
-	for k, v := range t.ExtraHosts {
+	for _, k := range slices.Sorted(maps.Keys(t.ExtraHosts)) {
+		v := t.ExtraHosts[k]
 		if v == nil {
 			continue
 		}

--- a/bake/bake_test.go
+++ b/bake/bake_test.go
@@ -1812,6 +1812,28 @@ func TestAttestDuplicates(t *testing.T) {
 	}, opts["default"].Attests)
 }
 
+func TestExtraHostsDeterministicOrder(t *testing.T) {
+	expected := []string{
+		"alpha.example.com=1.1.1.1",
+		"beta.example.com=2.2.2.2",
+		"delta.example.com=4.4.4.4",
+		"gamma.example.com=3.3.3.3",
+	}
+	for range 64 {
+		bo, err := toBuildOpt(&Target{
+			DockerfileInline: ptrstr("FROM scratch"),
+			ExtraHosts: map[string]*string{
+				"gamma.example.com": ptrstr("3.3.3.3"),
+				"alpha.example.com": ptrstr("1.1.1.1"),
+				"delta.example.com": ptrstr("4.4.4.4"),
+				"beta.example.com":  ptrstr("2.2.2.2"),
+			},
+		}, &Input{})
+		require.NoError(t, err)
+		require.Equal(t, expected, bo.ExtraHosts)
+	}
+}
+
 func TestAnnotations(t *testing.T) {
 	fp := File{
 		Name: "docker-bake.hcl",


### PR DESCRIPTION
fixes #3788 

This change makes bake emit extra-hosts in a stable order before passing them into build options.