### PR TITLE
chore: group codeql dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
       crazy-max-dot-github:
         patterns:
           - "crazy-max/.github/*"
+      codeql-actions:
+        patterns:
+          - "github/codeql-action/*"
     labels:
       - "area/dependencies"
       - "bot"


### PR DESCRIPTION
relates to https://github.com/docker/buildx/actions/runs/28814465562/job/85450234717?pr=3937#step:9:2

<img width="982" height="314" alt="image" src="https://github.com/user-attachments/assets/94f02910-e008-4706-bf4b-d014684db18a" />

`github/codeql-action/*` updates must be grouped together.