### PR TITLE
ocilayout: narrow Windows drive path detection

### DIFF
--- a/util/ocilayout/parse.go
+++ b/util/ocilayout/parse.go
@@ -1,6 +1,7 @@
 package ocilayout
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/distribution/reference"
@@ -59,10 +60,8 @@ func (r Ref) String() string {
 	return s
 }
 
+var windowsDrivePath = regexp.MustCompile(`^[A-Za-z]:[\\/]`)
+
 func isWindowsDrivePath(path string, colon int) bool {
-	if colon != 1 || len(path) < 2 {
-		return false
-	}
-	c := path[0]
-	return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z')
+	return colon == 1 && windowsDrivePath.MatchString(path)
 }

--- a/util/ocilayout/parse_test.go
+++ b/util/ocilayout/parse_test.go
@@ -41,8 +41,18 @@ func TestParse(t *testing.T) {
 			tag:  "latest",
 		},
 		{
+			s:    "oci-layout://a:1.3",
+			path: "a",
+			tag:  "1.3",
+		},
+		{
 			s:    `oci-layout://C:\path\to\oci\layout`,
 			path: `C:\path\to\oci\layout`,
+			tag:  "latest",
+		},
+		{
+			s:    `oci-layout://C:/path/to/oci/layout`,
+			path: `C:/path/to/oci/layout`,
 			tag:  "latest",
 		},
 		{


### PR DESCRIPTION
follow-up https://github.com/docker/buildx/pull/3812#discussion_r3139847353

The previous check treated any single letter followed by a colon as a Windows drive prefix, which made `oci-layout://a:1.3` parse incorrectly.

This change tightens Windows drive path detection in OCI layout reference parsing so one-character relative paths with tags are not mistaken for Windows absolute paths.