### PR TITLE
commands: complete --platform values for build

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -26,6 +26,7 @@ import (
 	"github.com/docker/buildx/store/storeutil"
 	"github.com/docker/buildx/util/buildflags"
 	"github.com/docker/buildx/util/cobrautil"
+	"github.com/docker/buildx/util/cobrautil/completion"
 	"github.com/docker/buildx/util/confutil"
 	"github.com/docker/buildx/util/desktop"
 	"github.com/docker/buildx/util/dockerutil"
@@ -585,6 +586,7 @@ func buildCmd(dockerCli command.Cli, rootOpts *rootOptions, debugger debuggerOpt
 	flags.StringArrayVarP(&options.outputs, "output", "o", []string{}, `Output destination (format: "type=local,dest=path")`)
 
 	flags.StringArrayVar(&options.platforms, "platform", platformsDefault, "Set target platform for build")
+	cmd.RegisterFlagCompletionFunc("platform", completion.Platforms()) //nolint:errcheck
 
 	flags.StringArrayVar(&options.policy, "policy", []string{}, `Policy configuration (format: "filename=path[,filename=path][,reset=true|false][,disabled=true|false][,strict=true|false][,log-level=level]")`)
 

--- a/util/cobrautil/completion/completion.go
+++ b/util/cobrautil/completion/completion.go
@@ -60,3 +60,25 @@ func BuilderNames(dockerCli command.Cli) ValidArgsFn {
 		return filtered, cobra.ShellCompDirectiveNoFileComp
 	}
 }
+
+var commonPlatforms = []string{
+	"linux/386",
+	"linux/amd64",
+	"linux/arm",
+	"linux/arm/v5",
+	"linux/arm/v6",
+	"linux/arm/v7",
+	"linux/arm64",
+	"linux/arm64/v8",
+	"linux/ppc64le",
+	"linux/s390x",
+	"linux/riscv64",
+	"windows/amd64",
+	"wasip1/wasm",
+}
+
+func Platforms() ValidArgsFn {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return commonPlatforms, cobra.ShellCompDirectiveNoFileComp
+	}
+}

--- a/util/cobrautil/completion/completion_test.go
+++ b/util/cobrautil/completion/completion_test.go
@@ -1,0 +1,27 @@
+package completion
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestPlatforms(t *testing.T) {
+	values, directive := Platforms()(nil, nil, "")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Fatalf("directive = %v, want NoFileComp", directive)
+	}
+	if len(values) == 0 {
+		t.Fatal("expected platform completions")
+	}
+	want := map[string]bool{"linux/amd64": true, "linux/arm64": true, "windows/amd64": true}
+	got := map[string]bool{}
+	for _, v := range values {
+		got[v] = true
+	}
+	for p := range want {
+		if !got[p] {
+			t.Errorf("missing platform %q in %v", p, values)
+		}
+	}
+}


### PR DESCRIPTION
`docker buildx build --platform <TAB>` didn't complete anything. `docker build` already does.

same short platform list as the CLI, on the buildx flag.

related to docker/cli#5517