### PR TITLE
commands: print lint warnings after --call output

### DIFF
--- a/commands/bake.go
+++ b/commands/bake.go
@@ -186,6 +186,7 @@ func runBake(ctx context.Context, dockerCli command.Cli, targets []string, in ba
 	progressMode := progressui.DisplayMode(cFlags.progress)
 
 	var printer *progress.Printer
+	printWarningsOnClose := true
 	defer func() {
 		if printer != nil {
 			printer.Wait()
@@ -198,7 +199,9 @@ func runBake(ctx context.Context, dockerCli command.Cli, targets []string, in ba
 			progress.WithDesc(progressTextDesc, progressConsoleDesc),
 			progress.WithMetrics(mp, attributes),
 			progress.WithOnClose(func() {
-				printWarnings(os.Stderr, printer.Warnings(), progressMode)
+				if printWarningsOnClose {
+					printWarnings(os.Stderr, printer.Warnings(), progressMode)
+				}
 			}),
 		)
 		return err
@@ -331,6 +334,13 @@ func runBake(ctx context.Context, dockerCli command.Cli, targets []string, in ba
 			} else {
 				opt.CallFunc.Name = cf.Name
 			}
+		}
+	}
+
+	for _, opt := range bo {
+		if opt.CallFunc != nil {
+			printWarningsOnClose = false
+			break
 		}
 	}
 
@@ -497,6 +507,10 @@ func runBake(ctx context.Context, dockerCli command.Cli, targets []string, in ba
 				fmt.Fprintf(dockerCli.Out(), "\n# %s\n%s\n", name, v)
 			}
 		}
+	}
+
+	if !printWarningsOnClose {
+		printWarnings(os.Stderr, printer.Warnings(), progressMode)
 	}
 
 	if exitCode != 0 {

--- a/commands/build.go
+++ b/commands/build.go
@@ -408,7 +408,9 @@ func runBuild(ctx context.Context, dockerCli command.Cli, debugOpts debuggerOpti
 		),
 		progress.WithMetrics(mp, attributes),
 		progress.WithOnClose(func() {
-			printWarnings(os.Stderr, printer.Warnings(), progressMode)
+			if opts.CallFunc == nil {
+				printWarnings(os.Stderr, printer.Warnings(), progressMode)
+			}
 		}),
 	)
 	if err != nil {
@@ -450,7 +452,9 @@ func runBuild(ctx context.Context, dockerCli command.Cli, debugOpts debuggerOpti
 		}
 	}
 	if opts.CallFunc != nil {
-		if exitCode, err := printResult(dockerCli.Out(), opts.CallFunc, resp.ExporterResponse, options.target, inputs); err != nil {
+		exitCode, err := printResult(dockerCli.Out(), opts.CallFunc, resp.ExporterResponse, options.target, inputs)
+		printWarnings(os.Stderr, printer.Warnings(), progressMode)
+		if err != nil {
 			return err
 		} else if exitCode != 0 {
 			return cobrautil.ExitCodeError(exitCode)


### PR DESCRIPTION
`--call outline` prints on stdout while vertex warnings were dumped from the progress printer's OnClose on stderr, so they could overlap the outline.

warnings still go to stderr, just after the call result.

Fixes #2973