### PR TITLE
imagetools: validate descriptor input for create -f

### DIFF
--- a/commands/imagetools/create.go
+++ b/commands/imagetools/create.go
@@ -353,25 +353,22 @@ func parseSource(in string) (*imagetools.Source, error) {
 		return nil, err
 	}
 
-	var s imagetools.Source
-	if err := json.Unmarshal([]byte(in), &s.Desc); err != nil {
+	var parsed struct {
+		SchemaVersion int `json:"schemaVersion"`
+		ocispecs.Descriptor
+	}
+	if err := json.Unmarshal([]byte(in), &parsed); err != nil {
 		return nil, errors.WithStack(err)
 	}
-	if err := validateDescriptorJSON(in, s.Desc); err != nil {
+	if err := validateDescriptor(parsed.Descriptor, parsed.SchemaVersion); err != nil {
 		return nil, err
 	}
-	return &s, nil
+	return &imagetools.Source{Desc: parsed.Descriptor}, nil
 }
 
-func validateDescriptorJSON(raw string, desc ocispecs.Descriptor) error {
-	var meta struct {
-		SchemaVersion int `json:"schemaVersion"`
-	}
-	if err := json.Unmarshal([]byte(raw), &meta); err != nil {
-		return errors.WithStack(err)
-	}
-	if meta.SchemaVersion != 0 {
-		return errors.Errorf("expected an OCI content descriptor, got a manifest or index (schemaVersion %d)", meta.SchemaVersion)
+func validateDescriptor(desc ocispecs.Descriptor, schemaVersion int) error {
+	if schemaVersion != 0 {
+		return errors.Errorf("expected an OCI content descriptor, got a manifest or index (schemaVersion %d)", schemaVersion)
 	}
 	if desc.Digest == "" {
 		return errors.Errorf("invalid descriptor: digest is required")

--- a/commands/imagetools/create.go
+++ b/commands/imagetools/create.go
@@ -357,7 +357,29 @@ func parseSource(in string) (*imagetools.Source, error) {
 	if err := json.Unmarshal([]byte(in), &s.Desc); err != nil {
 		return nil, errors.WithStack(err)
 	}
+	if err := validateDescriptorJSON(in, s.Desc); err != nil {
+		return nil, err
+	}
 	return &s, nil
+}
+
+func validateDescriptorJSON(raw string, desc ocispecs.Descriptor) error {
+	var meta struct {
+		SchemaVersion int `json:"schemaVersion"`
+	}
+	if err := json.Unmarshal([]byte(raw), &meta); err != nil {
+		return errors.WithStack(err)
+	}
+	if meta.SchemaVersion != 0 {
+		return errors.Errorf("expected an OCI content descriptor, got a manifest or index (schemaVersion %d)", meta.SchemaVersion)
+	}
+	if desc.Digest == "" {
+		return errors.Errorf("invalid descriptor: digest is required")
+	}
+	if _, err := digest.Parse(desc.Digest.String()); err != nil {
+		return errors.Wrap(err, "invalid descriptor digest")
+	}
+	return nil
 }
 
 func createCmd(dockerCli command.Cli, opts RootOptions) *cobra.Command {

--- a/commands/imagetools/create_test.go
+++ b/commands/imagetools/create_test.go
@@ -1,0 +1,27 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSourceDescriptorValidation(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseSource(`{"schemaVersion":2,"mediaType":"application/vnd.docker.distribution.manifest.list.v2+json","manifests":[]}`)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "expected an OCI content descriptor")
+
+	_, err = parseSource(`{"mediaType":"application/vnd.oci.image.manifest.v1+json"}`)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "digest is required")
+
+	_, err = parseSource(`{"digest":"not-a-digest","mediaType":"application/vnd.oci.image.manifest.v1+json","size":123}`)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid descriptor digest")
+
+	src, err := parseSource(`{"digest":"sha256:0000000000000000000000000000000000000000000000000000000000000000","mediaType":"application/vnd.oci.image.manifest.v1+json","size":123}`)
+	require.NoError(t, err)
+	require.Equal(t, "sha256:0000000000000000000000000000000000000000000000000000000000000000", src.Desc.Digest.String())
+}


### PR DESCRIPTION
## Summary

- Validate JSON passed to `imagetools create -f` is an OCI content descriptor, not a manifest or index.
- Reject descriptors with missing or invalid digests before push, returning a clear error instead of panicking.

Fixes #2091

## Test plan

- [x] `go test ./commands/imagetools/ -run TestParseSourceDescriptorValidation`
- [ ] `docker buildx imagetools inspect --raw alpine | docker buildx imagetools create -f /dev/stdin -t example/test` returns a descriptive error (no panic)
- [ ] Valid descriptor JSON with digest, mediaType, and size still works