### PR TITLE
buildflags: fix missing cache type error typo

### DIFF
--- a/util/buildflags/cache.go
+++ b/util/buildflags/cache.go
@@ -114,7 +114,7 @@ func (e *CacheOptionsEntry) UnmarshalText(text []byte) error {
 	}
 
 	if e.Type == "" {
-		return errors.Errorf("type required form> %q", in)
+		return errors.Errorf("type required for %q", in)
 	}
 	return e.validate(text)
 }
@@ -132,7 +132,7 @@ func (e *CacheOptionsEntry) validate(gv any) error {
 		default:
 			text, _ = json.Marshal(gv)
 		}
-		return errors.Errorf("type required form> %q", string(text))
+		return errors.Errorf("type required for %q", string(text))
 	}
 	return nil
 }

--- a/util/buildflags/cache_test.go
+++ b/util/buildflags/cache_test.go
@@ -86,3 +86,16 @@ func TestCacheOptions_RefOnlyFormat(t *testing.T) {
 		{Type: "registry", Attrs: map[string]string{"ref": "ref2"}},
 	}, opts)
 }
+
+func TestCacheOptions_MissingTypeError(t *testing.T) {
+	t.Run("ParseCacheEntry", func(t *testing.T) {
+		_, err := ParseCacheEntry([]string{"test=test"})
+		require.EqualError(t, err, `type required for "test=test"`)
+	})
+
+	t.Run("UnmarshalJSON", func(t *testing.T) {
+		var actual CacheOptionsEntry
+		err := json.Unmarshal([]byte(`{"ref":"user/app:cache"}`), &actual)
+		require.EqualError(t, err, `type required for "{\"ref\":\"user/app:cache\"}"`)
+	})
+}


### PR DESCRIPTION
The cache flag parser reported `form>` instead of `for` when `type=` was omitted from cache options.