### PR TITLE
Update Windows CLI plugins path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ On Unix environments:
 
 On Windows:
 
-* `C:\ProgramData\Docker\cli-plugins`
 * `C:\Program Files\Docker\cli-plugins`
+* `C:\ProgramData\Docker\cli-plugins` (for docker 28.x and earlier only)
 
 > [!NOTE]
 > On Unix environments, it may also be necessary to make it executable with `chmod +x`:


### PR DESCRIPTION
Clarify the location for Docker CLI plugins on Windows as `C:\ProgramData` isn't checked anymore since docker v29.

Refs:
- https://docs.docker.com/engine/release-notes/29/#deprecations-1
- https://github.com/docker/cli/pull/6713