### PR TITLE
policy: normalize local policy paths

### DIFF
--- a/build/policy_loader.go
+++ b/build/policy_loader.go
@@ -200,7 +200,7 @@ func (p *policyPathFSRef) resolve(name string) (fs.StatFS, string, error) {
 		if err != nil {
 			return nil, "", err
 		}
-		return cwd, filepath.Clean(v), nil
+		return cwd, path.Clean(filepath.ToSlash(v)), nil
 	}
 
 	contextFS, err := p.getContextFS()
@@ -276,13 +276,12 @@ func (p *policyPathFSRef) Close() error {
 func normalizeLocalPolicyPath(name, contextDir string) string {
 	if filepath.IsAbs(name) && contextDir != "" {
 		if rel, err := filepath.Rel(contextDir, name); err == nil {
-			rel = filepath.Clean(rel)
 			if rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-				return rel
+				return path.Clean(filepath.ToSlash(rel))
 			}
 		}
 	}
-	return filepath.Clean(name)
+	return path.Clean(filepath.ToSlash(name))
 }
 
 type memoizedPolicyFS struct {

--- a/build/policy_loader_test.go
+++ b/build/policy_loader_test.go
@@ -11,6 +11,55 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestLoadPolicyDataLocalPaths(t *testing.T) {
+	dir := t.TempDir()
+	policyData := []byte("package docker\n")
+	policyRelPath := filepath.Join("policy", "allow.rego")
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "policy"), 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, policyRelPath), policyData, 0600))
+
+	t.Run("context-relative", func(t *testing.T) {
+		provider := newPolicyPathFS(context.Background(), nil, policyOpt{
+			ContextDir: dir,
+		})
+
+		dt, ok, err := loadPolicyData(provider, policyRelPath)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, policyData, dt)
+	})
+
+	t.Run("context-absolute", func(t *testing.T) {
+		provider := newPolicyPathFS(context.Background(), nil, policyOpt{
+			ContextDir: dir,
+		})
+
+		dt, ok, err := loadPolicyData(provider, filepath.Join(dir, policyRelPath))
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, policyData, dt)
+	})
+
+	t.Run("cwd", func(t *testing.T) {
+		cwd, err := os.Getwd()
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(dir))
+		t.Cleanup(func() {
+			require.NoError(t, os.Chdir(cwd))
+		})
+
+		provider := newPolicyPathFS(context.Background(), nil, policyOpt{})
+		dt, ok, err := loadPolicyData(provider, "cwd://"+policyRelPath)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, policyData, dt)
+	})
+}
+
+func TestNormalizeLocalPolicyPath(t *testing.T) {
+	require.Equal(t, "policy/allow.rego", normalizeLocalPolicyPath(filepath.Join("policy", "allow.rego"), ""))
+}
+
 func TestMemoizedPolicyFSRefCountedClose(t *testing.T) {
 	var initCalls int
 	var closeCalls int


### PR DESCRIPTION
~needs #3943~

Was testing some policies on multiple machines and it fails in a case on Windows because `fs.FS` paths must use forward slashes, but local policy paths were cleaned with `filepath.Clean`, which produces backslashes on Windows. That made valid policy files fail to load with `invalid argument`:

```powershell
mkdir bx-policy-repro\policy
Set-Content bx-policy-repro\Dockerfile "FROM scratch"
Set-Content bx-policy-repro\policy\allow.rego @'
package docker

default allow := true

decision := {"allow": allow}
'@

cd bx-policy-repro
docker buildx build --check --policy "filename=cwd://policy/allow.rego" .
```
```text
failed to stat policy file cwd://policy/allow.rego: stat policy\allow.rego: invalid argument
```

The policy loader now converts local and `cwd://` policy filenames with `filepath.ToSlash` and `path.Clean` before resolving them through the policy filesystem.