### PR TITLE
build: resolve target links for call methods

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -607,16 +607,45 @@ func BuildWithResultHandler(ctx context.Context, nodes []builder.Node, opts map[
 						// Capture the error from this build function.
 						defer catchFrontendError(&retErr, &frontendErr)
 
-						if opt.CallFunc != nil {
-							if _, ok := req.FrontendOpt["frontend.caps"]; !ok {
-								req.FrontendOpt["frontend.caps"] = "moby.buildkit.frontend.subrequests+forward"
-							} else {
-								req.FrontendOpt["frontend.caps"] += ",moby.buildkit.frontend.subrequests+forward"
+						rKey := resultKey(dp, k)
+						children := childTargets[rKey]
+
+						// A call method replies with the metadata of the subrequest
+						// instead of a build result, so there would be nothing to link
+						// into the targets using this one as a named context. Solve the
+						// build request on its own in that case and register its result
+						// for them. It is never evaluated, so this only resolves the
+						// definition and does not build anything.
+						linked := false
+						if opt.CallFunc != nil && len(children) > 0 {
+							linkReq := req
+							linkReq.FrontendOpt = maps.Clone(req.FrontendOpt)
+							// checks are reported by the call method below, skip them
+							// here so that this request is not rejected by a Dockerfile
+							// that asks for check violations to be errors
+							linkReq.FrontendOpt["build-arg:BUILDKIT_DOCKERFILE_CHECK"] = "skip=all;error=false"
+							res, err := solve(ctx, c, linkReq)
+							if err != nil {
+								return nil, err
 							}
-							req.FrontendOpt["requestid"] = "frontend." + opt.CallFunc.Name
+							results.Set(rKey, res)
+							linked = true
 						}
 
-						res, err := solve(ctx, c, req)
+						solveReq := req
+						if opt.CallFunc != nil {
+							// keep the initial request untouched, it may have already
+							// been sent for the linked result above
+							solveReq.FrontendOpt = maps.Clone(req.FrontendOpt)
+							if _, ok := solveReq.FrontendOpt["frontend.caps"]; !ok {
+								solveReq.FrontendOpt["frontend.caps"] = "moby.buildkit.frontend.subrequests+forward"
+							} else {
+								solveReq.FrontendOpt["frontend.caps"] += ",moby.buildkit.frontend.subrequests+forward"
+							}
+							solveReq.FrontendOpt["requestid"] = "frontend." + opt.CallFunc.Name
+						}
+
+						res, err := solve(ctx, c, solveReq)
 						if err != nil {
 							return nil, err
 						}
@@ -625,11 +654,12 @@ func BuildWithResultHandler(ctx context.Context, nodes []builder.Node, opts map[
 							callRes = res.Metadata
 						}
 
-						rKey := resultKey(dp, k)
-						results.Set(rKey, res)
+						if !linked {
+							results.Set(rKey, res)
+						}
 
 						forceEval := false
-						if children := childTargets[rKey]; len(children) > 0 {
+						if len(children) > 0 {
 							// wait for the child targets to register their LLB before evaluating
 							_, err := results.Get(ctx, children...)
 							if err != nil {

--- a/tests/bake.go
+++ b/tests/bake.go
@@ -83,6 +83,7 @@ var bakeTests = []func(t *testing.T, sb integration.Sandbox){
 	testBakeListVariables,
 	testBakeListTypedVariables,
 	testBakeCallCheck,
+	testBakeCallCheckLinkedTargets,
 	testBakeCallCheckFlag,
 	testBakeCallMetadata,
 	testBakeMultiPlatform,
@@ -2447,6 +2448,63 @@ target "validate" {
 	require.Error(t, err, out)
 
 	require.Contains(t, out, "validate")
+	require.Contains(t, out, "ConsistentInstructionCasing")
+}
+
+func testBakeCallCheckLinkedTargets(t *testing.T, sb integration.Sandbox) {
+	dockerfileBuilder := []byte(`
+FROM scratch
+COPY foo /foo
+	`)
+	dockerfileBase := []byte(`
+FROM builder
+COPY foo /bar
+	`)
+	dockerfileApp := []byte(`
+FROM base
+COPy foo /baz
+	`)
+	bakefile := []byte(`
+target "builder" {
+	dockerfile = "builder.Dockerfile"
+}
+
+target "base" {
+	dockerfile = "base.Dockerfile"
+	contexts = {
+		builder = "target:builder"
+	}
+}
+
+target "app" {
+	dockerfile = "app.Dockerfile"
+	contexts = {
+		base = "target:base"
+	}
+}
+`)
+	dir := tmpdir(
+		t,
+		fstest.CreateFile("docker-bake.hcl", bakefile, 0600),
+		fstest.CreateFile("builder.Dockerfile", dockerfileBuilder, 0600),
+		fstest.CreateFile("base.Dockerfile", dockerfileBase, 0600),
+		fstest.CreateFile("app.Dockerfile", dockerfileApp, 0600),
+		fstest.CreateFile("foo", []byte("foo"), 0600),
+	)
+
+	out, err := bakeCmd(
+		sb,
+		withDir(dir),
+		withArgs("app", "--check"),
+	)
+	require.Error(t, err, out)
+
+	// the "target:" contexts must be resolved for the call method instead of
+	// being forwarded to the frontend
+	require.NotContains(t, out, "unsupported context source target")
+
+	// the requested target and the ones it links to are all checked
+	require.Equal(t, 3, strings.Count(out, "Check complete"), out)
 	require.Contains(t, out, "ConsistentInstructionCasing")
 }
 


### PR DESCRIPTION
Targets referencing each other through a "target:" named context are resolved on the client: the linked target is solved first and its result is then rewritten into an "input:" context by waitContextDeps.

A call method such as check or outline replies with the metadata of the subrequest and does not return a build result, so nothing can be linked into the targets depending on it. The "target:" context is then left untouched and reaches the frontend, which rejects it:

  $ docker buildx bake -f providers.hcl -f build.hcl app --check
  app
  error: unsupported context source target for base
  base
  error: unsupported context source target for builder

Solve the build request separately when a target using a call method is linked to by another one, and register that result for them. It is never evaluated, so the definition is only resolved and nothing is built. Checks are skipped for that request as they are already reported by the call method, otherwise a Dockerfile asking for check violations to be errors would fail it before the report is produced.

Fixes #3343