### PR TITLE
rm: keep builder removal outside the status timeout

### DIFF
--- a/commands/rm.go
+++ b/commands/rm.go
@@ -91,7 +91,7 @@ func runRm(ctx context.Context, dockerCli command.Cli, in rmOptions) error {
 					return err
 				}
 
-				err1 := rm(timeoutCtx, nodes, in)
+				err1 := rm(ctx, nodes, in)
 				if err := txn.Remove(b.Name); err != nil {
 					return err
 				}
@@ -200,7 +200,7 @@ func rmAllInactive(ctx context.Context, txn *store.Txn, dockerCli command.Cli, i
 					return nil
 				}
 				if b.Inactive() {
-					rmerr := rm(timeoutCtx, nodes, in)
+					rmerr := rm(ctx, nodes, in)
 					if err := txn.Remove(b.Name); err != nil {
 						return err
 					}


### PR DESCRIPTION
fixes https://github.com/docker/buildx/issues/4067

Use the caller context for cleanup so slow container and volume removal can finish after the builder-status timeout expires.