### PR TITLE
Build fails when shared context directory contains non-ASCII characters

### DIFF
--- a/build/opt.go
+++ b/build/opt.go
@@ -850,7 +850,7 @@ func loadInputs(ctx context.Context, d *driver.DriverHandle, inp *Inputs, pw pro
 		if p, err := filepath.Abs(sharedKey); err == nil {
 			sharedKey = filepath.Base(p)
 		}
-		target.SharedKey = sharedKey
+		target.SharedKey = sanitizeSharedKey(sharedKey)
 		switch inp.DockerfilePath {
 		case "-":
 			dockerfileReader = inp.InStream.NewReadCloser()
@@ -1032,7 +1032,7 @@ func loadInputs(ctx context.Context, d *driver.DriverHandle, inp *Inputs, pw pro
 		} else {
 			sharedKey = filepath.Base(sharedKey)
 		}
-		target.FrontendAttrs["sharedkey:localdir:"+k] = sharedKey
+		target.FrontendAttrs["sharedkey:localdir:"+k] = sanitizeSharedKey(sharedKey)
 	}
 
 	release := func() {
@@ -1540,6 +1540,16 @@ func isActive(ce *client.CacheOptionsEntry) bool {
 		return true
 	}
 	return ce.Attrs["token"] != "" && (ce.Attrs["url"] != "" || ce.Attrs["url_v2"] != "")
+}
+
+// sanitizeSharedKey hashes non-ASCII keys for gRPC metadata
+func sanitizeSharedKey(key string) string {
+	for i := 0; i < len(key); i++ {
+		if key[i] < 0x20 || key[i] > 0x7E {
+			return digest.FromString(key).Encoded()
+		}
+	}
+	return key
 }
 
 func defaultPlatform(bopts gateway.BuildOpts) *ocispecs.Platform {

--- a/build/opt_test.go
+++ b/build/opt_test.go
@@ -167,6 +167,31 @@ func TestProxyArgKeyExists(t *testing.T) {
 	}
 }
 
+func TestSanitizeSharedKey(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		want string
+	}{
+		{
+			name: "ascii",
+			key:  "a",
+			want: "a",
+		},
+		{
+			name: "non-ascii",
+			key:  "早",
+			want: "e7c7fb50f3db8408eacd8f1702021a00a7b8cfb549f422fcf4d977f725df4b36",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, sanitizeSharedKey(tt.key))
+		})
+	}
+}
+
 func TestApplyPolicyCapsEnablesProxyNetwork(t *testing.T) {
 	p := policyWithDecision(`
 package docker


### PR DESCRIPTION
Initially caught by docker/compose#13965 2 Compose services sharing a build context containing Chinese characters, but after some digging, every build dialed over gRPC fails. Same as #2793 which was closed as not reproducible.

Sanitize the shared key before it reaches gRPC.

Steps to reproduce:
```sh
mkdir -p 早

docker buildx create --name repro --driver docker-container
docker buildx build --builder repro 早

docker buildx bake -f - a b <<'EOF'
target "a" { context = "早" }
target "b" { context = "早" }
EOF

docker compose -f - build <<'EOF'
services:
  a: {build: 早}
  b: {build: 早}
EOF
```

All 3 fail with:
```
failed to dial gRPC: rpc error: code = Internal desc = rpc error: code = Internal desc = header key "x-docker-expose-session-sharedkey" contains value with non-printable ASCII characters
```
