### PR TITLE
policy: normalize HTTP schemes, host casing, and default ports

### DIFF
--- a/policy/validate.go
+++ b/policy/validate.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/fs"
 	"maps"
-	"net"
 	"net/url"
 	"path"
 	"slices"
@@ -533,22 +532,13 @@ func (p *Policy) Print(ctx print.Context, msg string) error {
 	return nil
 }
 
-// httpHostForPolicy returns the host used in policy input.http.host.
-// Well-known default ports (http/80, https/443) are stripped so curl-style
-// URLs like https://example.com:443 match allow-lists that contain example.com.
-func httpHostForPolicy(scheme, host string) string {
-	h, port, err := net.SplitHostPort(host)
-	if err != nil {
-		return host
-	}
+func normalizeHTTPHost(u *url.URL) string {
+	port := strings.TrimLeft(u.Port(), "0")
 	switch {
-	case scheme == "https" && port == "443", scheme == "http" && port == "80":
-		if strings.Contains(h, ":") {
-			return "[" + h + "]"
-		}
-		return h
+	case u.Scheme == "http" && port == "80", u.Scheme == "https" && port == "443":
+		return strings.TrimSuffix(u.Host, ":"+u.Port())
 	default:
-		return host
+		return u.Host
 	}
 }
 
@@ -574,7 +564,7 @@ func sourceToInput(ctx context.Context, getVerifier PolicyVerifierProvider, src 
 		inp.HTTP = &HTTP{
 			URL:    src.Source.Identifier,
 			Schema: scheme,
-			Host:   httpHostForPolicy(scheme, u.Host),
+			Host:   normalizeHTTPHost(u),
 			Path:   u.Path,
 			Query:  u.Query(),
 		}

--- a/policy/validate.go
+++ b/policy/validate.go
@@ -533,13 +533,16 @@ func (p *Policy) Print(ctx print.Context, msg string) error {
 }
 
 func normalizeHTTPHost(u *url.URL) string {
+	host := u.Host
 	port := strings.TrimLeft(u.Port(), "0")
-	switch {
-	case u.Scheme == "http" && port == "80", u.Scheme == "https" && port == "443":
-		return strings.TrimSuffix(u.Host, ":"+u.Port())
-	default:
-		return u.Host
+	if u.Scheme == "http" && port == "80" || u.Scheme == "https" && port == "443" {
+		host = strings.TrimSuffix(host, ":"+u.Port())
 	}
+	// Preserve IPv6 zone identifiers, which may be case-sensitive interface names.
+	if i := strings.IndexByte(host, '%'); strings.HasPrefix(host, "[") && i >= 0 {
+		return strings.ToLower(host[:i]) + host[i:]
+	}
+	return strings.ToLower(host)
 }
 
 func sourceToInput(ctx context.Context, getVerifier PolicyVerifierProvider, src *gwpb.ResolveSourceMetaResponse, platform *ocispecs.Platform, logf func(logrus.Level, string)) (Input, []string, error) {
@@ -554,6 +557,7 @@ func sourceToInput(ctx context.Context, getVerifier PolicyVerifierProvider, src 
 	if !ok {
 		return inp, nil, errors.Errorf("invalid source identifier: %s", src.Source.Identifier)
 	}
+	scheme = strings.ToLower(scheme)
 
 	switch scheme {
 	case "http", "https":

--- a/policy/validate.go
+++ b/policy/validate.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/fs"
 	"maps"
+	"net"
 	"net/url"
 	"path"
 	"slices"
@@ -532,6 +533,25 @@ func (p *Policy) Print(ctx print.Context, msg string) error {
 	return nil
 }
 
+// httpHostForPolicy returns the host used in policy input.http.host.
+// Well-known default ports (http/80, https/443) are stripped so curl-style
+// URLs like https://example.com:443 match allow-lists that contain example.com.
+func httpHostForPolicy(scheme, host string) string {
+	h, port, err := net.SplitHostPort(host)
+	if err != nil {
+		return host
+	}
+	switch {
+	case scheme == "https" && port == "443", scheme == "http" && port == "80":
+		if strings.Contains(h, ":") {
+			return "[" + h + "]"
+		}
+		return h
+	default:
+		return host
+	}
+}
+
 func sourceToInput(ctx context.Context, getVerifier PolicyVerifierProvider, src *gwpb.ResolveSourceMetaResponse, platform *ocispecs.Platform, logf func(logrus.Level, string)) (Input, []string, error) {
 	var inp Input
 	var unknowns []string
@@ -554,7 +574,7 @@ func sourceToInput(ctx context.Context, getVerifier PolicyVerifierProvider, src 
 		inp.HTTP = &HTTP{
 			URL:    src.Source.Identifier,
 			Schema: scheme,
-			Host:   u.Host,
+			Host:   httpHostForPolicy(scheme, u.Host),
 			Path:   u.Path,
 			Query:  u.Query(),
 		}

--- a/policy/validate_test.go
+++ b/policy/validate_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"testing"
 	"time"
 
@@ -14,6 +15,8 @@ import (
 	slsa1 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v1"
 	gwpb "github.com/moby/buildkit/frontend/gateway/pb"
 	"github.com/moby/buildkit/solver/pb"
+	policyaction "github.com/moby/buildkit/sourcepolicy/pb"
+	"github.com/moby/buildkit/sourcepolicy/policysession"
 	policyverifier "github.com/moby/policy-helpers"
 	policyimage "github.com/moby/policy-helpers/image"
 	policytypes "github.com/moby/policy-helpers/types"
@@ -23,23 +26,34 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestHTTPHostForPolicy(t *testing.T) {
+func TestNormalizeHTTPHost(t *testing.T) {
 	tests := []struct {
 		scheme, host, want string
 	}{
 		{"https", "example.com", "example.com"},
 		{"https", "example.com:443", "example.com"},
 		{"http", "example.com:80", "example.com"},
+		{"https", ":443", ""},
+		{"http", ":80", ""},
+		{"https", "example.com:000443", "example.com"},
+		{"http", "example.com:00080", "example.com"},
+		{"https", "example.com:00080", "example.com:00080"},
+		{"http", "example.com:000443", "example.com:000443"},
+		{"https", "example.com:008443", "example.com:008443"},
+		{"http", "example.com:000", "example.com:000"},
+		{"https", "example.com:80", "example.com:80"},
+		{"http", "example.com:443", "example.com:443"},
 		{"https", "example.com:8443", "example.com:8443"},
 		{"http", "example.com:8080", "example.com:8080"},
 		{"https", "[2001:db8::1]", "[2001:db8::1]"},
 		{"https", "[2001:db8::1]:443", "[2001:db8::1]"},
+		{"https", "[2001:db8::1]:000443", "[2001:db8::1]"},
+		{"http", "[2001:db8::1]:00080", "[2001:db8::1]"},
 		{"https", "[2001:db8::1]:8443", "[2001:db8::1]:8443"},
-		{"https", "example.com:443", "example.com"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.scheme+" "+tt.host, func(t *testing.T) {
-			require.Equal(t, tt.want, httpHostForPolicy(tt.scheme, tt.host))
+			require.Equal(t, tt.want, normalizeHTTPHost(&url.URL{Scheme: tt.scheme, Host: tt.host}))
 		})
 	}
 }
@@ -68,6 +82,20 @@ func TestSourceToInputSingleSource(t *testing.T) {
 				Source: &pb.SourceOp{Identifier: "not-a-source"},
 			},
 			expErrMsg: "invalid source identifier: not-a-source",
+		},
+		{
+			name: "http-ipv6-without-brackets",
+			src: &gwpb.ResolveSourceMetaResponse{
+				Source: &pb.SourceOp{Identifier: "http://::1:443"},
+			},
+			expErrMsg: "failed to parse http source url",
+		},
+		{
+			name: "https-ipv6-without-brackets",
+			src: &gwpb.ResolveSourceMetaResponse{
+				Source: &pb.SourceOp{Identifier: "https://::1:443"},
+			},
+			expErrMsg: "failed to parse http source url",
 		},
 		{
 			name: "http-source-with-checksum-and-auth",
@@ -195,6 +223,36 @@ func TestSourceToInputSingleSource(t *testing.T) {
 					Checksum: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 				},
 			},
+		},
+		{
+			name: "http-empty-host-with-default-port",
+			src: &gwpb.ResolveSourceMetaResponse{
+				Source: &pb.SourceOp{Identifier: "http://:80"},
+			},
+			expInput: Input{
+				HTTP: &HTTP{
+					URL:    "http://:80",
+					Schema: "http",
+					Host:   "",
+					Query:  map[string][]string{},
+				},
+			},
+			expUnk: []string{"input.http.checksum"},
+		},
+		{
+			name: "https-empty-host-with-default-port",
+			src: &gwpb.ResolveSourceMetaResponse{
+				Source: &pb.SourceOp{Identifier: "https://:443"},
+			},
+			expInput: Input{
+				HTTP: &HTTP{
+					URL:    "https://:443",
+					Schema: "https",
+					Host:   "",
+					Query:  map[string][]string{},
+				},
+			},
+			expUnk: []string{"input.http.checksum"},
 		},
 		{
 			name: "https-non-default-port-kept-on-host",
@@ -984,6 +1042,59 @@ func TestSourceToInputSingleSource(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tc.expInput, inp)
 			require.Equal(t, tc.expUnk, unknowns)
+		})
+	}
+}
+
+func TestCheckPolicyHTTPHost(t *testing.T) {
+	for _, tc := range []struct {
+		url   string
+		allow bool
+	}{
+		{"https://example.com/", true},
+		{"https://example.com:443/", true},
+		{"http://example.com:80/", true},
+		{"https://example.com:000443/", true},
+		{"http://example.com:00080/", true},
+		{"https://example.com:00080/", false},
+		{"http://example.com:000443/", false},
+		{"https://example.com:008443/", false},
+		{"https://example.com:80/", false},
+		{"http://example.com:443/", false},
+		{"https://example.com:8443/", false},
+		{"https://[2001:db8::1]:443/", true},
+		{"https://[2001:db8::1]:000443/", true},
+		{"http://[2001:db8::1]:00080/", true},
+		{"https://[2001:db8::1]:8443/", false},
+	} {
+		t.Run(tc.url, func(t *testing.T) {
+			p := NewPolicy(Opt{
+				Files: []File{{
+					Filename: "policy.rego",
+					Data: []byte(`
+package docker
+
+default allow := false
+allow if input.http.host in ["example.com", "[2001:db8::1]"]
+decision := {"allow": allow}
+`),
+				}},
+			})
+
+			// Exec proxy requests do not include HTTP checksum metadata.
+			decision, next, err := p.CheckPolicy(t.Context(), &policysession.CheckPolicyRequest{
+				Source: &gwpb.ResolveSourceMetaResponse{
+					Source: &pb.SourceOp{Identifier: tc.url},
+				},
+			})
+			require.NoError(t, err)
+			require.Nil(t, next)
+			require.NotNil(t, decision)
+			want := policyaction.PolicyAction_DENY
+			if tc.allow {
+				want = policyaction.PolicyAction_ALLOW
+			}
+			require.Equal(t, want, decision.Action)
 		})
 	}
 }

--- a/policy/validate_test.go
+++ b/policy/validate_test.go
@@ -31,6 +31,9 @@ func TestNormalizeHTTPHost(t *testing.T) {
 		scheme, host, want string
 	}{
 		{"https", "example.com", "example.com"},
+		{"http", "Example.com", "example.com"},
+		{"https", "EXAMPLE.COM:000443", "example.com"},
+		{"https", "eXaMpLe.CoM:8443", "example.com:8443"},
 		{"https", "example.com:443", "example.com"},
 		{"http", "example.com:80", "example.com"},
 		{"https", ":443", ""},
@@ -46,6 +49,9 @@ func TestNormalizeHTTPHost(t *testing.T) {
 		{"https", "example.com:8443", "example.com:8443"},
 		{"http", "example.com:8080", "example.com:8080"},
 		{"https", "[2001:db8::1]", "[2001:db8::1]"},
+		{"https", "[2001:DB8::ABCD]:443", "[2001:db8::abcd]"},
+		{"https", "[FE80::ABCD%Eth0]:000443", "[fe80::abcd%Eth0]"},
+		{"https", "[FE80::ABCD%Eth0]:8443", "[fe80::abcd%Eth0]:8443"},
 		{"https", "[2001:db8::1]:443", "[2001:db8::1]"},
 		{"https", "[2001:db8::1]:000443", "[2001:db8::1]"},
 		{"http", "[2001:db8::1]:00080", "[2001:db8::1]"},
@@ -96,6 +102,54 @@ func TestSourceToInputSingleSource(t *testing.T) {
 				Source: &pb.SourceOp{Identifier: "https://::1:443"},
 			},
 			expErrMsg: "failed to parse http source url",
+		},
+		{
+			name: "http-mixed-case-scheme-and-host",
+			src: &gwpb.ResolveSourceMetaResponse{
+				Source: &pb.SourceOp{Identifier: "hTtP://User:PaSs@eXaMpLe.CoM:00080/Case/Path?Key=VaLuE#Frag"},
+			},
+			expInput: Input{
+				HTTP: &HTTP{
+					URL:    "hTtP://User:PaSs@eXaMpLe.CoM:00080/Case/Path?Key=VaLuE#Frag",
+					Schema: "http",
+					Host:   "example.com",
+					Path:   "/Case/Path",
+					Query:  map[string][]string{"Key": {"VaLuE"}},
+				},
+			},
+			expUnk: []string{"input.http.checksum"},
+		},
+		{
+			name: "https-mixed-case-host-with-non-default-port",
+			src: &gwpb.ResolveSourceMetaResponse{
+				Source: &pb.SourceOp{Identifier: "HTTPS://EXAMPLE.COM:8443/Case?Key=Value"},
+			},
+			expInput: Input{
+				HTTP: &HTTP{
+					URL:    "HTTPS://EXAMPLE.COM:8443/Case?Key=Value",
+					Schema: "https",
+					Host:   "example.com:8443",
+					Path:   "/Case",
+					Query:  map[string][]string{"Key": {"Value"}},
+				},
+			},
+			expUnk: []string{"input.http.checksum"},
+		},
+		{
+			name: "https-ipv6-zone-case-preserved",
+			src: &gwpb.ResolveSourceMetaResponse{
+				Source: &pb.SourceOp{Identifier: "HTTPS://[FE80::ABCD%25Eth0]:000443/Case"},
+			},
+			expInput: Input{
+				HTTP: &HTTP{
+					URL:    "HTTPS://[FE80::ABCD%25Eth0]:000443/Case",
+					Schema: "https",
+					Host:   "[fe80::abcd%Eth0]",
+					Path:   "/Case",
+					Query:  map[string][]string{},
+				},
+			},
+			expUnk: []string{"input.http.checksum"},
 		},
 		{
 			name: "http-source-with-checksum-and-auth",
@@ -1052,6 +1106,11 @@ func TestCheckPolicyHTTPHost(t *testing.T) {
 		allow bool
 	}{
 		{"https://example.com/", true},
+		{"Http://Example.com/", true},
+		{"hTtP://eXaMpLe.CoM/", true},
+		{"HTTP://EXAMPLE.COM/", true},
+		{"HTTPS://EXAMPLE.COM:000443/", true},
+		{"HTTPS://EXAMPLE.COM:8443/", false},
 		{"https://example.com:443/", true},
 		{"http://example.com:80/", true},
 		{"https://example.com:000443/", true},

--- a/policy/validate_test.go
+++ b/policy/validate_test.go
@@ -23,6 +23,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestHTTPHostForPolicy(t *testing.T) {
+	tests := []struct {
+		scheme, host, want string
+	}{
+		{"https", "example.com", "example.com"},
+		{"https", "example.com:443", "example.com"},
+		{"http", "example.com:80", "example.com"},
+		{"https", "example.com:8443", "example.com:8443"},
+		{"http", "example.com:8080", "example.com:8080"},
+		{"https", "[2001:db8::1]", "[2001:db8::1]"},
+		{"https", "[2001:db8::1]:443", "[2001:db8::1]"},
+		{"https", "[2001:db8::1]:8443", "[2001:db8::1]:8443"},
+		{"https", "example.com:443", "example.com"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.scheme+" "+tt.host, func(t *testing.T) {
+			require.Equal(t, tt.want, httpHostForPolicy(tt.scheme, tt.host))
+		})
+	}
+}
+
 func TestSourceToInputSingleSource(t *testing.T) {
 	tm := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
 
@@ -130,6 +151,90 @@ func TestSourceToInputSingleSource(t *testing.T) {
 					Path:     "/secure.tgz",
 					Query:    map[string][]string{},
 					Checksum: "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+				},
+			},
+		},
+		{
+			name: "https-default-port-stripped-from-host",
+			src: &gwpb.ResolveSourceMetaResponse{
+				Source: &pb.SourceOp{
+					Identifier: "https://example.com:443/foo.tar.gz",
+				},
+				HTTP: &gwpb.ResolveSourceHTTPResponse{
+					Checksum: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				},
+			},
+			expInput: Input{
+				HTTP: &HTTP{
+					URL:      "https://example.com:443/foo.tar.gz",
+					Schema:   "https",
+					Host:     "example.com",
+					Path:     "/foo.tar.gz",
+					Query:    map[string][]string{},
+					Checksum: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				},
+			},
+		},
+		{
+			name: "http-default-port-stripped-from-host",
+			src: &gwpb.ResolveSourceMetaResponse{
+				Source: &pb.SourceOp{
+					Identifier: "http://example.com:80/foo.tar.gz",
+				},
+				HTTP: &gwpb.ResolveSourceHTTPResponse{
+					Checksum: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+				},
+			},
+			expInput: Input{
+				HTTP: &HTTP{
+					URL:      "http://example.com:80/foo.tar.gz",
+					Schema:   "http",
+					Host:     "example.com",
+					Path:     "/foo.tar.gz",
+					Query:    map[string][]string{},
+					Checksum: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+				},
+			},
+		},
+		{
+			name: "https-non-default-port-kept-on-host",
+			src: &gwpb.ResolveSourceMetaResponse{
+				Source: &pb.SourceOp{
+					Identifier: "https://example.com:8443/foo.tar.gz",
+				},
+				HTTP: &gwpb.ResolveSourceHTTPResponse{
+					Checksum: "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+				},
+			},
+			expInput: Input{
+				HTTP: &HTTP{
+					URL:      "https://example.com:8443/foo.tar.gz",
+					Schema:   "https",
+					Host:     "example.com:8443",
+					Path:     "/foo.tar.gz",
+					Query:    map[string][]string{},
+					Checksum: "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+				},
+			},
+		},
+		{
+			name: "https-ipv6-default-port-stripped-from-host",
+			src: &gwpb.ResolveSourceMetaResponse{
+				Source: &pb.SourceOp{
+					Identifier: "https://[2001:db8::1]:443/foo.tar.gz",
+				},
+				HTTP: &gwpb.ResolveSourceHTTPResponse{
+					Checksum: "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+				},
+			},
+			expInput: Input{
+				HTTP: &HTTP{
+					URL:      "https://[2001:db8::1]:443/foo.tar.gz",
+					Schema:   "https",
+					Host:     "[2001:db8::1]",
+					Path:     "/foo.tar.gz",
+					Query:    map[string][]string{},
+					Checksum: "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
 				},
 			},
 		},


### PR DESCRIPTION
fixes #4061 
closes #4065 

Normalize HTTP policy input so hostname allowlists match requests regardless of scheme casing, host casing, or explicit default ports, including curl requests through the exec proxy. Strip `:80` for HTTP and `:443` for HTTPS, including zero-padded forms, while preserving non-default ports, IPv6 brackets and zone casing, and the original URL. Existing policies matching explicit default ports or mixed-case hostnames must use the normalized host instead.

This supersedes #4065, retaining its original commit and adding simplified normalization, case handling, and regression coverage through source conversion and policy evaluation.