### PR TITLE
bake/hclparser: use testify instead of manually using go-spew

### DIFF
--- a/bake/hclparser/gohcl/decode_test.go
+++ b/bake/hclparser/gohcl/decode_test.go
@@ -9,9 +9,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/hcl/v2"
 	hclJSON "github.com/hashicorp/hcl/v2/json"
+	"github.com/stretchr/testify/assert"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -699,9 +699,7 @@ func TestDecodeBody(t *testing.T) {
 				}
 			}
 			got := targetVal.Elem().Interface()
-			if !test.Check(got) {
-				t.Errorf("wrong result\ngot:  %s", spew.Sdump(got))
-			}
+			assert.Truef(t, test.Check(got), "wrong result\ngot: %#v", got)
 		})
 	}
 }

--- a/bake/hclparser/gohcl/schema_test.go
+++ b/bake/hclparser/gohcl/schema_test.go
@@ -5,11 +5,10 @@ package gohcl
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestImpliedBodySchema(t *testing.T) {
@@ -215,19 +214,8 @@ func TestImpliedBodySchema(t *testing.T) {
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%#v", test.val), func(t *testing.T) {
 			schema, partial := ImpliedBodySchema(test.val)
-			if !reflect.DeepEqual(schema, test.wantSchema) {
-				t.Errorf(
-					"wrong schema\ngot:  %s\nwant: %s",
-					spew.Sdump(schema), spew.Sdump(test.wantSchema),
-				)
-			}
-
-			if partial != test.wantPartial {
-				t.Errorf(
-					"wrong partial flag\ngot:  %#v\nwant: %#v",
-					partial, test.wantPartial,
-				)
-			}
+			assert.Equal(t, test.wantSchema, schema, "wrong schema")
+			assert.Equal(t, test.wantPartial, partial, "wrong partial flag")
 		})
 	}
 }

--- a/bake/hclparser/merged_test.go
+++ b/bake/hclparser/merged_test.go
@@ -5,11 +5,11 @@ package hclparser
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMergedBodiesContent(t *testing.T) {
@@ -348,9 +348,7 @@ func TestMergedBodiesContent(t *testing.T) {
 				}
 			}
 
-			if !reflect.DeepEqual(got, test.Want) {
-				t.Errorf("wrong result\ngot:  %s\nwant: %s", spew.Sdump(got), spew.Sdump(test.Want))
-			}
+			require.Equal(t, test.Want, got, "wrong result")
 		})
 	}
 }
@@ -551,13 +549,8 @@ func TestMergeBodiesPartialContent(t *testing.T) {
 				}
 			}
 
-			if !reflect.DeepEqual(got, test.WantContent) {
-				t.Errorf("wrong content result\ngot:  %s\nwant: %s", spew.Sdump(got), spew.Sdump(test.WantContent))
-			}
-
-			if !reflect.DeepEqual(gotRemain, test.WantRemain) {
-				t.Errorf("wrong remaining result\ngot:  %s\nwant: %s", spew.Sdump(gotRemain), spew.Sdump(test.WantRemain))
-			}
+			assert.Equal(t, test.WantContent, got, "wrong content result")
+			assert.Equal(t, test.WantRemain, gotRemain, "wrong remaining result")
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/containerd/log v0.1.0
 	github.com/containerd/platforms v1.0.0-rc.4
 	github.com/creack/pty v1.1.24
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/distribution/reference v0.6.0
 	github.com/docker/cli v29.6.2+incompatible
 	github.com/docker/cli-docs-tool v0.11.0
@@ -107,6 +106,7 @@ require (
 	github.com/containerd/typeurl/v2 v2.3.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect
 	github.com/digitorus/pkcs7 v0.0.0-20230818184609-3a137a874352 // indirect
 	github.com/digitorus/timestamp v0.0.0-20231217203849-220c5c2851b7 // indirect


### PR DESCRIPTION
- relates to https://github.com/docker/buildx/pull/4015