### PR TITLE
policy: remove uses of deprecated WithBuiltins

### DIFF
--- a/policy/tester.go
+++ b/policy/tester.go
@@ -7,7 +7,6 @@ import (
 	"io/fs"
 	"maps"
 	"path/filepath"
-	"slices"
 	"sort"
 	"strings"
 
@@ -212,20 +211,7 @@ func loadPolicyModules(root fs.StatFS, filename string) (map[string]*ast.Module,
 }
 
 func compilePolicyModules(modules map[string]*ast.Module, p *Policy, fsProvider func() (fs.StatFS, func() error, error)) (*ast.Compiler, func() error, error) {
-	caps := &ast.Capabilities{
-		Builtins: builtins(),
-		Features: slices.Clone(ast.Features),
-	}
-	comp := ast.NewCompiler().WithCapabilities(caps).WithKeepModules(true)
-
-	builtinDefs := make(map[string]*ast.Builtin)
-	for _, f := range p.funcs {
-		builtinDefs[f.decl.Name] = &ast.Builtin{
-			Name: f.decl.Name,
-			Decl: f.decl.Decl,
-		}
-	}
-	comp = comp.WithBuiltins(builtinDefs)
+	comp := ast.NewCompiler().WithCapabilities(p.capabilities()).WithKeepModules(true)
 
 	loader, closeLoader := newPolicyModuleLoader(fsProvider)
 	comp = comp.WithModuleLoader(loader)

--- a/policy/validate.go
+++ b/policy/validate.go
@@ -130,24 +130,25 @@ func (p *Policy) IsPolicyError(err error) bool {
 	return false
 }
 
-func (p *Policy) regoBaseOpts() ([]func(*rego.Rego), func(), error) {
+func (p *Policy) capabilities() *ast.Capabilities {
 	caps := &ast.Capabilities{
 		Builtins: builtins(),
 		Features: slices.Clone(ast.Features),
 	}
-	comp := ast.NewCompiler().WithCapabilities(caps).WithKeepModules(true)
+	for _, f := range p.funcs {
+		caps.Builtins = append(caps.Builtins, &ast.Builtin{
+			Name: f.decl.Name,
+			Decl: f.decl.Decl,
+		})
+	}
+	return caps
+}
+
+func (p *Policy) regoBaseOpts() ([]func(*rego.Rego), func(), error) {
+	comp := ast.NewCompiler().WithCapabilities(p.capabilities()).WithKeepModules(true)
 	if p.opt.Log != nil {
 		comp = comp.WithEnablePrintStatements(true)
 	}
-
-	builtins := make(map[string]*ast.Builtin)
-	for _, f := range p.funcs {
-		builtins[f.decl.Name] = &ast.Builtin{
-			Name: f.decl.Name,
-			Decl: f.decl.Decl,
-		}
-	}
-	comp = comp.WithBuiltins(builtins)
 
 	var root fs.StatFS
 	var closeFS func() error


### PR DESCRIPTION
- relates to https://github.com/docker/buildx/commit/c6ecdc08cfc37a88e0b5cba037d41233baec6733 / https://github.com/docker/buildx/pull/3592
- relates to https://github.com/docker/buildx/pull/3913


The WithBuiltins method was deprecated in opa v0.23.0 ([opa@afc8c5e]) in favor of WithCapabilities, but the deprecation didn't use the standard format, causing it not being detected as deprecated. OPA v1.1.0 corrected the deprecation in [opa@622434d].

This patch replaces uses of the deprecated functions.

[opa@afc8c5e]: https://github.com/open-policy-agent/opa/commit/afc8c5e2a22878086067821f24e15d060594227a
[opa@622434d]: https://github.com/open-policy-agent/opa/commit/622434d11386c7b12aee703d7c1eedea34a27c7b