### PR TITLE
logutil: fix data race when Pause is called concurrently

### DIFF
--- a/util/logutil/pause.go
+++ b/util/logutil/pause.go
@@ -8,45 +8,63 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+var (
+	loggerWriters   = map[*logrus.Logger]*loggerWriter{}
+	loggerWritersMu sync.Mutex
+)
+
 func Pause(l *logrus.Logger) func() {
-	// initialize formatter with original terminal settings
+	loggerWritersMu.Lock()
+	writer, found := loggerWriters[l]
+	if !found {
+		writer = newLoggerWriter(l)
+		loggerWriters[l] = writer
+	}
+	loggerWritersMu.Unlock()
+
+	return writer.pause()
+}
+
+type loggerWriter struct {
+	mu     sync.Mutex
+	buffer bytes.Buffer
+	output io.Writer
+	pauses int
+}
+
+func newLoggerWriter(l *logrus.Logger) *loggerWriter {
 	l.Formatter.Format(logrus.NewEntry(l))
+	writer := &loggerWriter{output: l.Out}
+	l.SetOutput(writer)
+	return writer
+}
 
-	bw := newBufferedWriter(l.Out)
-	l.SetOutput(bw)
+func (w *loggerWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.pauses > 0 {
+		return w.buffer.Write(p)
+	}
+
+	return w.output.Write(p)
+}
+
+func (w *loggerWriter) pause() func() {
+	w.mu.Lock()
+	w.pauses++
+	w.mu.Unlock()
+
+	var once sync.Once
 	return func() {
-		bw.resume()
-	}
-}
+		once.Do(func() {
+			w.mu.Lock()
+			defer w.mu.Unlock()
 
-type bufferedWriter struct {
-	mu  sync.Mutex
-	buf *bytes.Buffer
-	w   io.Writer
-}
-
-func newBufferedWriter(w io.Writer) *bufferedWriter {
-	return &bufferedWriter{
-		buf: bytes.NewBuffer(nil),
-		w:   w,
+			w.pauses--
+			if w.pauses == 0 {
+				_, _ = w.buffer.WriteTo(w.output)
+			}
+		})
 	}
-}
-
-func (bw *bufferedWriter) Write(p []byte) (int, error) {
-	bw.mu.Lock()
-	defer bw.mu.Unlock()
-	if bw.buf == nil {
-		return bw.w.Write(p)
-	}
-	return bw.buf.Write(p)
-}
-
-func (bw *bufferedWriter) resume() {
-	bw.mu.Lock()
-	defer bw.mu.Unlock()
-	if bw.buf == nil {
-		return
-	}
-	io.Copy(bw.w, bw.buf)
-	bw.buf = nil
 }

--- a/util/logutil/pause_test.go
+++ b/util/logutil/pause_test.go
@@ -1,0 +1,91 @@
+package logutil
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestPauseConcurrent(t *testing.T) {
+	logger := logrus.New()
+	logger.SetOutput(&bytes.Buffer{})
+
+	firstResume := Pause(logger)
+	resumed := make(chan struct{})
+	go func() {
+		Pause(logger)()
+		close(resumed)
+	}()
+
+	select {
+	case <-resumed:
+	case <-time.After(time.Second):
+		t.Fatal("concurrent pause waited for active pause")
+	}
+
+	firstResume()
+}
+
+func TestPauseInitializationConcurrent(t *testing.T) {
+	logger := logrus.New()
+	logger.SetOutput(&bytes.Buffer{})
+
+	start := make(chan struct{})
+	resumes := make(chan func(), 2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			<-start
+			resumes <- Pause(logger)
+		}()
+	}
+
+	close(start)
+	for i := 0; i < 2; i++ {
+		(<-resumes)()
+	}
+}
+
+func TestPauseBuffersOverlappingOutput(t *testing.T) {
+	output := &bytes.Buffer{}
+	logger := logrus.New()
+	logger.SetOutput(output)
+
+	firstResume := Pause(logger)
+	secondResume := Pause(logger)
+	logger.Print("message")
+	secondResume()
+
+	if output.Len() != 0 {
+		t.Fatalf("got output before all pauses resumed: %q", output.String())
+	}
+
+	firstResume()
+	if !strings.Contains(output.String(), "message") {
+		t.Fatalf("missing buffered output: %q", output.String())
+	}
+}
+
+func TestPauseResumeIsIdempotent(t *testing.T) {
+	output := &bytes.Buffer{}
+	logger := logrus.New()
+	logger.SetOutput(output)
+
+	firstResume := Pause(logger)
+	secondResume := Pause(logger)
+
+	firstResume()
+	firstResume()
+
+	logger.Print("message")
+	if output.Len() != 0 {
+		t.Fatalf("double resume cancelled a sibling pause: %q", output.String())
+	}
+
+	secondResume()
+	if !strings.Contains(output.String(), "message") {
+		t.Fatalf("missing buffered output: %q", output.String())
+	}
+}


### PR DESCRIPTION
### Problem

`logutil.Pause` mutates the shared logger's output on every call:

```go
func Pause(l *logrus.Logger) func() {
	l.Formatter.Format(logrus.NewEntry(l))
	bw := newBufferedWriter(l.Out)
	l.SetOutput(bw)          // write to l.Out
	return func() { bw.resume() }
}
```

`Printer.updateDisplay` calls `Pause(logrus.StandardLogger())` and holds it
(via `defer resumeLogs()`) for the printer's entire active period. When more
than one `Printer` runs at the same time in a single process — e.g. a tool
that drives several concurrent `build` operations — each one reads `l.Out`
and calls `l.SetOutput` on the same process-wide `logrus.StandardLogger()`
without synchronization:

```
WARNING: DATA RACE
Read at ... by goroutine A:
  logutil.Pause()            pause.go  (l.Out)
Previous write by goroutine B:
  logrus.(*Logger).SetOutput()
  logutil.Pause()            pause.go  (l.SetOutput)
```

### Fix

Install a single refcounting writer per logger instead of swapping the
logger's output on every `Pause`:

- The first `Pause` for a logger wraps `l.Out` once (formatter terminal-init
  still happens while `l.Out` is the real terminal) and stores the wrapper in
  a small guarded map.
- Each `Pause` increments a counter; each resume decrements it. Output is
  buffered while the count is > 0 and flushed, in order, when it returns to 0.
- `Pause` never blocks on another active pause, so concurrent printers keep
  running in parallel — only the interleaving of logrus output with the
  progress display is serialized, not the work itself.

### Test

`util/logutil/pause_test.go` (new) covers concurrent pause/resume, concurrent
first-time initialization (the raced path), overlapping-output buffering, and
resume idempotency. `go test -race ./util/logutil` fails on master and passes
with this change.
