### PR TITLE
vendor: github.com/sirupsen/logrus v1.10.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10
 	github.com/serialx/hashring v0.0.0-20200727003509-22c0c7ab6b1b
 	github.com/sigstore/sigstore-go v1.2.2
-	github.com/sirupsen/logrus v1.10.0
+	github.com/sirupsen/logrus v1.10.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -515,8 +515,8 @@ github.com/sigstore/sigstore/pkg/signature/kms/hashivault v1.10.8 h1:1DGe4/clcdO
 github.com/sigstore/sigstore/pkg/signature/kms/hashivault v1.10.8/go.mod h1:6IDFhpgxtzqbnzrFkyegbj7RfWwKeRrb3/+xAD1Wp+Y=
 github.com/sigstore/timestamp-authority/v2 v2.1.2 h1:7DDhnknLL4w8VwomyvW2W8qblOS9LDR8oihna+jc7Ls=
 github.com/sigstore/timestamp-authority/v2 v2.1.2/go.mod h1:o6rAVZceFyejClIj/uStRNIemP16bVMZtbMmhk6pr0U=
-github.com/sirupsen/logrus v1.10.0 h1:T8MxJJXVZkfcC5zSRMRAg2F8+lxjmUCGGWPzFxO+Msc=
-github.com/sirupsen/logrus v1.10.0/go.mod h1:FXZFonkDAnFozmO+5hGAFvB0Yg9/j2SIhA/QuIkP180=
+github.com/sirupsen/logrus v1.10.1 h1:xi4336Zh11WpU14fXR6I67V3yaTPQYwRx2WEtHbRg4Q=
+github.com/sirupsen/logrus v1.10.1/go.mod h1:vsQHnG7xzNsxk3NrwboUiWPnIC3dmbjcGPykD7+tiHk=
 github.com/spdx/tools-golang v0.5.7 h1:+sWcKGnhwp3vLdMqPcLdA6QK679vd86cK9hQWH3AwCg=
 github.com/spdx/tools-golang v0.5.7/go.mod h1:jg7w0LOpoNAw6OxKEzCoqPC2GCTj45LyTlVmXubDsYw=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=

--- a/vendor/github.com/sirupsen/logrus/CHANGELOG.md
+++ b/vendor/github.com/sirupsen/logrus/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.10.1
+
+Fixes:
+
+  * Fix a regression introduced in v1.10.0 where `TextFormatter` could panic
+    when formatting nil or panicking `error` and `fmt.Stringer` values.
+  * Allow function-backed implementations of `error` as field values.
+
 ## 1.10.0
 
 Fixes:

--- a/vendor/github.com/sirupsen/logrus/entry.go
+++ b/vendor/github.com/sirupsen/logrus/entry.go
@@ -159,15 +159,7 @@ func (entry *Entry) String() (string, error) {
 // WithError adds an error as single field (using the key defined in [ErrorKey])
 // to the Entry.
 func (entry *Entry) WithError(err error) *Entry {
-	// Avoid reflection work in WithFields; we know the type is an error;
-	// copy the entry data and set the ErrorKey directly.
-	dup := entry.dup()
-	dup.Data = maps.Clone(entry.Data)
-	if dup.Data == nil {
-		dup.Data = make(Fields, 1)
-	}
-	dup.Data[ErrorKey] = err
-	return dup
+	return entry.WithField(ErrorKey, err)
 }
 
 // WithContext adds a context to the Entry.
@@ -182,18 +174,7 @@ func (entry *Entry) WithContext(ctx context.Context) *Entry {
 func (entry *Entry) WithField(key string, value any) *Entry {
 	dup := entry.dup()
 	dup.Data = maps.Clone(entry.Data)
-	if isInvalidField(value) {
-		if dup.err != "" {
-			dup.err += ", skipping unsupported field " + strconv.Quote(key)
-		} else {
-			dup.err = "skipping unsupported field " + strconv.Quote(key)
-		}
-		return dup
-	}
-	if dup.Data == nil {
-		dup.Data = make(Fields, 1)
-	}
-	dup.Data[key] = value
+	dup.addField(key, value)
 	return dup
 }
 
@@ -204,25 +185,9 @@ func (entry *Entry) WithFields(fields Fields) *Entry {
 	maps.Copy(dup.Data, entry.Data)
 
 	for key, value := range fields {
-		if isInvalidField(value) {
-			if dup.err != "" {
-				dup.err += ", skipping unsupported field " + strconv.Quote(key)
-			} else {
-				dup.err = "skipping unsupported field " + strconv.Quote(key)
-			}
-		} else {
-			dup.Data[key] = value
-		}
+		dup.addField(key, value)
 	}
 	return dup
-}
-
-func isInvalidField(v any) bool {
-	t := reflect.TypeOf(v)
-	if t == nil {
-		return false
-	}
-	return t.Kind() == reflect.Func || t.Kind() == reflect.Pointer && t.Elem().Kind() == reflect.Func
 }
 
 // WithTime overrides the time of the Entry.
@@ -231,6 +196,25 @@ func (entry *Entry) WithTime(t time.Time) *Entry {
 	dup.Data = maps.Clone(entry.Data)
 	dup.Time = t
 	return dup
+}
+
+func (entry *Entry) addField(key string, value any) {
+	if _, ok := value.(error); !ok {
+		t := reflect.TypeOf(value)
+		if t != nil && (t.Kind() == reflect.Func || t.Kind() == reflect.Pointer && t.Elem().Kind() == reflect.Func) {
+			if entry.err != "" {
+				entry.err += ", skipping unsupported field " + strconv.Quote(key)
+			} else {
+				entry.err = "skipping unsupported field " + strconv.Quote(key)
+			}
+			return
+		}
+	}
+
+	if entry.Data == nil {
+		entry.Data = make(Fields, 1)
+	}
+	entry.Data[key] = value
 }
 
 // getPackageName reduces a fully qualified function name to the package name

--- a/vendor/github.com/sirupsen/logrus/exported.go
+++ b/vendor/github.com/sirupsen/logrus/exported.go
@@ -55,7 +55,7 @@ func AddHook(hook Hook) {
 // WithError creates an entry from the standard logger and adds an error to it,
 // using the value defined in [ErrorKey] as key.
 func WithError(err error) *Entry {
-	return std.WithField(ErrorKey, err)
+	return std.WithError(err)
 }
 
 // WithContext creates an entry from the standard logger and adds a context to it.

--- a/vendor/github.com/sirupsen/logrus/text_formatter.go
+++ b/vendor/github.com/sirupsen/logrus/text_formatter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"os"
+	"reflect"
 	"runtime"
 	"slices"
 	"strconv"
@@ -329,10 +330,10 @@ func (f *TextFormatter) appendValue(b *bytes.Buffer, value any) {
 		f.appendBytes(b, strconv.AppendBool(raw[:0], v))
 		return
 	case error:
-		f.appendString(b, v.Error())
+		f.appendError(b, v)
 		return
 	case fmt.Stringer:
-		f.appendString(b, v.String())
+		f.appendStringer(b, v)
 		return
 	}
 
@@ -415,6 +416,29 @@ func (f *TextFormatter) appendNumeric(b *bytes.Buffer, out []byte) {
 		return
 	}
 	b.Write(out)
+}
+
+func (f *TextFormatter) appendError(b *bytes.Buffer, v error) {
+	defer f.recoverValue(b, v, "Error")
+
+	f.appendString(b, v.Error())
+}
+
+func (f *TextFormatter) appendStringer(b *bytes.Buffer, v fmt.Stringer) {
+	defer f.recoverValue(b, v, "String")
+
+	f.appendString(b, v.String())
+}
+
+func (f *TextFormatter) recoverValue(b *bytes.Buffer, v any, method string) {
+	if r := recover(); r != nil {
+		rv := reflect.ValueOf(v)
+		if rv.Kind() == reflect.Pointer && rv.IsNil() {
+			f.appendString(b, "<nil>")
+		} else {
+			f.appendString(b, fmt.Sprintf("%%!v(PANIC=%s method: %v)", method, r))
+		}
+	}
 }
 
 // needsQuoting returns true if the string contains any byte that

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1030,7 +1030,7 @@ github.com/sigstore/sigstore-go/pkg/verify
 # github.com/sigstore/timestamp-authority/v2 v2.1.2
 ## explicit; go 1.25.0
 github.com/sigstore/timestamp-authority/v2/pkg/verification
-# github.com/sirupsen/logrus v1.10.0
+# github.com/sirupsen/logrus v1.10.1
 ## explicit; go 1.23
 github.com/sirupsen/logrus
 # github.com/spf13/cobra v1.10.2


### PR DESCRIPTION
- fix a regression introduced in v1.10.0 where `TextFormatter` could panic when formatting nil or panicking `error` and `fmt.Stringer` values.
- allow function-backed values implementing `error` to be used with `WithError`, `WithField`, and `WithFields`.
- update github.com/stretchr/testify to v1.12.0

full diff: https://github.com/sirupsen/logrus/compare/v1.10.0...v1.10.1