### PR TITLE
ci: skip windows release checksums and sigstore bundles

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -336,7 +336,7 @@ jobs:
               mv "provenance.json" "${filename}.provenance.json"
               mv "sbom-binaries.spdx.json" "${filename}.sbom.json"
               find . -name 'sbom*.json' -exec rm {} \;
-              if [[ "$binname" == *darwin* ]]; then
+              if [[ "$binname" == *darwin* ]] || [[ "$binname" == *windows* ]]; then
                 rm -f "provenance.sigstore.json"
               elif [ -f "provenance.sigstore.json" ]; then
                 mv "provenance.sigstore.json" "${filename}.sigstore.json"
@@ -350,7 +350,7 @@ jobs:
         working-directory: ${{ env.DESTDIR }}
         run: |
           sha256sum -b buildx-* > ./checksums.txt
-          sed -i '/darwin/d' ./checksums.txt
+          sed -i -e '/darwin/d' -e '/windows/d' ./checksums.txt
           sha256sum -c --strict checksums.txt
       -
         name: List artifacts


### PR DESCRIPTION
This updates the Buildx release workflow so Windows artifacts are handled like Darwin artifacts before the external signing handoff.

Windows binaries are signed by a downstream workflow, which downloads the Buildx release assets, keeps the Darwin and Windows binaries, signs them, verifies the signatures, and uploads the signed binaries back to the release. Skipping Windows checksums here avoids publishing checksums for pre-signed binaries that will be replaced by the signing workflow.