### PR TITLE
commands: refresh inspect timeout after bootstrap

### DIFF
--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -38,22 +38,24 @@ func runInspect(ctx context.Context, dockerCli command.Cli, in inspectOptions) e
 		return err
 	}
 
-	timeoutCtx, cancel := context.WithCancelCause(ctx)
-	if in.timeout > 0 {
-		timeoutCtx, _ = context.WithTimeoutCause(timeoutCtx, in.timeout, errors.WithStack(context.DeadlineExceeded)) //nolint:govet // no need to manually cancel this context as we already rely on parent
-	}
-	defer func() { cancel(errors.WithStack(context.Canceled)) }()
-
 	imageVerifier := policy.DefaultImageVerifier(confutil.NewConfig(dockerCli))
-	nodes, err := b.LoadNodes(timeoutCtx, builder.WithData(), builder.WithImageVerifier(imageVerifier))
+	loadNodes := func() ([]builder.Node, error) {
+		timeoutCtx, cancel := context.WithCancelCause(ctx)
+		if in.timeout > 0 {
+			timeoutCtx, _ = context.WithTimeoutCause(timeoutCtx, in.timeout, errors.WithStack(context.DeadlineExceeded)) //nolint:govet // no need to manually cancel this context as we already rely on parent
+		}
+		defer func() { cancel(errors.WithStack(context.Canceled)) }()
+		return b.LoadNodes(timeoutCtx, builder.WithData(), builder.WithImageVerifier(imageVerifier))
+	}
+
+	nodes, err := loadNodes()
 	if in.bootstrap {
 		var ok bool
-		ok, err = b.Boot(ctx)
-		if err != nil {
+		if ok, err = b.Boot(ctx); err != nil {
 			return err
 		}
 		if ok {
-			nodes, err = b.LoadNodes(timeoutCtx, builder.WithData(), builder.WithImageVerifier(imageVerifier))
+			nodes, err = loadNodes()
 		}
 	}
 


### PR DESCRIPTION
fixes https://github.com/docker/buildx/issues/1935
closes https://github.com/docker/buildx/pull/4038

`docker buildx inspect --bootstrap` can print stale node status when the initial status load consumes the inspect timeout while bootstrap is still waiting for the builder to become ready. The subsequent reload now gets its own timeout window, so inspect can report the freshly booted node state instead of reusing an expired context.

This keeps the existing bootstrap behavior intact and only changes the timeout scope used by inspect status loading.