### PR TITLE
build: fix partial multi-node image pushes

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -433,29 +433,35 @@ func toRepoOnly(in string) (string, error) {
 }
 
 func prepareMultiDriverExports(so *client.SolveOpt, pushNames *string, insecurePush *bool) error {
-	for i, e := range so.Exports {
+	var pushPrepared bool
+	for i := range so.Exports {
+		e := &so.Exports[i]
 		switch e.Type {
 		case "oci", "tar":
 			return errors.Errorf("%s for multi-node builds currently not supported", e.Type)
 		case "image":
-			if *pushNames == "" && e.Attrs["push"] != "" {
-				if ok, _ := strconv.ParseBool(e.Attrs["push"]); ok {
-					*pushNames = e.Attrs["name"]
-					if *pushNames == "" {
-						return errors.Errorf("tag is needed when pushing to registry")
-					}
-					names, err := toRepoOnly(e.Attrs["name"])
-					if err != nil {
-						return err
-					}
-					if ok, _ := strconv.ParseBool(e.Attrs["registry.insecure"]); ok {
-						*insecurePush = true
-					}
-					e.Attrs["name"] = names
-					e.Attrs["push-by-digest"] = "true"
-					so.Exports[i].Attrs = e.Attrs
+			if pushPrepared {
+				continue
+			}
+			if ok, _ := strconv.ParseBool(e.Attrs["push"]); !ok {
+				continue
+			}
+			if *pushNames == "" {
+				*pushNames = e.Attrs["name"]
+				if *pushNames == "" {
+					return errors.Errorf("tag is needed when pushing to registry")
+				}
+				if ok, _ := strconv.ParseBool(e.Attrs["registry.insecure"]); ok {
+					*insecurePush = true
 				}
 			}
+			names, err := toRepoOnly(e.Attrs["name"])
+			if err != nil {
+				return err
+			}
+			e.Attrs["name"] = names
+			e.Attrs["push-by-digest"] = "true"
+			pushPrepared = true
 		}
 	}
 	return nil

--- a/build/build.go
+++ b/build/build.go
@@ -432,6 +432,35 @@ func toRepoOnly(in string) (string, error) {
 	return strings.Join(out, ","), nil
 }
 
+func prepareMultiDriverExports(so *client.SolveOpt, pushNames *string, insecurePush *bool) error {
+	for i, e := range so.Exports {
+		switch e.Type {
+		case "oci", "tar":
+			return errors.Errorf("%s for multi-node builds currently not supported", e.Type)
+		case "image":
+			if *pushNames == "" && e.Attrs["push"] != "" {
+				if ok, _ := strconv.ParseBool(e.Attrs["push"]); ok {
+					*pushNames = e.Attrs["name"]
+					if *pushNames == "" {
+						return errors.Errorf("tag is needed when pushing to registry")
+					}
+					names, err := toRepoOnly(e.Attrs["name"])
+					if err != nil {
+						return err
+					}
+					if ok, _ := strconv.ParseBool(e.Attrs["registry.insecure"]); ok {
+						*insecurePush = true
+					}
+					e.Attrs["name"] = names
+					e.Attrs["push-by-digest"] = "true"
+					so.Exports[i].Attrs = e.Attrs
+				}
+			}
+		}
+	}
+	return nil
+}
+
 type (
 	EvaluateFunc func(ctx context.Context, name string, c gateway.Client, res *gateway.Result, opt Options) error
 	Handler      struct {
@@ -566,30 +595,8 @@ func BuildWithResultHandler(ctx context.Context, nodes []builder.Node, opts map[
 				node := dp.Node()
 				so := reqForNodes[k][i].so
 				if multiDriver {
-					for i, e := range so.Exports {
-						switch e.Type {
-						case "oci", "tar":
-							return errors.Errorf("%s for multi-node builds currently not supported", e.Type)
-						case "image":
-							if pushNames == "" && e.Attrs["push"] != "" {
-								if ok, _ := strconv.ParseBool(e.Attrs["push"]); ok {
-									pushNames = e.Attrs["name"]
-									if pushNames == "" {
-										return errors.Errorf("tag is needed when pushing to registry")
-									}
-									names, err := toRepoOnly(e.Attrs["name"])
-									if err != nil {
-										return err
-									}
-									if ok, _ := strconv.ParseBool(e.Attrs["registry.insecure"]); ok {
-										insecurePush = true
-									}
-									e.Attrs["name"] = names
-									e.Attrs["push-by-digest"] = "true"
-									so.Exports[i].Attrs = e.Attrs
-								}
-							}
-						}
+					if err := prepareMultiDriverExports(so, &pushNames, &insecurePush); err != nil {
+						return err
 					}
 				}
 

--- a/build/build_test.go
+++ b/build/build_test.go
@@ -35,6 +35,48 @@ func (d warnOutputDriver) IsMobyDriver() bool {
 	return d.moby
 }
 
+func TestPrepareMultiDriverExportsForEveryNode(t *testing.T) {
+	const taggedName = "registry.example.com/user/app:latest"
+	const secondaryName = "registry.example.com/user/secondary:latest"
+	newSolveOpt := func() *client.SolveOpt {
+		return &client.SolveOpt{
+			Exports: []client.ExportEntry{
+				{
+					Type: "image",
+					Attrs: map[string]string{
+						"name":              taggedName,
+						"push":              "true",
+						"registry.insecure": "true",
+					},
+				},
+				{
+					Type: "image",
+					Attrs: map[string]string{
+						"name": secondaryName,
+						"push": "true",
+					},
+				},
+			},
+		}
+	}
+	solveOpts := []*client.SolveOpt{newSolveOpt(), newSolveOpt()}
+
+	var pushNames string
+	var insecurePush bool
+	for _, so := range solveOpts {
+		require.NoError(t, prepareMultiDriverExports(so, &pushNames, &insecurePush))
+	}
+
+	require.Equal(t, taggedName, pushNames)
+	require.True(t, insecurePush)
+	for _, so := range solveOpts {
+		require.Equal(t, "registry.example.com/user/app", so.Exports[0].Attrs["name"])
+		require.Equal(t, "true", so.Exports[0].Attrs["push-by-digest"])
+		require.Equal(t, secondaryName, so.Exports[1].Attrs["name"])
+		require.NotContains(t, so.Exports[1].Attrs, "push-by-digest")
+	}
+}
+
 func TestWarnOnNoOutput(t *testing.T) {
 	cloudNodes := []builder.Node{{Driver: newWarnOutputDriver("cloud", false)}}
 	mobyNodes := []builder.Node{{Driver: newWarnOutputDriver("docker", true)}}

--- a/tests/build.go
+++ b/tests/build.go
@@ -67,6 +67,7 @@ var buildTests = []func(t *testing.T, sb integration.Sandbox){
 	testBuildRegistryExport,
 	testBuildRegistryExportAttestations,
 	testBuildRegistryExportNoDefaultOCIArtifact,
+	testBuildMultiNodePushFailureDoesNotPublishTag,
 	testBuildTarExport,
 	testBuildMobyFromLocalImage,
 	testBuildDetailsLink,
@@ -687,6 +688,34 @@ func requireLegacyAttestationStorage(t *testing.T, sb integration.Sandbox, ref s
 	require.NoError(t, err)
 	require.Nil(t, mfst.Subject)
 	require.NotEmpty(t, mfst.Layers)
+}
+
+func testBuildMultiNodePushFailureDoesNotPublishTag(t *testing.T, sb integration.Sandbox) {
+	if !isRemoteMultiNodeWorker(sb) {
+		t.Skip("only testing with remote multi-node worker")
+	}
+
+	dir := createTestProject(t)
+	err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte(`FROM alpine
+ARG TARGETARCH
+RUN if [ "$TARGETARCH" = arm64 ]; then exit 1; fi
+RUN echo "$TARGETARCH" > /platform
+`), 0644)
+	require.NoError(t, err)
+
+	registry, err := sb.NewRegistry()
+	if errors.Is(err, integration.ErrRequirements) {
+		t.Skip(err.Error())
+	}
+	require.NoError(t, err)
+
+	target := registry + "/buildx/partial-push:" + identity.NewID()
+
+	out, err := buildCmd(sb, withArgs("-t", target, "--push", "--platform=linux/amd64,linux/arm64", "--provenance=false", dir))
+	require.Error(t, err, string(out))
+
+	_, _, err = contentutil.ProviderFromRef(sb.Context(), target)
+	require.Error(t, err)
 }
 
 func testImageIDOutput(t *testing.T, sb integration.Sandbox) {


### PR DESCRIPTION
## Why

A failed multi-node registry build must not leave the requested tag pointing to a single-platform image. Commit [`de05d88f`](https://github.com/docker/buildx/commit/de05d88f6053ae750e22ce5c2a22ebea8f131128), `build: let drivers prepare solve options`, correctly gave each node an independent copy of its exporter attributes, exposing code that still depended on those attributes being shared. Only one node was switched to a repository-only digest push; another node could publish the final tag before every platform completed.

## Reproduction

Assume `repro` is a two-node builder where the first node handles `linux/arm64` and the second handles `linux/amd64`. Start with a tag that does not exist.

```dockerfile
FROM alpine
ARG TARGETARCH
RUN if [ "$TARGETARCH" = arm64 ]; then sleep 30; exit 1; fi
RUN echo "$TARGETARCH" > /platform
```

```console
docker buildx build \
  --builder repro \
  --platform linux/arm64,linux/amd64 \
  --tag registry.example/repro:test \
  --push .

# The build fails after the amd64 node has finished exporting.
docker buildx imagetools inspect registry.example/repro:test
```

On an affected version, the tag exists and contains only `linux/amd64`, even though the requested multi-platform build failed. Buildx never reaches the final manifest-list assembly because the arm64 solve failed.

## Fix

Before 0.37, every node shared the same exporter attribute map, so rewriting the first node implicitly rewrote the others. Once those maps were cloned, the target-wide `pushNames` guard caused later nodes to skip the rewrite.

`BuildWithResultHandler` loops over `dps`, one entry per node, and calls `prepareMultiDriverExports` with that node's `SolveOpt` on every iteration. Inside the helper, `pushPrepared` is local and therefore resets for each node, while `pushNames` remains target-wide and captures the final tag only once. Each node's first pushed image exporter is consequently changed to a repository-only digest push. Buildx publishes the requested tag only after every node succeeds and the manifest list is assembled. Additional image exporters keep their existing behavior.

## Notes

The first commit only extracts the existing exporter preparation. The second commit changes its behavior and adds the unit regression test. The third commit adds a `remote+multinode` integration test for the failed-push behavior.



