### PR TITLE
rm: reject context builders before loading nodes

### DIFF
--- a/commands/rm.go
+++ b/commands/rm.go
@@ -74,13 +74,13 @@ func runRm(ctx context.Context, dockerCli command.Cli, in rmOptions) error {
 					return err
 				}
 
+				if b.DockerContext {
+					return errors.Errorf("context builder cannot be removed, run `docker context rm %s` to remove this context", b.Name)
+				}
+
 				nodes, err := b.LoadNodes(timeoutCtx)
 				if err != nil {
 					return err
-				}
-
-				if cb := b.ContextName(); cb != "" {
-					return errors.Errorf("context builder cannot be removed, run `docker context rm %s` to remove this context", cb)
 				}
 
 				err1 := rm(ctx, nodes, in)


### PR DESCRIPTION
Current ordering is wrong for offline sockets. It forced driver detection and a daemon ping before rejecting a context-backed builder, which changed the user-facing error from the expected context removal guidance to an unrelated connection error:

```
$ docker buildx rm dev-mode
failed to remove dev-mode: failed to connect to the docker API at unix:///Users/foo/bar/dev/.docker/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /Users/foo/bar/dev/.docker/run/docker.sock: connect: no such file or directory
ERROR: failed to remove one or more builders
```

The removal path now checks whether the selected builder came from a Docker context immediately after builder lookup and returns the existing `docker context rm` guidance without calling `LoadNodes`.

cc @fiam 