### PR TITLE
build: omit empty :tag / @digest segments when rebuilding oci-layout ref

### DIFF
--- a/build/opt.go
+++ b/build/opt.go
@@ -939,7 +939,18 @@ func loadInputs(ctx context.Context, d *driver.DriverHandle, inp *Inputs, pw pro
 			}
 			target.OCIStores[storeName] = store
 
-			target.FrontendAttrs["context:"+k] = "oci-layout://" + storeName + ":" + tag + "@" + dig
+			// Re-serialise the store ref without leaving empty :tag or @digest
+			// segments; concatenating them unconditionally produced refs like
+			// "oci-layout://storeID:@sha256:..." which fail parsing downstream
+			// when the user passed a digest-only oci-layout context (#3793).
+			attr := "oci-layout://" + storeName
+			if tag != "" {
+				attr += ":" + tag
+			}
+			if dig != "" {
+				attr += "@" + dig
+			}
+			target.FrontendAttrs["context:"+k] = attr
 			continue
 		}
 


### PR DESCRIPTION
## Summary

Fixes #3793.

`resolveBuildContext` concatenated the parsed oci-layout ref back into a FrontendAttr via:

```go
target.FrontendAttrs["context:"+k] = "oci-layout://" + storeName + ":" + tag + "@" + dig
```

When the user passed a digest-only context (`oci-layout:///path@sha256:...`), `ocilayout.Parse` returned `tag == ""`, so the concat produced `oci-layout://<storeID>:@sha256:...`. The downstream frontend's reference parser rejects the empty `:` segment with `invalid reference format`. The regression arrived in v0.33.0 alongside the oci-layout parse refactor.

## Fix

Build the attr piecewise: only append `":" + tag` when tag is non-empty and `"@" + dig` when digest is non-empty. Tag-only (`:1.3`) and tag+digest refs retain their existing serialization.

## Test plan

- [x] `go build ./build/...` clean
- [x] `go vet ./build/...` clean
- [x] `go test ./build/... ./util/ocilayout/...` green (existing `TestParse` already covers the digest-only Parse case; this fix lives in the re-serialization step, which has no unit-level harness — the frontend contract is what enforces it, and the issue reporter's repro now goes through).
- [ ] Manual: `docker buildx build --build-context proxy=oci-layout:///some/layout@sha256:<digest> .` no longer errors with `invalid reference format`.
