### PR TITLE
hack: scope docs validation and show diff on failure

### DIFF
--- a/hack/dockerfiles/docs.Dockerfile
+++ b/hack/dockerfiles/docs.Dockerfile
@@ -21,7 +21,7 @@ RUN --mount=target=/context \
   --mount=target=.,type=tmpfs <<EOT
 set -e
 rsync -a /context/. .
-docsgen --formats "$FORMATS" --source "docs/reference" --bake-stdlib-source "docs/bake-stdlib.md"
+docsgen --formats "$FORMATS" --source "docs/reference/" --bake-stdlib-source "docs/bake-stdlib.md"
 mkdir /out
 cp -r docs/reference docs/bake-stdlib.md /out
 rm -f /out/reference/*__INTERNAL_SERVE.yaml /out/reference/*__INTERNAL_SERVE.md
@@ -35,12 +35,25 @@ RUN --mount=target=/context \
   --mount=target=.,type=tmpfs <<EOT
 set -e
 rsync -a /context/. .
-git add -A
-rm -rf docs/reference/* docs/bake-stdlib.md
-cp -rf /out/* ./docs/
+
+# Replace the checked-in docs with freshly generated output, then verify that
+# the working tree still matches HEAD under these paths. This enforces the
+# same contract as `make docs`: after regenerating, the repo must be clean.
+rsync -a --delete /out/reference/ docs/reference/
+cp /out/bake-stdlib.md docs/bake-stdlib.md
+
+# Intent-to-add so untracked files (e.g. a new command's docs) appear in the
+# diff below; `git diff` skips untracked files by default.
+git add -N -- docs/reference docs/bake-stdlib.md
+
 if [ -n "$(git status --porcelain -- docs/reference docs/bake-stdlib.md)" ]; then
-  echo >&2 'ERROR: Docs result differs. Please update with "make docs"'
+  echo >&2 'ERROR: Docs are out of date. Run "make docs" and commit the result.'
+  echo >&2
+  echo >&2 '--- changed paths ---'
   git status --porcelain -- docs/reference docs/bake-stdlib.md
+  echo >&2
+  echo >&2 '--- diff (truncated to 200 lines) ---'
+  git diff -- docs/reference docs/bake-stdlib.md | head -n 200
   exit 1
 fi
 EOT


### PR DESCRIPTION
## Summary

Tighten the validate stage of `hack/dockerfiles/docs.Dockerfile`:

- Drop the unscoped `git add -A`; the validation is a working-tree-vs-HEAD check, which `git status --porcelain` answers directly without mutating the index.
- Path-scope both detection (`git status --porcelain`) and diagnostics (`git diff`) to `docs/reference` and `docs/bake-stdlib.md`, so unrelated working-tree state cannot false-positive.
- Mirror the freshly generated docs with `rsync -a --delete` so any stale files are also reset (no separate `rm -rf` needed).
- On failure, print changed paths and a (truncated) diff alongside the existing error message, giving contributors an actionable signal instead of just filenames.
- `git add -N` before diffing so untracked files (e.g. a new command's docs) appear in the diff instead of only in the path list.

## Approach

Detection and diagnostics are both path-scoped: `git status --porcelain` for the binary check, `git diff` for the failure output. `rsync --delete` handles the wholesale replacement, and `git add -N` ensures the diff shows content for newly added files.

## Test plan

- [x] `make docs && make validate-docs` succeeds when docs are in sync
- [x] Modify a file under `docs/reference/`, re-run `make validate-docs`, confirm validate fails with the new changed-paths + diff output
- [x] Add a new file under `docs/reference/`, re-run `make validate-docs`, confirm the new file's content is shown in the diff
- [x] Dirty a file outside the scoped paths, confirm `make validate-docs` still passes (no false positive)

## AI disclosure

Prepared with AI assistance (Claude Code).