### PR TITLE
client: bump defaults.DefaultMax{Recv,Send}MsgSize to 128MiB

### DIFF
--- a/vendor/github.com/moby/buildkit/client/client.go
+++ b/vendor/github.com/moby/buildkit/client/client.go
@@ -43,8 +43,8 @@ type ClientOpt interface {
 // New returns a new buildkit client. Address can be empty for the system-default address.
 func New(ctx context.Context, address string, opts ...ClientOpt) (*Client, error) {
 	gopts := []grpc.DialOption{
-		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(defaults.DefaultMaxRecvMsgSize)),
-		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(defaults.DefaultMaxSendMsgSize)),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(8 * defaults.DefaultMaxRecvMsgSize)),
+		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(8 * defaults.DefaultMaxSendMsgSize)),
 	}
 	needDialer := true
 


### PR DESCRIPTION
Related to https://github.com/moby/buildkit/pull/6951