### PR TITLE
driver/kubernetes: enable gRPC keepalive to avoid infinite hangs

### DIFF
--- a/driver/kubernetes/driver.go
+++ b/driver/kubernetes/driver.go
@@ -21,6 +21,8 @@ import (
 	"github.com/moby/buildkit/client"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -394,11 +396,19 @@ func calculateBackoff(attempt int, baseDelay, maxDelay time.Duration) time.Durat
 	return min(time.Duration(1<<uint(attempt))*baseDelay, maxDelay)
 }
 
+// clientKeepaliveParams ensures that if the peer stops responding, the transport
+// will eventually be closed and any reads/writes will be unblocked.
+var clientKeepaliveParams = keepalive.ClientParameters{
+	Time:    20 * time.Second,
+	Timeout: 20 * time.Second,
+}
+
 func (d *Driver) Client(ctx context.Context, opts ...client.ClientOpt) (*client.Client, error) {
 	opts = append([]client.ClientOpt{
 		client.WithContextDialer(func(context.Context, string) (net.Conn, error) {
 			return d.Dial(ctx)
 		}),
+		client.WithGRPCDialOption(grpc.WithKeepaliveParams(clientKeepaliveParams)),
 	}, opts...)
 	return client.New(ctx, "", opts...)
 }


### PR DESCRIPTION
Add a gRPC keepalive in the kubernetes driver to detect when the remote doesn't respond for too long and stop the connection, which avoids blocking the process forever.

This is related to #556 but fixes a wider bug on the kubernetes driver: the issue is about the hanging when the remote container/pod is killed (NB: this is addressed directly by https://github.com/docker/buildx/pull/3966), the keepalive fixes this but also avoids issues when the connection stays open but the remote is unresponsive (eg. suspended).

The values for [ClientParameters](https://pkg.go.dev/google.golang.org/grpc/keepalive#ClientParameters) have been picked arbitrarily and I'm very open to suggestions to change them.

I didn't add unit tests for this because the `keepalive` package [enforces a minimum of 10 seconds](https://github.com/grpc/grpc-go/blob/25387aabbf6861b80db644465e823c2e8b427090/internal/internal.go#L40-L42) for `Time`, so any unit test exercising this would take at least 10 seconds.

## Repro / testing
Setup:
```sh
# create kind cluster
kind create cluster --name buildkit-repro

# create a builder
docker buildx create --driver kubernetes --name kindbuilder --driver-opt namespace=default,replicas=1 --bootstrap
```

Create a Dockerfile which takes some time, eg.:
```Dockerfile
FROM alpine:latest
RUN echo "step1 starting" && sleep 120 && echo "step1 done"
```

and build it:
```sh
docker buildx build --builder kindbuilder --progress=plain -f Dockerfile .
```

Wait for the log to show that it's running the sleep step, then open a new shell and suspend the buildkit process:
```sh
# Find the PID
docker exec buildkit-repro-control-plane ps aux | grep buildkitd

# Suspend it
docker exec buildkit-repro-control-plane kill -STOP <PID>
```

The `build` command will then hang forever (in particular won't finish after 2 minutes), even with https://github.com/docker/buildx/pull/3966.

Now build `cmd/buildx` from this PR, and re-run the same steps using this `buildx` binary instead of `docker buildx`, you should observe that the build command fails with the following error around 40 seconds after SIGSTOP is sent:

```
ERROR: failed to build: failed to receive status: rpc error: code = Unavailable desc = keepalive ping failed to receive ACK within timeout
```