### PR TITLE
build: improve resource limits output and docs

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -610,9 +610,7 @@ func (c Config) newOverrides(v []string) (map[string]map[string]Override, error)
 				if len(keys) != 3 {
 					return nil, errors.Errorf("invalid key %s, resources requires name", parts[0])
 				}
-				if len(parts) == 2 {
-					override.Value = parts[1]
-				}
+				override.Value = parts[1]
 			case "args":
 				if len(keys) != 3 {
 					return nil, errors.Errorf("invalid key %s, args requires name", parts[0])

--- a/commands/history/inspect.go
+++ b/commands/history/inspect.go
@@ -585,10 +585,10 @@ workers0:
 		fmt.Fprintf(tw, "Resource Limits:\t%s\n", out.Config.Ulimit)
 	}
 	if out.Config.Memory != "" {
-		fmt.Fprintf(tw, "Memory:\t%s\n", out.Config.Memory)
+		fmt.Fprintf(tw, "Memory:\t%s\n", humanizeBytes(out.Config.Memory))
 	}
 	if out.Config.MemorySwap != "" {
-		fmt.Fprintf(tw, "Memory Swap:\t%s\n", out.Config.MemorySwap)
+		fmt.Fprintf(tw, "Memory Swap:\t%s\n", humanizeBytes(out.Config.MemorySwap))
 	}
 	if out.Config.CPUShares != "" {
 		fmt.Fprintf(tw, "CPU Shares:\t%s\n", out.Config.CPUShares)

--- a/commands/history/utils.go
+++ b/commands/history/utils.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/docker/buildx/builder"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/go-units"
 	controlapi "github.com/moby/buildkit/api/services/control"
 	"github.com/moby/buildkit/frontend/dockerfile/dfgitutil"
 	"github.com/pkg/errors"
@@ -190,6 +191,17 @@ func formatDuration(d time.Duration) string {
 		return fmt.Sprintf("%.1fs", d.Seconds())
 	}
 	return fmt.Sprintf("%dm %2ds", int(d.Minutes()), int(d.Seconds())%60)
+}
+
+// humanizeBytes formats a raw byte-count string (as stored in the frontend
+// attributes) into a human-readable size. Non-numeric values such as "-1"
+// (unlimited swap) are returned unchanged.
+func humanizeBytes(v string) string {
+	n, err := strconv.ParseInt(v, 10, 64)
+	if err != nil || n < 0 {
+		return v
+	}
+	return units.BytesSize(float64(n))
 }
 
 type matchFunc func(*controlapi.BuildHistoryRecord) bool

--- a/docs/reference/buildx_bake.md
+++ b/docs/reference/buildx_bake.md
@@ -432,6 +432,7 @@ $ docker buildx bake --set *.platform=linux/arm64       # overrides platform for
 $ docker buildx bake --set foo*.no-cache                # bypass caching only for targets starting with 'foo'
 $ docker buildx bake --set target.platform+=linux/arm64 # appends 'linux/arm64' to the platform list
 $ docker buildx bake --set target.contexts.bar=../bar   # overrides 'bar' named context
+$ docker buildx bake --set target.resources.memory=2g   # overrides memory resource limit
 ```
 
 > [!NOTE]
@@ -462,6 +463,7 @@ You can override the following fields:
 * `platform`
 * `pull`
 * `push`
+* `resources`
 * `secrets`
 * `ssh`
 * `tags`


### PR DESCRIPTION
This PR is a follow-up of #3876, I fixed the things mentioned in the last review that weren't addressed before merging:
- Removed redundant if
- Added to docs
- Added a logic for human-readable print of memory