### PR TITLE
bake: add targets.current support

### DIFF
--- a/bake/bake.go
+++ b/bake/bake.go
@@ -41,6 +41,8 @@ var (
 	targetNamePattern    = regexp.MustCompile(`^` + validTargetNameChars + `$`)
 )
 
+const targetsCurrentPlaceholder = "\x00buildx.targets.current\x00"
+
 type File struct {
 	Name string
 	Data []byte
@@ -683,7 +685,7 @@ func (c Config) group(name string, visited map[string]visit) ([]string, []string
 }
 
 func (c Config) ResolveTarget(name string, overrides map[string]map[string]Override, ent *EntitlementConf) (*Target, error) {
-	t, err := c.target(name, map[string]*Target{}, overrides, ent)
+	t, err := c.target(name, map[string]*Target{}, overrides, ent, name)
 	if err != nil {
 		return nil, err
 	}
@@ -699,7 +701,7 @@ func (c Config) ResolveTarget(name string, overrides map[string]map[string]Overr
 	return t, nil
 }
 
-func (c Config) target(name string, visited map[string]*Target, overrides map[string]map[string]Override, ent *EntitlementConf) (*Target, error) {
+func (c Config) target(name string, visited map[string]*Target, overrides map[string]map[string]Override, ent *EntitlementConf, currentName string) (*Target, error) {
 	if t, ok := visited[name]; ok {
 		return t, nil
 	}
@@ -715,8 +717,9 @@ func (c Config) target(name string, visited map[string]*Target, overrides map[st
 		return nil, errors.Errorf("failed to find target %s", name)
 	}
 	tt := &Target{}
+	var err error
 	for _, name := range t.Inherits {
-		t, err := c.target(name, visited, overrides, ent)
+		t, err := c.target(name, visited, overrides, ent, currentName)
 		if err != nil {
 			return nil, err
 		}
@@ -729,6 +732,10 @@ func (c Config) target(name string, visited map[string]*Target, overrides map[st
 	m.Merge(t)
 	tt = m
 	if err := tt.AddOverrides(overrides[name], ent); err != nil {
+		return nil, err
+	}
+	tt, err = resolveTargetsCurrent(tt, currentName)
+	if err != nil {
 		return nil, err
 	}
 	tt.normalize()
@@ -1215,7 +1222,7 @@ func (t *Target) GetEvalContexts(ectx *hcl.EvalContext, block *hcl.Block, loadDe
 
 	attr, ok := content.Attributes["matrix"]
 	if !ok {
-		return []*hcl.EvalContext{ectx}, nil
+		return []*hcl.EvalContext{targetEvalContext(ectx)}, nil
 	}
 	if diags := loadDeps(attr.Expr); diags.HasErrors() {
 		return nil, diags
@@ -1230,7 +1237,7 @@ func (t *Target) GetEvalContexts(ectx *hcl.EvalContext, block *hcl.Block, loadDe
 	}
 	matrix := value.AsValueMap()
 
-	ectxs := []*hcl.EvalContext{ectx}
+	ectxs := []*hcl.EvalContext{targetEvalContext(ectx)}
 	for k, expr := range matrix {
 		if !expr.CanIterateElements() {
 			return nil, errors.Errorf("matrix values must be a list")
@@ -1251,6 +1258,35 @@ func (t *Target) GetEvalContexts(ectx *hcl.EvalContext, block *hcl.Block, loadDe
 		ectxs = ectxs2
 	}
 	return ectxs, nil
+}
+
+func resolveTargetsCurrent(t *Target, name string) (*Target, error) {
+	type targetClone Target
+	dt, err := json.Marshal((*targetClone)(t))
+	if err != nil {
+		return nil, err
+	}
+	encodedPlaceholder, err := json.Marshal(targetsCurrentPlaceholder)
+	if err != nil {
+		return nil, err
+	}
+	dt = []byte(strings.ReplaceAll(string(dt), strings.Trim(string(encodedPlaceholder), `"`), name))
+
+	var tt targetClone
+	if err := json.Unmarshal(dt, &tt); err != nil {
+		return nil, err
+	}
+	return (*Target)(&tt), nil
+}
+
+func targetEvalContext(parent *hcl.EvalContext) *hcl.EvalContext {
+	ectx := parent.NewChild()
+	ectx.Variables = map[string]cty.Value{
+		"targets": cty.ObjectVal(map[string]cty.Value{
+			"current": cty.StringVal(targetsCurrentPlaceholder),
+		}),
+	}
+	return ectx
 }
 
 func (g *Group) GetName(ectx *hcl.EvalContext, block *hcl.Block, loadDeps func(hcl.Expression) hcl.Diagnostics) (string, error) {

--- a/bake/bake_test.go
+++ b/bake/bake_test.go
@@ -1557,6 +1557,81 @@ func TestTargetName(t *testing.T) {
 	}
 }
 
+func TestTargetsCurrentDirectTarget(t *testing.T) {
+	ctx := context.TODO()
+	f := File{
+		Name: "docker-bake.hcl",
+		Data: []byte(`
+target "app" {
+  args = {
+    TARGET = targets.current
+  }
+  tags = ["example/${targets.current}:latest"]
+}
+`),
+	}
+
+	m, _, err := ReadTargets(ctx, []File{f}, []string{"app"}, nil, nil, nil, &EntitlementConf{})
+	require.NoError(t, err)
+	require.Equal(t, "app", *m["app"].Args["TARGET"])
+	require.Equal(t, []string{"example/app:latest"}, m["app"].Tags)
+}
+
+func TestTargetsCurrentInheritedTarget(t *testing.T) {
+	ctx := context.TODO()
+	f := File{
+		Name: "docker-bake.hcl",
+		Data: []byte(`
+target "_common" {
+  args = {
+    TARGET = targets.current
+  }
+  tags = ["example/${targets.current}:latest"]
+  cache-from = ["type=registry,ref=cache/${targets.current}"]
+}
+
+target "image1" {
+  inherits = ["_common"]
+}
+
+target "image2" {
+  inherits = ["_common"]
+}
+`),
+	}
+
+	m, _, err := ReadTargets(ctx, []File{f}, []string{"image1", "image2"}, nil, nil, nil, &EntitlementConf{})
+	require.NoError(t, err)
+	require.Equal(t, "image1", *m["image1"].Args["TARGET"])
+	require.Equal(t, []string{"example/image1:latest"}, m["image1"].Tags)
+	require.Equal(t, []string{"cache/image1"}, stringify(m["image1"].CacheFrom))
+	require.Equal(t, "image2", *m["image2"].Args["TARGET"])
+	require.Equal(t, []string{"example/image2:latest"}, m["image2"].Tags)
+	require.Equal(t, []string{"cache/image2"}, stringify(m["image2"].CacheFrom))
+}
+
+func TestTargetsCurrentMatrixTarget(t *testing.T) {
+	ctx := context.TODO()
+	f := File{
+		Name: "docker-bake.hcl",
+		Data: []byte(`
+target "image" {
+  matrix = {
+    flavor = ["one", "two"]
+  }
+  name = "image-${flavor}"
+  tags = ["example/${targets.current}:latest"]
+}
+`),
+	}
+
+	m, g, err := ReadTargets(ctx, []File{f}, []string{"image"}, nil, nil, nil, &EntitlementConf{})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"image-one", "image-two"}, g["image"].Targets)
+	require.Equal(t, []string{"example/image-one:latest"}, m["image-one"].Tags)
+	require.Equal(t, []string{"example/image-two:latest"}, m["image-two"].Tags)
+}
+
 func TestNestedGroupsWithSameTarget(t *testing.T) {
 	ctx := context.TODO()
 

--- a/docs/bake-reference.md
+++ b/docs/bake-reference.md
@@ -606,6 +606,29 @@ target "default" {
 A target can inherit attributes from other targets.
 Use `inherits` to reference from one target to another.
 
+Inherited attributes can refer to the name of the target currently being
+resolved with `targets.current`. This is useful when multiple targets share
+common configuration, but image names, tags, cache references, or other values
+must still include the final target name.
+
+```hcl
+target "_common" {
+  tags = ["docker.io/username/${targets.current}:latest"]
+  cache-from = ["type=registry,ref=cache/${targets.current}"]
+}
+
+target "app-dev" {
+  inherits = ["_common"]
+}
+
+target "app-release" {
+  inherits = ["_common"]
+}
+```
+
+In this example, `targets.current` resolves to `app-dev` while resolving the
+`app-dev` target and to `app-release` while resolving the `app-release` target.
+
 In the following example,
 the `app-dev` target specifies an image name and tag.
 The `app-release` target uses `inherits` to reuse the tag name.


### PR DESCRIPTION
Adds `targets.current` for bake HCL targets so shared target config can refer to the final target currently being resolved.

The value is available while target expressions are decoded, but it is resolved after inheritance and overrides. That keeps the common inherited case working as expected: a `_common` target inherited by `image1` and `image2` resolves `targets.current` to each child target name, not `_common` and not whichever block happened to parse last. Matrix-derived target names are covered as well.

This also updates the Bake reference docs with the inherited-target use case from the issue.

Closes #1203.

Validation:
- `go test ./bake -count=1`
- `go test ./bake/hclparser/... -count=1`
