### PR TITLE
ci: use PAT auth for Scout Docker Hub login

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -416,17 +416,16 @@ jobs:
     permissions:
       contents: read # same as global permission
       security-events: write # required to write sarif report
-      id-token: write # for logging in to Docker Hub with GitHub OIDC
     needs:
       - bin-image
     steps:
       -
+        # FIXME: switch to OIDC once Scout supports it
         name: Login to DockerHub
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        env:
-          DOCKERHUB_OIDC_CONNECTIONID: ${{ vars.DOCKERHUB_OIDC_CONNECTIONID }}
         with:
-          username: docker
+          username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
+          password: ${{ secrets.DOCKERPUBLICBOT_READ_PAT }}
       -
         name: Scout
         id: scout


### PR DESCRIPTION
relates to https://github.com/docker/buildx/actions/runs/31011492529/job/92329179778#step:3:211

```
/usr/bin/docker scout cves registry://docker/buildx-bin:master --format sarif --output /home/runner/work/_temp/docker-scout-9e5R4q/result.txt
      i New version 1.24.0 available (installed version is 1.11.0) at https://github.com/docker/scout-cli
        Log in with your Docker ID or email address to use docker scout.
  
  If you don't have a Docker ID, head over to https://hub.docker.com/ to
  create one. You can log in with your password or a Personal Access Token (PAT)
  by running docker login.
  Using a limited-scope PAT grants better security and is required for organizations
  using SSO. Learn more at https://docs.docker.com/go/access-tokens/
  
  You can also log in using Docker Desktop.
```

OIDC doesn't seem supported by Scout at the moment.