### PR TITLE
ci: add dependency update workflow

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -1,0 +1,436 @@
+name: update-deps
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/update-deps.yml'
+      - '.github/workflows/build.yml'
+      - 'Dockerfile'
+  schedule:
+    - cron: '0 9 * * *'
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  update:
+    runs-on: ubuntu-24.04
+    if: ${{ github.repository == 'docker/buildx' }}
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        dep:
+          - docker
+          - registry
+          - buildkit
+          - compose
+          - scout
+          - undock
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      -
+        name: Install npm deps
+        run: |
+          install_dir="$RUNNER_TEMP/update-deps-node"
+          mkdir -p "$install_dir"
+
+          cat > "$install_dir/package.json" <<'EOF'
+          {
+            "name": "buildx-update-deps",
+            "version": "0.0.0",
+            "private": true,
+            "dependencies": {
+              "semver": "7.8.3"
+            }
+          }
+          EOF
+
+          cat > "$install_dir/package-lock.json" <<'EOF'
+          {
+            "name": "buildx-update-deps",
+            "version": "0.0.0",
+            "lockfileVersion": 3,
+            "requires": true,
+            "packages": {
+              "": {
+                "name": "buildx-update-deps",
+                "version": "0.0.0",
+                "dependencies": {
+                  "semver": "7.8.3"
+                }
+              },
+              "node_modules/semver": {
+                "version": "7.8.3",
+                "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
+                "integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
+                "license": "ISC",
+                "bin": {
+                  "semver": "bin/semver.js"
+                },
+                "engines": {
+                  "node": ">=10"
+                }
+              }
+            }
+          }
+          EOF
+
+          npm ci --prefix "$install_dir" --loglevel=error --ignore-scripts --omit=dev --fund=false --audit=false
+          echo "NODE_PATH=$install_dir/node_modules" >> "$GITHUB_ENV"
+      -
+        name: Update dependency
+        id: update
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          INPUT_DEP: ${{ matrix.dep }}
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const semver = require('semver');
+
+            const dep = core.getInput('dep');
+
+            function escapeRegExp(value) {
+              return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            }
+
+            function dockerfileArgPattern(key) {
+              return new RegExp(`^(ARG\\s+${escapeRegExp(key)}\\s*=\\s*)(["']?)([^"'\\s#]+)\\2(\\s*(?:#.*)?)$`, 'm');
+            }
+
+            function workflowEnvPattern(key) {
+              return new RegExp(`^(  ${escapeRegExp(key)}:\\s*)(["'])([^"']*)\\2(\\s*(?:#.*)?)$`, 'm');
+            }
+
+            function matchVersion(match) {
+              return match[3];
+            }
+
+            function replaceVersion(content, pattern, version) {
+              return content.replace(pattern, (...args) => {
+                const groups = args.slice(1, -2);
+                return `${groups[0]}${groups[1]}${version}${groups[1]}${groups[3] || ''}`;
+              });
+            }
+
+            function stripLeadingV(value) {
+              return value.startsWith('v') ? value.slice(1) : value;
+            }
+
+            function stripPrefix(value, prefix = '') {
+              if (!prefix) {
+                return value;
+              }
+              return value.startsWith(prefix) ? value.slice(prefix.length) : undefined;
+            }
+
+            async function semverReleases({owner, repo, tagPrefix}) {
+              const result = [];
+
+              for (let page = 1; page <= 10; page++) {
+                const releases = await github.rest.repos.listReleases({
+                  owner,
+                  repo,
+                  page,
+                  per_page: 100
+                });
+                for (const release of releases.data) {
+                  const tag = stripPrefix(release.tag_name, tagPrefix);
+                  const version = tag ? semver.parse(tag) : undefined;
+                  if (!release.draft && version) {
+                    result.push({
+                      tag: release.tag_name,
+                      version,
+                      prerelease: release.prerelease
+                    });
+                  }
+                }
+                if (releases.data.length < 100) {
+                  break;
+                }
+              }
+
+              return result.sort((left, right) => semver.rcompare(left.version, right.version));
+            }
+
+            function latestMinorReleaseTags(releases, count) {
+              const result = [];
+              const seen = new Set();
+              for (const release of releases) {
+                if (release.prerelease || release.version.prerelease.length > 0) {
+                  continue;
+                }
+                const key = `${release.version.major}.${release.version.minor}`;
+                if (seen.has(key)) {
+                  continue;
+                }
+                seen.add(key);
+                result.push(release.tag);
+                if (result.length === count) {
+                  return result;
+                }
+              }
+              throw new Error(`Unable to resolve the latest ${count} minor release tags`);
+            }
+
+            function updateBuildkitMatrix(content, releases) {
+              const lines = content.split('\n');
+              const keyPattern = /^(\s*)buildkit:\s*(?:#.*)?\r?$/;
+              const startIndex = lines.findIndex(line => keyPattern.test(line));
+              if (startIndex === -1) {
+                throw new Error('Missing buildkit matrix in .github/workflows/build.yml');
+              }
+
+              const baseIndent = lines[startIndex].match(keyPattern)[1].length;
+              let endIndex = startIndex + 1;
+              for (; endIndex < lines.length; endIndex++) {
+                const line = lines[endIndex];
+                if (/^\s*(?:#.*)?\r?$/.test(line)) {
+                  continue;
+                }
+                const indent = line.match(/^\s*/)[0].length;
+                if (indent <= baseIndent) {
+                  break;
+                }
+              }
+
+              const releaseRows = [];
+              let sequenceIndent;
+              for (let index = startIndex + 1; index < endIndex; index++) {
+                const match = lines[index].match(/^(\s*-\s+)(["']?)([^"'\s#]+)\2(.*)$/);
+                if (!match) {
+                  continue;
+                }
+                const itemIndent = match[1].match(/^\s*/)[0].length;
+                if (itemIndent <= baseIndent) {
+                  continue;
+                }
+                if (sequenceIndent === undefined) {
+                  sequenceIndent = itemIndent;
+                }
+                if (itemIndent !== sequenceIndent || !semver.parse(match[3])) {
+                  continue;
+                }
+                releaseRows.push({
+                  index,
+                  prefix: match[1],
+                  quote: match[2],
+                  value: match[3],
+                  suffix: match[4]
+                });
+              }
+              if (releaseRows.length === 0) {
+                throw new Error('BuildKit matrix has no release entries');
+              }
+
+              const versions = latestMinorReleaseTags(releases, releaseRows.length + 1).slice(1);
+              for (const [index, row] of releaseRows.entries()) {
+                lines[row.index] = `${row.prefix}${row.quote}${versions[index]}${row.quote}${row.suffix}`;
+              }
+
+              return {
+                content: lines.join('\n'),
+                before: releaseRows.map(row => row.value),
+                after: versions
+              };
+            }
+
+            function changeSentence(change) {
+              if (change.kind === 'buildkit-matrix') {
+                return `This updates the BuildKit integration test matrix in \`${change.path}\` from \`${change.before.join(', ')}\` to \`${change.after.join(', ')}\`.`;
+              }
+              return `This updates \`${change.arg}\` in \`${change.path}\` from \`${change.before}\` to \`${change.after}\`.`;
+            }
+
+            function pullRequestBody(changes, sourceUrl) {
+              const body = changes.length > 0
+                ? changes.map(changeSentence).join('\n\n')
+                : 'No dependency updates were detected.';
+              return `${body}\n\nThe source of truth for this update is ${sourceUrl}.`;
+            }
+
+            function pullRequestTitle(config, dep, version, changes) {
+              if (dep === 'buildkit' && changes.length === 1 && changes[0].kind === 'buildkit-matrix') {
+                return 'ci: update buildkit matrix';
+              }
+              return `${config.titlePrefix || 'dockerfile'}: update ${dep} ${stripLeadingV(version)}`;
+            }
+
+            const dependencyConfigs = {
+              docker: {
+                name: 'Docker version',
+                branch: 'deps/docker-version',
+                owner: 'moby',
+                repo: 'moby',
+                tagPrefix: 'docker-',
+                path: 'Dockerfile',
+                arg: 'DOCKER_VERSION',
+                pattern: dockerfileArgPattern('DOCKER_VERSION'),
+                value: tag => stripLeadingV(stripPrefix(tag, 'docker-'))
+              },
+              registry: {
+                name: 'Registry version',
+                branch: 'deps/registry-version',
+                owner: 'distribution',
+                repo: 'distribution',
+                path: 'Dockerfile',
+                arg: 'REGISTRY_VERSION',
+                pattern: dockerfileArgPattern('REGISTRY_VERSION'),
+                value: stripLeadingV
+              },
+              buildkit: {
+                name: 'BuildKit version',
+                branch: 'deps/buildkit-version',
+                owner: 'moby',
+                repo: 'buildkit',
+                path: 'Dockerfile',
+                arg: 'BUILDKIT_VERSION',
+                pattern: dockerfileArgPattern('BUILDKIT_VERSION'),
+                value: tag => tag,
+                updateBuildkitMatrix: true
+              },
+              compose: {
+                name: 'Compose version',
+                branch: 'deps/compose-version',
+                owner: 'docker',
+                repo: 'compose',
+                path: 'Dockerfile',
+                arg: 'COMPOSE_VERSION',
+                pattern: dockerfileArgPattern('COMPOSE_VERSION'),
+                value: tag => tag
+              },
+              scout: {
+                name: 'Scout version',
+                branch: 'deps/scout-version',
+                owner: 'docker',
+                repo: 'scout-cli',
+                path: '.github/workflows/build.yml',
+                arg: 'SCOUT_VERSION',
+                pattern: workflowEnvPattern('SCOUT_VERSION'),
+                titlePrefix: 'ci',
+                value: stripLeadingV
+              },
+              undock: {
+                name: 'Undock version',
+                branch: 'deps/undock-version',
+                owner: 'crazy-max',
+                repo: 'undock',
+                path: 'Dockerfile',
+                arg: 'UNDOCK_VERSION',
+                pattern: dockerfileArgPattern('UNDOCK_VERSION'),
+                value: stripLeadingV
+              }
+            };
+
+            const config = dependencyConfigs[dep];
+            if (!config) {
+              throw new Error(`Unknown dependency ${dep}`);
+            }
+
+            const releases = await semverReleases(config);
+            if (releases.length === 0) {
+              throw new Error(`Unable to resolve latest semver release or pre-release for ${config.owner}/${config.repo}`);
+            }
+
+            const tag = releases[0].tag;
+            const version = config.value(tag);
+            const absolutePath = path.join(process.env.GITHUB_WORKSPACE, config.path);
+            const content = fs.readFileSync(absolutePath, 'utf8');
+            const pattern = config.pattern;
+            const match = content.match(pattern);
+            if (!match) {
+              throw new Error(`Missing ${config.arg} in ${config.path}`);
+            }
+
+            const currentVersion = matchVersion(match);
+            const changes = [];
+            if (currentVersion !== version) {
+              fs.writeFileSync(absolutePath, replaceVersion(content, pattern, version), 'utf8');
+              core.info(`New ${config.name} ${version} found`);
+              changes.push({
+                kind: 'version',
+                arg: config.arg,
+                path: config.path,
+                before: currentVersion,
+                after: version
+              });
+            } else {
+              core.info(`No workspace changes needed for ${config.name}`);
+            }
+
+            if (config.updateBuildkitMatrix) {
+              const buildWorkflowPath = path.join(process.env.GITHUB_WORKSPACE, '.github', 'workflows', 'build.yml');
+              const buildWorkflowContent = fs.readFileSync(buildWorkflowPath, 'utf8');
+              const matrixUpdate = updateBuildkitMatrix(buildWorkflowContent, releases);
+              if (matrixUpdate.content !== buildWorkflowContent) {
+                fs.writeFileSync(buildWorkflowPath, matrixUpdate.content, 'utf8');
+                core.info(`Updated BuildKit test matrix to ${matrixUpdate.after.join(', ')}`);
+                changes.push({
+                  kind: 'buildkit-matrix',
+                  path: '.github/workflows/build.yml',
+                  before: matrixUpdate.before,
+                  after: matrixUpdate.after
+                });
+              } else {
+                core.info('No workspace changes needed for BuildKit test matrix');
+              }
+              core.setOutput('buildkit-matrix', matrixUpdate.after.join(', '));
+            }
+
+            const sourceUrl = `https://github.com/${config.owner}/${config.repo}/releases/tag/${tag}`;
+            const primaryChange = changes[0] || {
+              kind: 'version',
+              arg: config.arg,
+              path: config.path,
+              before: currentVersion,
+              after: version
+            };
+            core.info(`Resolved ${config.name} from ${sourceUrl}`);
+            core.setOutput('arg', config.arg);
+            core.setOutput('path', primaryChange.path);
+            core.setOutput('branch', config.branch);
+            core.setOutput('title', pullRequestTitle(config, dep, version, changes));
+            core.setOutput('before', Array.isArray(primaryChange.before) ? primaryChange.before.join(', ') : primaryChange.before);
+            core.setOutput('after', Array.isArray(primaryChange.after) ? primaryChange.after.join(', ') : primaryChange.after);
+            core.setOutput('body', pullRequestBody(changes, sourceUrl));
+            core.setOutput('source-url', sourceUrl);
+      -
+        name: Print diff
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          if git diff --quiet -- Dockerfile .github/workflows/build.yml; then
+            echo "No dependency updates found."
+          else
+            git diff -- Dockerfile .github/workflows/build.yml
+          fi
+      -
+        name: Create pull request
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          base: master
+          branch: ${{ steps.update.outputs.branch }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: ${{ steps.update.outputs.title }}
+          title: ${{ steps.update.outputs.title }}
+          signoff: true
+          sign-commits: true
+          delete-branch: true
+          body: ${{ steps.update.outputs.body }}


### PR DESCRIPTION
This adds an `update-deps` workflow that opens dependency update pull requests for the Dockerfile versions used by the test image.

The workflow resolves the latest release tags for Docker, registry, BuildKit, Compose, Scout and Undock, updates the matching Dockerfile arguments, and creates a signed pull request for each dependency. The BuildKit update also refreshes the `test-integration` matrix so it keeps testing `master`, `latest`, `buildx-stable-1`, and the latest three stable minor BuildKit release tags.