### PR TITLE
Serialize log pauses

### DIFF
--- a/util/logutil/pause.go
+++ b/util/logutil/pause.go
@@ -8,7 +8,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+var pauseMu sync.Mutex
+
 func Pause(l *logrus.Logger) func() {
+	pauseMu.Lock()
 	// initialize formatter with original terminal settings
 	l.Formatter.Format(logrus.NewEntry(l))
 
@@ -16,6 +19,7 @@ func Pause(l *logrus.Logger) func() {
 	l.SetOutput(bw)
 	return func() {
 		bw.resume()
+		pauseMu.Unlock()
 	}
 }
 

--- a/util/logutil/pause_test.go
+++ b/util/logutil/pause_test.go
@@ -1,0 +1,29 @@
+package logutil
+
+import (
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestPauseConcurrent(t *testing.T) {
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	for range 2 {
+		go func() {
+			defer wg.Done()
+			<-start
+			Pause(logger)()
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+}


### PR DESCRIPTION
Concurrent Buildx progress printers call `logutil.Pause` against one global logrus logger. `Pause` read and replaced the logger output without serializing the pause intervals, which races under Go's race detector.

Serialize pauses until their buffered output is resumed, and cover concurrent calls with a race regression test.