### PR TITLE
warn on duplicate cache-to targets

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -32,6 +32,7 @@ import (
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/frontend/dockerfile/dfgitutil"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/convert"
 )
@@ -1300,7 +1301,52 @@ func (t *Target) GetName(ectx *hcl.EvalContext, block *hcl.Block, loadDeps func(
 	return value.AsString(), nil
 }
 
+func cachePrimaryKey(e *buildflags.CacheOptionsEntry) string {
+	switch e.Type {
+	case "registry":
+		return "type=registry,ref=" + e.Attrs["ref"]
+	case "local":
+		return "type=local,dest=" + e.Attrs["dest"]
+	case "gha":
+		return "type=gha,scope=" + e.Attrs["scope"]
+	case "s3":
+		return "type=s3,bucket=" + e.Attrs["bucket"] + ",name=" + e.Attrs["name"]
+	case "azblob":
+		return "type=azblob,name=" + e.Attrs["name"]
+	case "inline":
+		return ""
+	default:
+		return "type=" + e.Type
+	}
+}
+
+func warnDuplicateCacheExports(m map[string]*Target) {
+	seen := map[string][]string{}
+	for _, name := range slices.Sorted(maps.Keys(m)) {
+		t := m[name]
+		seenForTarget := map[string]struct{}{}
+		for _, entry := range t.CacheTo {
+			key := cachePrimaryKey(entry)
+			if key == "" {
+				continue
+			}
+			if _, ok := seenForTarget[key]; ok {
+				continue
+			}
+			seenForTarget[key] = struct{}{}
+			seen[key] = append(seen[key], name)
+		}
+	}
+	for _, key := range slices.Sorted(maps.Keys(seen)) {
+		names := seen[key]
+		if len(names) > 1 {
+			logrus.Warnf("multiple targets write to the same cache export %q: %s", key, strings.Join(names, ", "))
+		}
+	}
+}
+
 func TargetsToBuildOpt(m map[string]*Target, inp *Input) (map[string]build.Options, error) {
+	warnDuplicateCacheExports(m)
 	m2 := make(map[string]build.Options, len(m))
 	for k, v := range m {
 		bo, err := toBuildOpt(v, inp)

--- a/bake/bake_test.go
+++ b/bake/bake_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/docker/buildx/util/buildflags"
 	"github.com/moby/buildkit/util/entitlements"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -2616,4 +2617,117 @@ func stringify[V fmt.Stringer](values []V) []string {
 	}
 	sort.Strings(s)
 	return s
+}
+
+func TestWarnDuplicateCacheExports(t *testing.T) {
+	var buf strings.Builder
+	logrus.SetOutput(&buf)
+	logrus.SetLevel(logrus.WarnLevel)
+	t.Cleanup(func() { logrus.SetOutput(os.Stderr) })
+
+	t.Run("duplicate cache-to", func(t *testing.T) {
+		buf.Reset()
+		m := map[string]*Target{
+			"app": {
+				CacheTo: buildflags.CacheOptions{
+					{Type: "registry", Attrs: map[string]string{"ref": "registry.example.com/cache/shared"}},
+				},
+			},
+			"worker": {
+				CacheTo: buildflags.CacheOptions{
+					{Type: "registry", Attrs: map[string]string{"ref": "registry.example.com/cache/shared"}},
+				},
+			},
+		}
+		warnDuplicateCacheExports(m)
+		require.Contains(t, buf.String(), "registry.example.com/cache/shared")
+	})
+
+	t.Run("same destination different mode", func(t *testing.T) {
+		buf.Reset()
+		m := map[string]*Target{
+			"app": {
+				CacheTo: buildflags.CacheOptions{
+					{Type: "registry", Attrs: map[string]string{"ref": "registry.example.com/cache/shared", "mode": "min"}},
+				},
+			},
+			"worker": {
+				CacheTo: buildflags.CacheOptions{
+					{Type: "registry", Attrs: map[string]string{"ref": "registry.example.com/cache/shared", "mode": "max"}},
+				},
+			},
+		}
+		warnDuplicateCacheExports(m)
+		require.Contains(t, buf.String(), "registry.example.com/cache/shared")
+	})
+
+	t.Run("no duplicate", func(t *testing.T) {
+		buf.Reset()
+		m := map[string]*Target{
+			"app": {
+				CacheTo: buildflags.CacheOptions{
+					{Type: "registry", Attrs: map[string]string{"ref": "registry.example.com/cache/app"}},
+				},
+			},
+			"worker": {
+				CacheTo: buildflags.CacheOptions{
+					{Type: "registry", Attrs: map[string]string{"ref": "registry.example.com/cache/worker"}},
+				},
+			},
+		}
+		warnDuplicateCacheExports(m)
+		require.Empty(t, buf.String())
+	})
+
+	t.Run("inline not flagged", func(t *testing.T) {
+		buf.Reset()
+		m := map[string]*Target{
+			"app":    {CacheTo: buildflags.CacheOptions{{Type: "inline", Attrs: map[string]string{}}}},
+			"worker": {CacheTo: buildflags.CacheOptions{{Type: "inline", Attrs: map[string]string{}}}},
+		}
+		warnDuplicateCacheExports(m)
+		require.Empty(t, buf.String())
+	})
+
+	t.Run("within-target entries not double-counted", func(t *testing.T) {
+		buf.Reset()
+		m := map[string]*Target{
+			"app": {
+				CacheTo: buildflags.CacheOptions{
+					{Type: "registry", Attrs: map[string]string{"ref": "registry.example.com/cache/shared", "mode": "min"}},
+					{Type: "registry", Attrs: map[string]string{"ref": "registry.example.com/cache/shared", "mode": "max"}},
+				},
+			},
+		}
+		warnDuplicateCacheExports(m)
+		require.Empty(t, buf.String())
+	})
+}
+
+func TestWarnDuplicateCacheExportsInheritance(t *testing.T) {
+	fp := File{
+		Name: "docker-bake.hcl",
+		Data: []byte(`
+			target "base" {
+				cache-to = ["type=registry,ref=registry.example.com/cache/shared,mode=max"]
+			}
+			target "app" {
+				inherits = ["base"]
+			}
+			target "worker" {
+				inherits = ["base"]
+			}
+		`),
+	}
+
+	var buf strings.Builder
+	logrus.SetOutput(&buf)
+	logrus.SetLevel(logrus.WarnLevel)
+	t.Cleanup(func() { logrus.SetOutput(os.Stderr) })
+
+	m, _, err := ReadTargets(context.TODO(), []File{fp}, []string{"app", "worker"}, nil, nil, nil, &EntitlementConf{})
+	require.NoError(t, err)
+	_, err = TargetsToBuildOpt(m, &Input{})
+	require.NoError(t, err)
+	require.Contains(t, buf.String(), "registry.example.com/cache/shared")
 }


### PR DESCRIPTION
## summary

closes #3819

* adds a warning when multiple build targets try to use the same cache destination

## ai model disclosure

used vscode copilot (claude sonnet 4.6) to understand the issue context and help generate a fix. changes were self-reviewed and verified via:

```bash
make validate-all
go build ./...
```