### PR TITLE
util/ocilayout: replace regex for matching windows drive-letters

### DIFF
--- a/util/ocilayout/parse.go
+++ b/util/ocilayout/parse.go
@@ -1,7 +1,6 @@
 package ocilayout
 
 import (
-	"regexp"
 	"strings"
 
 	"github.com/distribution/reference"
@@ -60,8 +59,13 @@ func (r Ref) String() string {
 	return s
 }
 
-var windowsDrivePath = regexp.MustCompile(`^[A-Za-z]:[\\/]`)
-
 func isWindowsDrivePath(path string, colon int) bool {
-	return colon == 1 && windowsDrivePath.MatchString(path)
+	if colon != 1 || len(path) < 3 {
+		return false
+	}
+	if path[2] != '/' && path[2] != '\\' {
+		return false
+	}
+	c := path[0]
+	return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z')
 }

--- a/util/ocilayout/parse_test.go
+++ b/util/ocilayout/parse_test.go
@@ -72,12 +72,14 @@ func TestParse(t *testing.T) {
 			dgst: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		},
 	} {
-		ref, ok, err := Parse(tt.s)
-		require.True(t, ok)
-		require.NoError(t, err)
-		assert.Equal(t, tt.path, ref.Path, "comparing path: %s", tt.s)
-		assert.Equal(t, tt.dgst, ref.Digest.String(), "comparing digest: %s", tt.s)
-		assert.Equal(t, tt.tag, ref.Tag, "comparing tag: %s", tt.s)
+		t.Run(tt.s, func(t *testing.T) {
+			ref, ok, err := Parse(tt.s)
+			require.True(t, ok)
+			require.NoError(t, err)
+			assert.Equal(t, tt.path, ref.Path, "comparing path: %s", tt.s)
+			assert.Equal(t, tt.dgst, ref.Digest.String(), "comparing digest: %s", tt.s)
+			assert.Equal(t, tt.tag, ref.Tag, "comparing tag: %s", tt.s)
+		})
 	}
 }
 


### PR DESCRIPTION
- follow-up https://github.com/docker/buildx/pull/3820

follow-up to bf34a4cbed33d90faae9add5f74170cd13d172cd, which changed the isWindowsDrivePath function to use a regex for matching the trailing slash.

This reverts it back to te previous implementation to avoid a regex, but adds a check for the colon to be followed by a forward-slash, which is faster, and avoids the overhead of `regex.MustCompile` during init.

    BenchmarkRegex-11    39056917      32.45 ns/op     0 B/op    0 allocs/op
    BenchmarkManual-11   1000000000     0.2476 ns/op   0 B/op    0 allocs/op