### PR TITLE
vendor: github.com/containerd/containerd/v2 v2.2.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.24
 	github.com/compose-spec/compose-go/v2 v2.11.0
 	github.com/containerd/console v1.0.5
-	github.com/containerd/containerd/v2 v2.2.4
+	github.com/containerd/containerd/v2 v2.2.5
 	github.com/containerd/continuity v0.5.0
 	github.com/containerd/errdefs v1.0.0
 	github.com/containerd/log v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,8 @@ github.com/containerd/console v1.0.5 h1:R0ymNeydRqH2DmakFNdmjR2k0t7UPuiOV/N/27/q
 github.com/containerd/console v1.0.5/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=
 github.com/containerd/containerd/api v1.10.0 h1:5n0oHYVBwN4VhoX9fFykCV9dF1/BvAXeg2F8W6UYq1o=
 github.com/containerd/containerd/api v1.10.0/go.mod h1:NBm1OAk8ZL+LG8R0ceObGxT5hbUYj7CzTmR3xh0DlMM=
-github.com/containerd/containerd/v2 v2.2.4 h1:8x2UdXqww7NYqGNabQ7i1nAgB5LegzjC9KQzO/900iA=
-github.com/containerd/containerd/v2 v2.2.4/go.mod h1:YBcTO8D9149QY9zNmUjy04Mhuc4DlrZQ8FIOwKZEM7o=
+github.com/containerd/containerd/v2 v2.2.5 h1:KTFzB02LviYmmfRmz8r9UFd+n6YlddVFK+5lbgQXUTU=
+github.com/containerd/containerd/v2 v2.2.5/go.mod h1:5t2+xFv2dGd/iDYp9Z8DXB4cmWrWQi1XqxGJPS2gBzU=
 github.com/containerd/continuity v0.5.0 h1:7a85HZpCSs+1Zps0Ee3DPSuAWY+0SJM1JNM51nlEVDg=
 github.com/containerd/continuity v0.5.0/go.mod h1:/lNJvtJKUQStBzpVQ1+rasXO1LAWtUQssk28EZvJ3nE=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=

--- a/vendor/github.com/containerd/containerd/v2/pkg/labels/labels.go
+++ b/vendor/github.com/containerd/containerd/v2/pkg/labels/labels.go
@@ -16,6 +16,18 @@
 
 package labels
 
+// ReservedPrefix is the prefix of the label namespace reserved for labels
+// defined and consumed by containerd itself. Labels in this namespace must
+// not be copied from untrusted sources such as image config labels. Use
+// IsReserved to check for such labels.
+const ReservedPrefix = "containerd.io/"
+
+// CRIContainerdPrefix is the prefix of the label namespace reserved for
+// labels defined and consumed by containerd's CRI plugin. Labels in this
+// namespace must not be copied from untrusted sources such as image config
+// labels. Use IsReserved to check for such labels.
+const CRIContainerdPrefix = "io.cri-containerd"
+
 // LabelUncompressed is added to compressed layer contents.
 // The value is digest of the uncompressed content.
 const LabelUncompressed = "containerd.io/uncompressed"

--- a/vendor/github.com/containerd/containerd/v2/pkg/labels/validate.go
+++ b/vendor/github.com/containerd/containerd/v2/pkg/labels/validate.go
@@ -18,6 +18,7 @@ package labels
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/containerd/errdefs"
 )
@@ -38,4 +39,12 @@ func Validate(k, v string) error {
 		return fmt.Errorf("label key and value length (%d bytes) greater than maximum size (%d bytes), key: %s: %w", total, maxSize, k, errdefs.ErrInvalidArgument)
 	}
 	return nil
+}
+
+// IsReserved returns true if the label key is in a namespace reserved for
+// containerd (ReservedPrefix) or its CRI plugin (CRIContainerdPrefix).
+// Reserved labels are interpreted by containerd and must not be copied from
+// untrusted sources such as image config labels.
+func IsReserved(k string) bool {
+	return strings.HasPrefix(k, ReservedPrefix) || strings.HasPrefix(k, CRIContainerdPrefix)
 }

--- a/vendor/github.com/containerd/containerd/v2/version/version.go
+++ b/vendor/github.com/containerd/containerd/v2/version/version.go
@@ -24,7 +24,7 @@ var (
 	Package = "github.com/containerd/containerd/v2"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "2.2.4+unknown"
+	Version = "2.2.5+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -215,8 +215,8 @@ github.com/containerd/console
 # github.com/containerd/containerd/api v1.10.0
 ## explicit; go 1.23.0
 github.com/containerd/containerd/api/services/content/v1
-# github.com/containerd/containerd/v2 v2.2.4
-## explicit; go 1.24.3
+# github.com/containerd/containerd/v2 v2.2.5
+## explicit; go 1.25.0
 github.com/containerd/containerd/v2/core/content
 github.com/containerd/containerd/v2/core/content/proxy
 github.com/containerd/containerd/v2/core/images


### PR DESCRIPTION
- [x] depends on / stacked on https://github.com/docker/buildx/pull/3907
- supersedes, closes https://github.com/docker/buildx/pull/3923


### vendor: github.com/containerd/containerd/v2 v2.2.5

- full diff: https://github.com/containerd/containerd/compare/v2.2.4...v2.2.5
- release notes: https://github.com/containerd/containerd/releases/tag/v2.2.5

The fifth patch release for containerd 2.2 contains various fixes
and updates including security patches.

### Security Updates

-  CVE-2026-50195 / [GHSA-cvxm-645q-p574] CRI: checkpoint import allows local image tag poisoning
-  CVE-2026-53488 / [GHSA-xhf5-7wjv-pqxp] CRI: image-config LABEL flows to host-root command execution from an image pull
-  CVE-2026-53492 / [GHSA-33vj-92qq-66hc] CRI: CDI annotation smuggling during CRI checkpoint restore
-  CVE-2026-53489 / [GHSA-rgh6-rfwx-v388] CRI: Arbitrary host file read via symlink following in CRI checkpoint restore
-  CVE-2026-47262 / [GHSA-jpcc-p29g-p8mq] containerd image-triggered runtime DoS via unbounded group parsing


[GHSA-cvxm-645q-p574]: https://github.com/containerd/containerd/security/advisories/GHSA-cvxm-645q-p574
[GHSA-xhf5-7wjv-pqxp]: https://github.com/containerd/containerd/security/advisories/GHSA-xhf5-7wjv-pqxp
[GHSA-33vj-92qq-66hc]: https://github.com/containerd/containerd/security/advisories/GHSA-33vj-92qq-66hc
[GHSA-rgh6-rfwx-v388]: https://github.com/containerd/containerd/security/advisories/GHSA-rgh6-rfwx-v388
[GHSA-jpcc-p29g-p8mq]: https://github.com/containerd/containerd/security/advisories/GHSA-jpcc-p29g-p8mq
