### PR TITLE
ci: scope labeler concurrency to the pull request

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,7 +4,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 on:


### PR DESCRIPTION
relates to https://github.com/docker/buildx/actions/runs/24363197956?pr=3796

```
labeler
Canceling since a higher priority waiting request for labeler-refs/heads/master exists
```

The workflow now uses `github.event.pull_request.number` for the labeler concurrency group instead of `github.ref`. That keeps cancellation behavior for duplicate runs on the same pull request without serializing unrelated pull requests against `refs/heads/master`.