### PR TITLE
docs: fix typo for bake output override

### DIFF
--- a/docs/bake-reference.md
+++ b/docs/bake-reference.md
@@ -43,7 +43,7 @@ The following attributes are overridden by the last occurrence:
 - `target.cache-to`
 - `target.dockerfile-inline`
 - `target.dockerfile`
-- `target.outputs`
+- `target.output`
 - `target.platforms`
 - `target.pull`
 - `target.tags`


### PR DESCRIPTION
carry and closes https://github.com/docker/buildx/pull/3901