### PR TITLE
ci: upload test results to codecov

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,14 +148,24 @@ jobs:
           TEST_REPORT_SUFFIX: "-${{ env.TESTREPORTS_NAME }}"
           TESTPKGS: "${{ matrix.pkg }}"
       -
-        name: Send to Codecov
+        name: Upload coverage to Codecov
         if: always()
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           directory: ./bin/testreports
           flags: integration
           token: ${{ secrets.CODECOV_TOKEN }}
-          disable_file_fixes: true
+          disable_file_fixes: true # needed for Go language https://docs.codecov.com/docs/fixing-reports
+      -
+        name: Upload test results to Codecov
+        if: always()
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        with:
+          report_type: test_results
+          directory: ./bin/testreports
+          flags: integration
+          token: ${{ secrets.CODECOV_TOKEN }}
+          disable_file_fixes: true # needed for Go language https://docs.codecov.com/docs/fixing-reports
       -
         name: Generate annotations
         if: always()
@@ -225,7 +235,7 @@ jobs:
               "-covermode" "atomic" ${{ env.TESTFLAGS }}
         shell: bash
       -
-        name: Send to Codecov
+        name: Upload coverage to Codecov
         if: always()
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
@@ -233,7 +243,18 @@ jobs:
           env_vars: RUNNER_OS
           flags: unit
           token: ${{ secrets.CODECOV_TOKEN }}
-          disable_file_fixes: true
+          disable_file_fixes: true # needed for Go language https://docs.codecov.com/docs/fixing-reports
+      -
+        name: Upload test results to Codecov
+        if: always()
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        with:
+          report_type: test_results
+          directory: ${{ env.TESTREPORTS_DIR }}
+          env_vars: RUNNER_OS
+          flags: unit
+          token: ${{ secrets.CODECOV_TOKEN }}
+          disable_file_fixes: true # needed for Go language https://docs.codecov.com/docs/fixing-reports
       -
         name: Generate annotations
         if: always()


### PR DESCRIPTION
This updates the build workflow so Codecov receives test results in addition to coverage reports for both integration and unit test jobs.

Uploading test results alongside coverage gives Codecov the data it needs to show test reporting without changing how coverage is collected or annotated in the existing CI flow.

> Test Analytics offers data on test run times, failure rates, and identifies flaky tests to help decrease the risk of deployment failures and make it easier to ship new features quickly.