### PR TITLE
docs: bake: remove "unstable" warning

### DIFF
--- a/docs/reference/buildx_bake.md
+++ b/docs/reference/buildx_bake.md
@@ -46,11 +46,6 @@ as part of the build.
 Read [High-level build options with Bake](https://docs.docker.com/build/bake/)
 guide for introduction to writing bake files.
 
-> [!NOTE]
-> `buildx bake` command may receive backwards incompatible features in the future
-> if needed. We are looking for feedback on improving the command and extending
-> the functionality further.
-
 ## Examples
 
 ### <a name="allow"></a> Allow extra privileged entitlement (--allow)


### PR DESCRIPTION
This note was originally added in d7b28fb4d340528926e17a29c4a6f0e352155055, when bake was still experimental. Now that it's GA ([1]), we can remove this warning as it follows the same stability as other commands.

[1]: https://www.docker.com/blog/ga-launch-docker-bake/