### PR TITLE
bake: fix duplicated type in bakeEnvFiles lookup param

### DIFF
--- a/commands/bake.go
+++ b/commands/bake.go
@@ -594,7 +594,7 @@ func bakePolicyOverrides(in []string) ([]string, bool, error) {
 	return overrides, false, nil
 }
 
-func bakeEnvFiles(lookup func(string string) (string, bool)) ([]string, error) {
+func bakeEnvFiles(lookup func(string) (string, bool)) ([]string, error) {
 	sep, _ := lookup(bakeEnvFileSeparator)
 	if sep == "" {
 		sep = string(os.PathListSeparator)


### PR DESCRIPTION
bakeEnvFiles declared its lookup parameter as func(string string) (string, bool) — a stray duplicate that names the param "string". The intended signature is func(string) (string, bool) (the only caller passes os.LookupEnv, a one-arg lookup). Same type, behavior-preserving.
