### PR TITLE
commands: remove redundant stdinDone reset in dial-stdio

### DIFF
--- a/commands/dial_stdio.go
+++ b/commands/dial_stdio.go
@@ -108,7 +108,6 @@ func proxyConn(ctx context.Context, conn net.Conn, stdin io.Reader, stdout io.Wr
 			if err != nil && !errors.Is(err, net.ErrClosed) && !errors.Is(err, io.ErrClosedPipe) {
 				return err
 			}
-			stdinDone = nil
 		case err := <-stdoutDone:
 			if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, net.ErrClosed) && !errors.Is(err, io.ErrClosedPipe) {
 				return err


### PR DESCRIPTION
follow-up https://github.com/docker/buildx/pull/3790#discussion_r3196562703