### PR TITLE
build: avoid empty source policy sessions

### DIFF
--- a/build/opt.go
+++ b/build/opt.go
@@ -712,6 +712,10 @@ func configureSourcePolicy(ctx context.Context, np *noderesolver.ResolvedNode, o
 	if err != nil {
 		return nil, err
 	}
+	if len(loadedOpts) == 0 {
+		so.SourcePolicyProvider = nil
+		return defers, nil
+	}
 	var policyFiles []string
 	for _, popt := range loadedOpts {
 		for _, f := range popt.Files {

--- a/tests/policy_bake.go
+++ b/tests/policy_bake.go
@@ -1,15 +1,22 @@
 package tests
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/containerd/continuity/fs/fstest"
+	"github.com/docker/buildx/util/gitutil"
+	"github.com/docker/buildx/util/gitutil/gittestutil"
+	"github.com/moby/buildkit/identity"
+	bkgitutil "github.com/moby/buildkit/util/gitutil"
 	"github.com/moby/buildkit/util/testutil/integration"
 	"github.com/stretchr/testify/require"
 )
 
 var policyBakeTests = []func(t *testing.T, sb integration.Sandbox){
 	testBakePolicyConfigFlags,
+	testBakeRemoteGitNoPolicyWithProxyNetwork,
 }
 
 func testBakePolicyConfigFlags(t *testing.T, sb integration.Sandbox) {
@@ -207,4 +214,70 @@ target "disabled-combined" {
 			require.Contains(t, string(out), tc.wantErrContains)
 		})
 	}
+}
+
+func testBakeRemoteGitNoPolicyWithProxyNetwork(t *testing.T, sb integration.Sandbox) {
+	if !isDockerContainerWorker(sb) {
+		t.Skip("only testing with docker-container worker")
+	}
+	skipNoCompatBuildKit(t, sb, ">= 0.31.0-0", "network proxy requires BuildKit v0.31.0+")
+
+	dockerfile := []byte(`
+FROM alpine:latest
+RUN wget -qO- https://checkip.amazonaws.com/ | grep -Eq "^[0-9a-fA-F:.]+$"
+`)
+	bakeFile := []byte(`
+target "default" {
+  output = ["type=cacheonly"]
+}
+`)
+	dir := tmpdir(
+		t,
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+		fstest.CreateFile("docker-bake.hcl", bakeFile, 0600),
+	)
+
+	git, err := gitutil.New(bkgitutil.WithDir(dir))
+	require.NoError(t, err)
+	gittestutil.GitInit(git, t)
+	gittestutil.GitAdd(git, t, "Dockerfile", "docker-bake.hcl")
+	gittestutil.GitCommit(git, t, "initial commit")
+	addr := gittestutil.GitServeHTTP(git, t)
+
+	buildkitdConfPath := filepath.Join(t.TempDir(), "buildkitd.toml")
+	require.NoError(t, os.WriteFile(buildkitdConfPath, []byte("proxyNetwork = true\n"), 0600))
+
+	builderName := "proxy-network-" + identity.NewID()
+	var created bool
+	t.Cleanup(func() {
+		if !created {
+			return
+		}
+		out, err := rmCmd(sb, withArgs("-f", builderName))
+		require.NoError(t, err, out)
+	})
+
+	out, err := createCmd(sb, withArgs(
+		"--bootstrap",
+		"--name="+builderName,
+		"--driver=docker-container",
+		"--driver-opt", "network=host",
+		"--driver-opt", "image="+buildkitImage,
+		"--buildkitd-config="+buildkitdConfPath,
+	))
+	require.NoError(t, err, out)
+	created = true
+
+	cmd := buildxCmd(sb, withDir(t.TempDir()), withArgs(
+		"bake",
+		"--progress=plain",
+		"--no-cache",
+		"--builder", builderName,
+		addr,
+	))
+	outBytes, err := cmd.CombinedOutput()
+	out = string(outBytes)
+	require.NoError(t, err, out)
+	require.Contains(t, out, "proxy network requests:")
+	require.Contains(t, out, "GET https://checkip.amazonaws.com/ -> 200")
 }


### PR DESCRIPTION
Remote Git contexts can enqueue an optional `Dockerfile.rego` lookup even when the build doesn't include a policy file. When that optional file was absent, Buildx resolved zero policy files but still attached a no-op `SourcePolicyProvider`, which made the solve request carry a `SourcePolicySession`. That matters for builders created with `proxyNetwork = true`, because BuildKit treats the presence of a source policy session as part of proxy-network enforcement, so a Git-context could fail with a proxy `403 Forbidden` even though the same target succeeded from a local context.

The issue is reproducible with:

```
docker buildx bake --no-cache --builder <builder> "https://github.com/crazy-max/docker-github-builder.git?ref=proxy-network&subdir=test" proxy-network
```

against a docker-container builder using `moby/buildkit:v0.32.2` and `proxyNetwork = true`.

This change keeps `SourcePolicyProvider` unset when policy resolution loads no policy files, so builds without policies don't accidentally opt into source-policy session behavior.