### PR TITLE
policy: pass registry auth to metadata resolver

### DIFF
--- a/commands/policy/eval.go
+++ b/commands/policy/eval.go
@@ -17,10 +17,13 @@ import (
 	"github.com/docker/buildx/builder"
 	"github.com/docker/buildx/policy"
 	"github.com/docker/buildx/util/confutil"
+	"github.com/docker/buildx/util/dockerutil/dockerconfig"
 	"github.com/docker/buildx/util/sourcemeta"
 	"github.com/docker/cli/cli/command"
 	"github.com/moby/buildkit/frontend/dockerui"
 	gwpb "github.com/moby/buildkit/frontend/gateway/pb"
+	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/session/auth/authprovider"
 	"github.com/moby/buildkit/solver/pb"
 	spb "github.com/moby/buildkit/sourcepolicy/pb"
 	"github.com/moby/buildkit/sourcepolicy/policysession"
@@ -107,7 +110,11 @@ func runEval(ctx context.Context, dockerCli command.Cli, source string, opts eva
 
 		p = workers[0].Platforms[0]
 	}
-	metaResolver := sourcemeta.NewResolver(c)
+
+	authProvider := authprovider.NewDockerAuthProvider(authprovider.DockerAuthProviderConfig{
+		AuthConfigProvider: dockerconfig.LoadAuthConfig(dockerCli),
+	})
+	metaResolver := sourcemeta.NewResolver(c, sourcemeta.WithSession([]session.Attachable{authProvider}))
 	defer metaResolver.Close()
 
 	platform := toPBPlatform(p)

--- a/commands/policy/test.go
+++ b/commands/policy/test.go
@@ -14,9 +14,12 @@ import (
 	"github.com/docker/buildx/policy"
 	"github.com/docker/buildx/util/cobrautil"
 	"github.com/docker/buildx/util/confutil"
+	"github.com/docker/buildx/util/dockerutil/dockerconfig"
 	"github.com/docker/buildx/util/sourcemeta"
 	"github.com/docker/cli/cli/command"
 	gwpb "github.com/moby/buildkit/frontend/gateway/pb"
+	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/session/auth/authprovider"
 	"github.com/moby/buildkit/solver/pb"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -204,7 +207,10 @@ func (r *policyTestOptionsProvider) init(ctx context.Context) error {
 			OS:           defaultPlatform.OS,
 			Variant:      defaultPlatform.Variant,
 		}
-		r.metaResolver = sourcemeta.NewResolver(c)
+		authProvider := authprovider.NewDockerAuthProvider(authprovider.DockerAuthProviderConfig{
+			AuthConfigProvider: dockerconfig.LoadAuthConfig(r.dockerCli),
+		})
+		r.metaResolver = sourcemeta.NewResolver(c, sourcemeta.WithSession([]session.Attachable{authProvider}))
 	})
 	return r.err
 }


### PR DESCRIPTION
fixes https://github.com/docker/buildx/issues/3984

`docker buildx policy eval --fields` now uses the Docker CLI auth configuration when resolving image metadata. This allows policy evaluation to inspect metadata for images in registries that require authentication instead of falling back to anonymous registry access.