### PR TITLE
bake: preserve empty compose cache lists

### DIFF
--- a/bake/compose.go
+++ b/bake/compose.go
@@ -266,6 +266,10 @@ func loadComposeFiles(cfgs []composetypes.ConfigFile, envs map[string]string, op
 		return nil, errors.New("empty compose file")
 	}
 
+	// compose-go schema validation does a JSON round trip that converts nil slices
+	// from YAML [] values into null, so keep empty lists as arrays before validation.
+	// buildx#3849
+	normalizeEmptyLists(filtered)
 	if err := composeschema.Validate(filtered); err != nil {
 		return nil, err
 	}
@@ -277,6 +281,23 @@ func loadComposeFiles(cfgs []composetypes.ConfigFile, envs map[string]string, op
 		ConfigFiles: cfgs,
 		Environment: envs,
 	})
+}
+
+func normalizeEmptyLists(value any) any {
+	switch v := value.(type) {
+	case []any:
+		if v == nil {
+			return []any{}
+		}
+		for i, e := range v {
+			v[i] = normalizeEmptyLists(e)
+		}
+	case map[string]any:
+		for k, e := range v {
+			v[k] = normalizeEmptyLists(e)
+		}
+	}
+	return value
 }
 
 func validateComposeFile(dt []byte, fn string, envOverrides map[string]string) (bool, error) {

--- a/bake/compose_test.go
+++ b/bake/compose_test.go
@@ -93,6 +93,23 @@ secrets:
 	require.Equal(t, "FROM alpine\n", *c.Targets[2].DockerfileInline)
 }
 
+func TestParseComposeEmptyCacheLists(t *testing.T) {
+	dt := []byte(`
+services:
+  webapp:
+    build:
+      context: ./dir
+      cache_from: []
+      cache_to: []
+`)
+
+	c, err := ParseCompose([]composetypes.ConfigFile{{Content: dt}}, nil)
+	require.NoError(t, err)
+	require.Len(t, c.Targets, 1)
+	require.Empty(t, c.Targets[0].CacheFrom)
+	require.Empty(t, c.Targets[0].CacheTo)
+}
+
 func TestNoBuildOutOfTreeService(t *testing.T) {
 	dt := []byte(`
 services:


### PR DESCRIPTION
ref https://github.com/docker/buildx/issues/3849

Workaround for regression in compose-go.

Normalize filtered Compose models before schema validation so empty YAML lists remain arrays through compose-go's JSON validation round trip.