### PR TITLE
build: preserve shared clients across linked target completion

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -615,7 +615,8 @@ func BuildWithResultHandler(ctx context.Context, nodes []builder.Node, opts map[
 					// shared solver vertices land on the same daemon instance
 					c = linkedClients[node.Name]
 					if c == nil {
-						c, err = dp.Client(ctx)
+						// The shared client must outlive this target's errgroup.
+						c, err = dp.Client(baseCtx)
 						if err == nil {
 							linkedClients[node.Name] = c
 						}


### PR DESCRIPTION
fixes https://github.com/docker/buildx/issues/4063

With the Kubernetes driver and `loadbalance=random`, linked Bake targets share a client so they reach the same BuildKit instance. That client was created with one target's `errgroup` context, which is canceled when the target finishes, even on success. Because the Kubernetes exec connection uses that context, completing one target could disconnect siblings still building through the shared client.

Create the shared client with the enclosing build context so its connection remains alive until the overall build completes or is canceled.