### PR TITLE
Do not drop OS version when converting build options to solver option frontend attributes

### DIFF
--- a/build/opt.go
+++ b/build/opt.go
@@ -580,7 +580,7 @@ func toSolveOpt(ctx context.Context, np *noderesolver.ResolvedNode, multiDriver 
 	if len(opt.Platforms) != 0 {
 		pp := make([]string, len(opt.Platforms))
 		for i, p := range opt.Platforms {
-			pp[i] = platforms.Format(p)
+			pp[i] = platforms.FormatAll(p)
 		}
 		if len(pp) > 1 && !nodeDriver.Features(ctx)[driver.MultiPlatform] {
 			return nil, nil, notSupported(driver.MultiPlatform, nodeDriver, "https://docs.docker.com/go/build-multi-platform/")

--- a/tests/build.go
+++ b/tests/build.go
@@ -78,6 +78,7 @@ var buildTests = []func(t *testing.T, sb integration.Sandbox){
 	testBuildCacheExportNotSupported,
 	testBuildOCIExportNotSupported,
 	testBuildMultiPlatform,
+	testBuildTargetPlatformOSVersion,
 	testDockerHostGateway,
 	testBuildNetworkModeBridge,
 	testBuildShmSize,
@@ -1004,6 +1005,23 @@ func testBuildMultiPlatform(t *testing.T, sb integration.Sandbox) {
 		require.Error(t, err, string(out))
 		require.Contains(t, string(out), "Multi-platform build is not supported")
 	}
+}
+
+func testBuildTargetPlatformOSVersion(t *testing.T, sb integration.Sandbox) {
+	skipNoCompatBuildKit(t, sb, ">= 0.19.0-0", "platform OS version")
+	integration.SkipOnPlatform(t, "windows")
+
+	dockerfile := []byte(`
+FROM --platform=$BUILDPLATFORM busybox:latest
+ARG TARGETPLATFORM
+ARG TARGETOSVERSION
+RUN test "$TARGETPLATFORM" = "windows(10.0.17763)/amd64"
+RUN test "$TARGETOSVERSION" = "10.0.17763"
+`)
+	dir := tmpdir(t, fstest.CreateFile("Dockerfile", dockerfile, 0o600))
+
+	out, err := buildCmd(sb, withArgs("--platform=windows(10.0.17763)/amd64", "--output=type=cacheonly", dir))
+	require.NoError(t, err, string(out))
 }
 
 func testDockerHostGateway(t *testing.T, sb integration.Sandbox) {


### PR DESCRIPTION
Follow up to https://github.com/moby/buildkit/pull/5614

The process of converting `build.Options` to `client.SolveOpt` uses `platforms.Format()` to build the string, which does not include the OS version. This causes the OS version to be dropped: `buildx build --platform 'windows(10.0.17763)/amd64,windows(10.0.20348)/amd64,windows(10.0.26100)/amd64'` becomes `so.FrontendAttrs{"platform": "windows/amd64,windows/amd64,windows/amd64"}` when submitting the solve request.