### PR TITLE
commands: stop dial-stdio when the builder connection closes

### DIFF
--- a/commands/dial_stdio.go
+++ b/commands/dial_stdio.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"io"
 	"net"
 	"os"
@@ -15,7 +16,6 @@ import (
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/sync/errgroup"
 )
 
 type stdioOptions struct {
@@ -79,27 +79,43 @@ func runDialStdio(dockerCli command.Cli, opts stdioOptions) error {
 			return err
 		}
 
-		defer conn.Close()
-
-		go func() {
-			<-ctx.Done()
-			closeWrite(conn)
-		}()
-
-		var eg errgroup.Group
-
-		eg.Go(func() error {
-			_, err := io.Copy(conn, os.Stdin)
-			closeWrite(conn)
-			return err
-		})
-		eg.Go(func() error {
-			_, err := io.Copy(os.Stdout, conn)
-			closeRead(conn)
-			return err
-		})
-		return eg.Wait()
+		return proxyConn(ctx, conn, os.Stdin, os.Stdout)
 	})
+}
+
+func proxyConn(ctx context.Context, conn net.Conn, stdin io.Reader, stdout io.Writer) error {
+	defer conn.Close()
+
+	stdinDone := make(chan error, 1)
+	stdoutDone := make(chan error, 1)
+
+	go func() {
+		_, err := io.Copy(conn, stdin)
+		closeWrite(conn)
+		stdinDone <- err
+	}()
+	go func() {
+		_, err := io.Copy(stdout, conn)
+		closeRead(conn)
+		stdoutDone <- err
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		case err := <-stdinDone:
+			if err != nil && !errors.Is(err, net.ErrClosed) && !errors.Is(err, io.ErrClosedPipe) {
+				return err
+			}
+			stdinDone = nil
+		case err := <-stdoutDone:
+			if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, net.ErrClosed) && !errors.Is(err, io.ErrClosedPipe) {
+				return err
+			}
+			return nil
+		}
+	}
 }
 
 func closeRead(conn net.Conn) error {

--- a/commands/dial_stdio.go
+++ b/commands/dial_stdio.go
@@ -1,9 +1,11 @@
 package commands
 
 import (
+	"context"
 	"io"
 	"net"
 	"os"
+	"sync"
 
 	"github.com/containerd/platforms"
 	"github.com/docker/buildx/build"
@@ -79,27 +81,66 @@ func runDialStdio(dockerCli command.Cli, opts stdioOptions) error {
 			return err
 		}
 
-		defer conn.Close()
-
-		go func() {
-			<-ctx.Done()
-			closeWrite(conn)
-		}()
-
-		var eg errgroup.Group
-
-		eg.Go(func() error {
-			_, err := io.Copy(conn, os.Stdin)
-			closeWrite(conn)
-			return err
-		})
-		eg.Go(func() error {
-			_, err := io.Copy(os.Stdout, conn)
-			closeRead(conn)
-			return err
-		})
-		return eg.Wait()
+		return proxyConn(ctx, conn, os.Stdin, os.Stdout)
 	})
+}
+
+var errStdinProxyCanceled = errors.New("stdin proxy canceled")
+
+func proxyConn(ctx context.Context, conn net.Conn, stdin io.Reader, stdout io.Writer) error {
+	defer conn.Close()
+
+	cancelableStdin := newCancelableReader(stdin)
+	defer cancelableStdin.cancel(errStdinProxyCanceled)
+
+	stopAfterFunc := context.AfterFunc(ctx, func() {
+		cancelableStdin.cancel(context.Cause(ctx))
+		closeWrite(conn)
+	})
+	defer stopAfterFunc()
+
+	var eg errgroup.Group
+	eg.Go(func() error {
+		_, err := io.Copy(conn, cancelableStdin)
+		closeWrite(conn)
+		if err != nil && !errors.Is(err, errStdinProxyCanceled) {
+			return err
+		}
+		return nil
+	})
+	eg.Go(func() error {
+		_, err := io.Copy(stdout, conn)
+		cancelableStdin.cancel(errStdinProxyCanceled)
+		closeRead(conn)
+		if err != nil && !errors.Is(err, io.EOF) {
+			return err
+		}
+		return nil
+	})
+	return eg.Wait()
+}
+
+type cancelableReader struct {
+	io.Reader
+	cancel func(error)
+}
+
+func newCancelableReader(r io.Reader) *cancelableReader {
+	pr, pw := io.Pipe()
+	var once sync.Once
+	closePipe := func(err error) {
+		once.Do(func() {
+			_ = pw.CloseWithError(err)
+		})
+	}
+	go func() {
+		_, err := io.Copy(pw, r)
+		closePipe(err)
+	}()
+	return &cancelableReader{
+		Reader: pr,
+		cancel: closePipe,
+	}
 }
 
 func closeRead(conn net.Conn) error {

--- a/commands/dial_stdio_test.go
+++ b/commands/dial_stdio_test.go
@@ -1,0 +1,56 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProxyConnRemoteClose(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer serverConn.Close()
+
+	stdin := &blockingReader{waitCh: make(chan struct{})}
+	defer stdin.Close()
+
+	var stdout bytes.Buffer
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- proxyConn(context.Background(), clientConn, stdin, &stdout)
+	}()
+
+	go func() {
+		_, _ = serverConn.Write([]byte("hello"))
+		_ = serverConn.Close()
+	}()
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+		require.Equal(t, "hello", stdout.String())
+	case <-time.After(2 * time.Second):
+		t.Fatal("proxyConn did not return after the remote side closed")
+	}
+}
+
+type blockingReader struct {
+	waitCh    chan struct{}
+	closeOnce sync.Once
+}
+
+func (r *blockingReader) Read([]byte) (int, error) {
+	<-r.waitCh
+	return 0, io.EOF
+}
+
+func (r *blockingReader) Close() {
+	r.closeOnce.Do(func() {
+		close(r.waitCh)
+	})
+}


### PR DESCRIPTION
fixes https://github.com/docker/buildx/issues/3668

Fixes a `dial-stdio` hang that could persist after the builder connection closed. The command now exits when the read side finishes instead of waiting for a new write on stdin to unblock the process.

The old code used two `io.Copy` calls and waited for both to finish, which meant a blocked read from stdin could keep the command alive even after the builder connection had already died. This showed up when the Docker daemon restarted and `dial-stdio` stayed hung until the user pressed Enter.

Tried to add an integration test for this but that's tricky. We would need some wiring with explicit restart/kill hook into the worker to test this regression. So needs changes in BuildKit test framework imo.

cc @invidian @cpuguy83 