### PR TITLE
ci: skip repository workflows in forks

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   codeql:
+    if: ${{ github.repository == 'docker/buildx' }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   labeler:
+    if: ${{ github.repository == 'docker/buildx' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read # same as global permission

--- a/.github/workflows/pr-assign-author.yml
+++ b/.github/workflows/pr-assign-author.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   run:
+    if: ${{ github.repository == 'docker/buildx' }}
     uses: crazy-max/.github/.github/workflows/pr-assign-author.yml@46267a6e61cd56aac2fc79943df180152f4c89d6 # v1.10.1
     permissions:
       contents: read # same as global permission

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -19,6 +19,7 @@ on:
 
 jobs:
   zizmor:
+    if: ${{ github.repository == 'docker/buildx' }}
     uses: crazy-max/.github/.github/workflows/zizmor.yml@46267a6e61cd56aac2fc79943df180152f4c89d6 # v1.10.1
     permissions:
       contents: read


### PR DESCRIPTION
These workflows don't need to run on forks.