### PR TITLE
build: retain sessions for linked target evaluation

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -428,7 +428,54 @@ type (
 	Handler      struct {
 		Evaluate EvaluateFunc
 	}
+	linkedTargetState struct {
+		results   *waitmap.Map
+		evaluated *waitmap.Map
+		completed *waitmap.Map
+		parents   map[string][]string
+		children  map[string][]string
+	}
 )
+
+func newLinkedTargetState(parents, children map[string][]string) *linkedTargetState {
+	return &linkedTargetState{
+		results:   waitmap.New(),
+		evaluated: waitmap.New(),
+		completed: waitmap.New(),
+		parents:   parents,
+		children:  children,
+	}
+}
+
+func (s *linkedTargetState) isLinked(key string) bool {
+	return len(s.parents[key]) > 0 || len(s.children[key]) > 0
+}
+
+func (s *linkedTargetState) run(ctx context.Context, key string, result any, evaluate func() error) error {
+	// Registration flows from parents to children. Waiting for every direct child
+	// here preserves external-cache lookup before evaluation begins.
+	s.results.Set(key, result)
+	children := s.children[key]
+	if _, err := s.results.Get(ctx, children...); err != nil {
+		return err
+	}
+	// Evaluation follows dependency order so the target's own session is attached
+	// to shared solver vertices before a dependent can evaluate them.
+	if _, err := s.evaluated.Get(ctx, s.parents[key]...); err != nil {
+		return err
+	}
+	if err := evaluate(); err != nil {
+		return err
+	}
+	s.evaluated.Set(key, struct{}{})
+	// Completion flows back from children to parents, retaining each parent job
+	// and its session until every dependent has finished evaluating.
+	if _, err := s.completed.Get(ctx, children...); err != nil {
+		return err
+	}
+	s.completed.Set(key, struct{}{})
+	return nil
+}
 
 func Build(ctx context.Context, nodes []builder.Node, opts map[string]Options, docker *dockerutil.Client, cfg *confutil.Config, w progress.Writer) (resp map[string]*client.SolveResponse, err error) {
 	return BuildWithResultHandler(ctx, nodes, opts, docker, cfg, w, nil)
@@ -476,10 +523,12 @@ func BuildWithResultHandler(ctx context.Context, nodes []builder.Node, opts map[
 
 	resp = map[string]*client.SolveResponse{}
 	var respMu sync.Mutex
-	results := waitmap.New()
 
 	multiTarget := len(opts) > 1
-	childTargets := calculateChildTargets(reqForNodes, opts)
+	linkedTargets := newLinkedTargetState(calculateTargetLinks(reqForNodes, opts))
+	// linkedClients is only accessed from the synchronous part of the target
+	// loop below, before any goroutines are spawned; no mutex needed.
+	linkedClients := make(map[string]*client.Client)
 
 	for k, opt := range opts {
 		err := func(k string) (err error) {
@@ -538,7 +587,21 @@ func BuildWithResultHandler(ctx context.Context, nodes []builder.Node, opts map[
 
 				pw := progress.WithPrefix(w, k, multiTarget)
 
-				c, err := dp.Client(ctx)
+				rKey := resultKey(dp, k)
+				var c *client.Client
+				if node.Driver != nil && node.Driver.RequiresUncachedClient() && linkedTargets.isLinked(rKey) {
+					// linked targets need to share a client so their sessions and
+					// shared solver vertices land on the same daemon instance
+					c = linkedClients[node.Name]
+					if c == nil {
+						c, err = dp.Client(ctx)
+						if err == nil {
+							linkedClients[node.Name] = c
+						}
+					}
+				} else {
+					c, err = dp.Client(ctx)
+				}
 				if err != nil {
 					return err
 				}
@@ -574,7 +637,7 @@ func BuildWithResultHandler(ctx context.Context, nodes []builder.Node, opts map[
 
 					pw = progress.ResetTime(pw)
 
-					if err := waitContextDeps(ctx, dp, results, so); err != nil {
+					if err := waitContextDeps(ctx, dp, linkedTargets.results, so); err != nil {
 						return err
 					}
 
@@ -625,30 +688,19 @@ func BuildWithResultHandler(ctx context.Context, nodes []builder.Node, opts map[
 							callRes = res.Metadata
 						}
 
-						rKey := resultKey(dp, k)
-						results.Set(rKey, res)
-
-						forceEval := false
-						if children := childTargets[rKey]; len(children) > 0 {
-							// wait for the child targets to register their LLB before evaluating
-							_, err := results.Get(ctx, children...)
-							if err != nil {
-								return nil, err
+						if err := linkedTargets.run(ctx, rKey, res, func() error {
+							// invoke custom evaluate handler if it is present
+							if bh != nil && bh.Evaluate != nil {
+								return bh.Evaluate(ctx, k, c, res, opt)
 							}
-							forceEval = true
-						}
-
-						// invoke custom evaluate handler if it is present
-						if bh != nil && bh.Evaluate != nil {
-							if err := bh.Evaluate(ctx, k, c, res, opt); err != nil {
-								return nil, err
+							if linkedTargets.isLinked(rKey) {
+								return eachRefParallel(ctx, res, func(ctx context.Context, ref gateway.Reference) error {
+									return ref.Evaluate(ctx)
+								})
 							}
-						} else if forceEval {
-							if err := eachRefParallel(ctx, res, func(ctx context.Context, ref gateway.Reference) error {
-								return ref.Evaluate(ctx)
-							}); err != nil {
-								return nil, err
-							}
+							return nil
+						}); err != nil {
+							return nil, err
 						}
 						return res, nil
 					}
@@ -1137,22 +1189,25 @@ func detectSharedMounts(ctx context.Context, reqs map[string][]*reqForNode) (_ m
 	return sessions, nil
 }
 
-// calculateChildTargets returns all the targets that depend on current target for reverse index
-func calculateChildTargets(reqs map[string][]*reqForNode, opt map[string]Options) map[string][]string {
-	out := make(map[string][]string)
+// calculateTargetLinks returns direct dependencies and dependents for every linked target.
+func calculateTargetLinks(reqs map[string][]*reqForNode, opt map[string]Options) (map[string][]string, map[string][]string) {
+	parents := make(map[string][]string)
+	children := make(map[string][]string)
 	for name := range opt {
 		dps := reqs[name]
 		for i, dp := range dps {
 			so := reqs[name][i].so
 			for k, v := range so.FrontendAttrs {
 				if strings.HasPrefix(k, "context:") && strings.HasPrefix(v, "target:") {
-					target := resultKey(dp.ResolvedNode, strings.TrimPrefix(v, "target:"))
-					out[target] = append(out[target], resultKey(dp.ResolvedNode, name))
+					parent := resultKey(dp.ResolvedNode, strings.TrimPrefix(v, "target:"))
+					child := resultKey(dp.ResolvedNode, name)
+					parents[child] = append(parents[child], parent)
+					children[parent] = append(children[parent], child)
 				}
 			}
 		}
 	}
-	return out
+	return parents, children
 }
 
 func waitContextDeps(ctx context.Context, node *noderesolver.ResolvedNode, results *waitmap.Map, so *client.SolveOpt) error {

--- a/build/linked_targets_test.go
+++ b/build/linked_targets_test.go
@@ -1,0 +1,151 @@
+package build
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLinkedTargetStateIsLinked(t *testing.T) {
+	state := newLinkedTargetState(
+		map[string][]string{"child": {"parent"}},
+		map[string][]string{"parent": {"child"}},
+	)
+	require.True(t, state.isLinked("parent"))
+	require.True(t, state.isLinked("child"))
+	require.False(t, state.isLinked("standalone"))
+}
+
+func TestLinkedTargetStateChainRetainsParents(t *testing.T) {
+	parents := map[string][]string{
+		"middle": {"root"},
+		"leaf":   {"middle"},
+	}
+	children := map[string][]string{
+		"root":   {"middle"},
+		"middle": {"leaf"},
+	}
+	state := newLinkedTargetState(parents, children)
+
+	leafStarted := make(chan struct{})
+	releaseLeaf := make(chan struct{})
+	done := map[string]chan error{
+		"root":   make(chan error, 1),
+		"middle": make(chan error, 1),
+		"leaf":   make(chan error, 1),
+	}
+
+	go func() {
+		done["root"] <- state.run(t.Context(), "root", struct{}{}, func() error { return nil })
+	}()
+	go func() {
+		done["middle"] <- state.run(t.Context(), "middle", struct{}{}, func() error { return nil })
+	}()
+	go func() {
+		done["leaf"] <- state.run(t.Context(), "leaf", struct{}{}, func() error {
+			close(leafStarted)
+			<-releaseLeaf
+			return nil
+		})
+	}()
+
+	select {
+	case <-leafStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("leaf evaluation did not start")
+	}
+	assertNotCompleted(t, done["root"])
+	assertNotCompleted(t, done["middle"])
+	close(releaseLeaf)
+	require.NoError(t, <-done["leaf"])
+	require.NoError(t, <-done["middle"])
+	require.NoError(t, <-done["root"])
+}
+
+func TestLinkedTargetStateDiamondEvaluatesBranchesInParallel(t *testing.T) {
+	parents := map[string][]string{
+		"left":  {"root"},
+		"right": {"root"},
+		"leaf":  {"left", "right"},
+	}
+	children := map[string][]string{
+		"root":  {"left", "right"},
+		"left":  {"leaf"},
+		"right": {"leaf"},
+	}
+	state := newLinkedTargetState(parents, children)
+
+	branchesStarted := make(chan string, 2)
+	releaseBranches := make(chan struct{})
+	done := make(chan error, 4)
+	run := func(key string, evaluate func() error) {
+		go func() {
+			done <- state.run(t.Context(), key, struct{}{}, evaluate)
+		}()
+	}
+	run("root", func() error { return nil })
+	for _, key := range []string{"left", "right"} {
+		run(key, func() error {
+			branchesStarted <- key
+			<-releaseBranches
+			return nil
+		})
+	}
+	leafStarted := make(chan struct{})
+	run("leaf", func() error {
+		close(leafStarted)
+		return nil
+	})
+
+	started := map[string]bool{}
+	for range 2 {
+		select {
+		case key := <-branchesStarted:
+			started[key] = true
+		case <-time.After(5 * time.Second):
+			t.Fatal("linked branches did not evaluate in parallel")
+		}
+	}
+	require.Equal(t, map[string]bool{"left": true, "right": true}, started)
+	assertNotSignaled(t, leafStarted)
+	close(releaseBranches)
+	for range 4 {
+		require.NoError(t, <-done)
+	}
+}
+
+func TestLinkedTargetStateCancellation(t *testing.T) {
+	state := newLinkedTargetState(
+		map[string][]string{"child": {"missing-parent"}},
+		map[string][]string{},
+	)
+	ctx, cancel := context.WithCancelCause(t.Context())
+	cause := errors.New("target failed")
+	done := make(chan error, 1)
+	go func() {
+		done <- state.run(ctx, "child", struct{}{}, func() error { return nil })
+	}()
+	cancel(cause)
+	require.ErrorIs(t, <-done, cause)
+}
+
+func assertNotCompleted(t *testing.T, ch <-chan error) {
+	t.Helper()
+	select {
+	case err := <-ch:
+		require.Failf(t, "target completed early", "unexpected error: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func assertNotSignaled(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-ch:
+		require.Fail(t, "target evaluated early")
+	case <-time.After(100 * time.Millisecond):
+	}
+}

--- a/tests/bake.go
+++ b/tests/bake.go
@@ -52,6 +52,7 @@ var bakeTests = []func(t *testing.T, sb integration.Sandbox){
 	testBakeRemoteAuth,
 	testBakeRemoteCmdContext,
 	testBakeRemoteLocalOverride,
+	testBakeRemoteLinkedTargetSecrets,
 	testBakeLocalCwdOverride,
 	testBakeRemoteCmdContextOverride,
 	testBakeRemoteContextSubdir,
@@ -1085,6 +1086,125 @@ EOT
 	require.NoError(t, err, out)
 
 	require.FileExists(t, filepath.Join(dirDest, "bar"))
+}
+
+func testBakeRemoteLinkedTargetSecrets(t *testing.T, sb integration.Sandbox) {
+	// Regression test for https://github.com/docker/buildx/issues/4011.
+	remoteBakefile := []byte(`
+target "base" {
+	output = ["type=cacheonly"]
+	dockerfile-inline = <<EOT
+FROM busybox
+EOT
+}
+
+target "source-prep" {
+	contexts = {
+		base = "target:base"
+	}
+	secret = ["id=SECRET1"]
+	output = ["type=cacheonly"]
+	dockerfile-inline = <<EOT
+FROM base
+RUN --mount=type=secret,id=SECRET1,env=SECRET1 [ -n "$SECRET1" ] && echo $SECRET1 > /secret1
+EOT
+}
+
+target "vs" {
+	contexts = {
+		base = "target:base"
+		source-prep = "target:source-prep"
+	}
+	output = ["type=cacheonly"]
+	dockerfile-inline = <<EOT
+FROM base
+COPY --from=source-prep /secret1 /
+EOT
+}
+`)
+	localBakefile := []byte(`
+target "vs-console" {
+	contexts = {
+		base = "target:vs"
+	}
+	secret = ["id=SECRET2"]
+	output = ["type=cacheonly"]
+	dockerfile-inline = <<EOT
+FROM base
+RUN --mount=type=secret,id=SECRET2,env=SECRET2 [ -n "$SECRET2" ] && echo $SECRET2 > /secret2
+EOT
+}
+
+target "default" {
+	contexts = {
+		base = "target:vs-console"
+		source-prep = "target:source-prep"
+	}
+	output = ["type=cacheonly"]
+	dockerfile-inline = <<EOT
+FROM base
+COPY --from=source-prep /secret1 /secret1_copy
+EOT
+}
+`)
+	remoteDir := tmpdir(
+		t,
+		fstest.CreateFile("docker-bake.hcl", remoteBakefile, 0600),
+	)
+	localDir := tmpdir(
+		t,
+		fstest.CreateFile("docker-bake.hcl", localBakefile, 0600),
+	)
+
+	git, err := gitutil.New(bkgitutil.WithDir(remoteDir))
+	require.NoError(t, err)
+	gittestutil.GitInit(git, t)
+	gittestutil.GitAdd(git, t, "docker-bake.hcl")
+	gittestutil.GitCommit(git, t, "initial commit")
+	addr := gittestutil.GitServeHTTP(git, t)
+
+	run := func(outputDir string, target ...string) (string, error) {
+		args := []string{
+			"bake",
+			"--no-cache",
+			"--progress=plain",
+			"--file=cwd://docker-bake.hcl",
+		}
+		if outputDir != "" {
+			args = append(args, "--set", "default.output=type=local,dest="+outputDir)
+		}
+		args = append(args, addr)
+		args = append(args, target...)
+		cmd := buildxCmd(
+			sb,
+			withDir(localDir),
+			withEnv("SECRET1=foo", "SECRET2=bar"),
+			withArgs(args...),
+		)
+		out, err := cmd.CombinedOutput()
+		return string(out), err
+	}
+
+	// Directly building the secret-bearing target is the non-racy control.
+	out, err := run("", "source-prep")
+	require.NoError(t, err, out)
+
+	// The linked graph has multiple jobs sharing the same secret-consuming LLB
+	// vertex. Repeat the invocation to exercise session selection timing.
+	const attempts = 5
+	for i := 1; i <= attempts; i++ {
+		outputDir := t.TempDir()
+		out, err := run(outputDir)
+		require.NoErrorf(t, err, "linked target attempt %d/%d failed:\n%s", i, attempts, out)
+		require.FileExists(t, filepath.Join(outputDir, "secret1_copy"))
+		require.FileExists(t, filepath.Join(outputDir, "secret2"))
+		secret1, err := os.ReadFile(filepath.Join(outputDir, "secret1_copy"))
+		require.NoError(t, err)
+		require.Equal(t, "foo\n", string(secret1))
+		secret2, err := os.ReadFile(filepath.Join(outputDir, "secret2"))
+		require.NoError(t, err)
+		require.Equal(t, "bar\n", string(secret2))
+	}
 }
 
 func testBakeLocalCwdOverride(t *testing.T, sb integration.Sandbox) {


### PR DESCRIPTION
fixes #4011

Order linked target evaluation by dependency and retain producer sessions until dependent targets finish evaluating shared solver vertices.

Reuse uncached clients for linked targets and add regression coverage for secret-bearing Bake target graphs.