### PR TITLE
build: bounds-check MountIDs/InputIDs in containerConfigFromError

### DIFF
--- a/build/result.go
+++ b/build/result.go
@@ -222,9 +222,13 @@ func containerConfigFromError(solveErr *errdefs.SolveError, cfg *InvokeConfig) (
 	}
 	var mounts []gateway.Mount
 	for i, mnt := range exec.Mounts {
-		rid := solveErr.MountIDs[i]
+		var rid string
 		if cfg.Initial {
-			rid = solveErr.InputIDs[i]
+			if i < len(solveErr.InputIDs) {
+				rid = solveErr.InputIDs[i]
+			}
+		} else if i < len(solveErr.MountIDs) {
+			rid = solveErr.MountIDs[i]
 		}
 		mounts = append(mounts, gateway.Mount{
 			Selector:  mnt.Selector,


### PR DESCRIPTION
Closes #3822. `SolveError` carries fewer Mount/Input IDs than `ExecOp.Mounts` for some failures; the bare `solveErr.MountIDs[i]` panics `buildx debug` build.